### PR TITLE
refactor(cli): centralize template rendering and defaults

### DIFF
--- a/packages/create-agent-kit/src/__tests__/template-defaults.test.ts
+++ b/packages/create-agent-kit/src/__tests__/template-defaults.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import {
+  GLOBAL_TEMPLATE_DEFAULTS,
+  normalizeTemplateDefaults,
+  resolveTemplateDefaults,
+  TemplateDefaults,
+} from "../template/defaults.js";
+
+describe("normalizeTemplateDefaults", () => {
+  it("converts non-string values to strings", () => {
+    const result = normalizeTemplateDefaults({
+      NUMBER: 42,
+      BOOL: true,
+      NULLISH: null,
+    });
+    expect(result).toEqual({
+      NUMBER: "42",
+      BOOL: "true",
+    } satisfies TemplateDefaults);
+  });
+
+  it("returns empty object when input undefined", () => {
+    expect(normalizeTemplateDefaults(undefined)).toEqual({});
+  });
+});
+
+describe("resolveTemplateDefaults", () => {
+  it("includes global defaults when no overrides provided", () => {
+    expect(resolveTemplateDefaults(undefined)).toEqual(
+      GLOBAL_TEMPLATE_DEFAULTS
+    );
+  });
+
+  it("overrides global defaults with template values", () => {
+    const result = resolveTemplateDefaults({
+      AGENT_DESCRIPTION: "Custom",
+      EXTRA: "value",
+    });
+    expect(result.AGENT_DESCRIPTION).toBe("Custom");
+    expect(result.EXTRA).toBe("value");
+    expect(result.ENTRYPOINT_KEY).toBe(GLOBAL_TEMPLATE_DEFAULTS.ENTRYPOINT_KEY);
+  });
+});

--- a/packages/create-agent-kit/src/__tests__/template-files.test.ts
+++ b/packages/create-agent-kit/src/__tests__/template-files.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { renderTemplateTree } from "../template/files.js";
+
+async function withTempDir<T>(run: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-kit-template-"));
+  try {
+    return await run(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("renderTemplateTree", () => {
+  it("replaces placeholders across directory tree", async () => {
+    await withTempDir(async (dir) => {
+      const srcDir = path.join(dir, "src");
+      await fs.mkdir(srcDir);
+      const filePath = path.join(srcDir, "agent.ts");
+      await fs.writeFile(filePath, "const name = '{{NAME}}';\n", "utf8");
+
+      await renderTemplateTree(dir, { NAME: "demo" });
+
+      const result = await fs.readFile(filePath, "utf8");
+      expect(result).toContain("const name = 'demo';");
+    });
+  });
+
+  it("skips default ignored directories", async () => {
+    await withTempDir(async (dir) => {
+      const skipDir = path.join(dir, "node_modules");
+      await fs.mkdir(skipDir);
+      const skipFile = path.join(skipDir, "package.txt");
+      await fs.writeFile(skipFile, "skip {{TOKEN}}", "utf8");
+
+      await renderTemplateTree(dir, { TOKEN: "value" });
+
+      const untouched = await fs.readFile(skipFile, "utf8");
+      expect(untouched).toBe("skip {{TOKEN}}");
+    });
+  });
+});

--- a/packages/create-agent-kit/src/__tests__/template-render.test.ts
+++ b/packages/create-agent-kit/src/__tests__/template-render.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import {
+  MissingTemplateValueError,
+  renderTemplate,
+} from "../template/render.js";
+
+describe("renderTemplate", () => {
+  it("replaces tokens with provided values", () => {
+    const output = renderTemplate("Hello {{NAME}}!", {
+      context: { NAME: "Agent" },
+    });
+    expect(output).toBe("Hello Agent!");
+  });
+
+  it("uses empty string for undefined values", () => {
+    const output = renderTemplate("{{GREETING}}, world!", {
+      context: { GREETING: undefined },
+    });
+    expect(output).toBe(", world!");
+  });
+
+  it("throws when token missing and no onMissing handler", () => {
+    expect(() =>
+      renderTemplate("Value: {{UNKNOWN}}", { context: {} })
+    ).toThrowError(MissingTemplateValueError);
+  });
+
+  it("delegates to onMissing handler when provided", () => {
+    const output = renderTemplate("{{FOO}} {{BAR}}", {
+      context: { FOO: "hi" },
+      onMissing: (token) => `[${token}]`,
+    });
+    expect(output).toBe("hi [BAR]");
+  });
+});

--- a/packages/create-agent-kit/src/template/defaults.ts
+++ b/packages/create-agent-kit/src/template/defaults.ts
@@ -1,0 +1,33 @@
+export type TemplateDefaults = Record<string, string>;
+
+export const GLOBAL_TEMPLATE_DEFAULTS: TemplateDefaults = {
+  AGENT_VERSION: "0.1.0",
+  AGENT_DESCRIPTION: "Starter agent generated with create-agent-kit",
+  ENTRYPOINT_KEY: "echo",
+  ENTRYPOINT_DESCRIPTION: "Returns text that you send to the agent.",
+  PAYMENTS_FACILITATOR_URL: "https://facilitator.daydreams.systems",
+  PAYMENTS_PAY_TO: "0xb308ed39d67D0d4BAe5BC2FAEF60c66BBb6AE429",
+  PAYMENTS_NETWORK: "base-sepolia",
+  PAYMENTS_DEFAULT_PRICE: "1000",
+};
+
+export function normalizeTemplateDefaults(
+  defaults: Record<string, unknown> | undefined
+): TemplateDefaults {
+  if (!defaults) return {};
+  const entries: [string, string][] = [];
+  for (const [key, value] of Object.entries(defaults)) {
+    if (value == null) continue;
+    entries.push([key, typeof value === "string" ? value : String(value)]);
+  }
+  return Object.fromEntries(entries);
+}
+
+export function resolveTemplateDefaults(
+  rawDefaults: Record<string, unknown> | undefined
+): TemplateDefaults {
+  return {
+    ...GLOBAL_TEMPLATE_DEFAULTS,
+    ...normalizeTemplateDefaults(rawDefaults),
+  };
+}

--- a/packages/create-agent-kit/src/template/files.ts
+++ b/packages/create-agent-kit/src/template/files.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  MissingTemplateValueError,
+  renderTemplate,
+} from "./render.js";
+
+const DEFAULT_SKIP_DIRS = new Set(["node_modules", "dist", ".git"]);
+
+export async function renderTemplateFile(
+  filePath: string,
+  replacements: Record<string, string>
+) {
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    let replaced = raw;
+    try {
+      replaced = renderTemplate(raw, { context: replacements });
+    } catch (error: unknown) {
+      if (error instanceof MissingTemplateValueError) {
+        const message = `Missing template value for "{{${error.token}}}" in ${filePath}`;
+        const wrapped = new Error(message);
+        (wrapped as any).cause = error;
+        throw wrapped;
+      }
+      throw error;
+    }
+    if (replaced === raw) return;
+    await fs.writeFile(filePath, replaced, "utf8");
+  } catch (error: unknown) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code !== "ENOENT") {
+      throw err;
+    }
+  }
+}
+
+export async function renderTemplateTree(
+  rootDir: string,
+  replacements: Record<string, string>,
+  options?: { skipDirs?: Set<string> }
+) {
+  const skipDirs = new Set([
+    ...DEFAULT_SKIP_DIRS,
+    ...(options?.skipDirs ?? []),
+  ]);
+  await renderRecursive(rootDir, replacements, skipDirs);
+}
+
+async function renderRecursive(
+  currentDir: string,
+  replacements: Record<string, string>,
+  skipDirs: Set<string>
+) {
+  const entries = await fs.readdir(currentDir, { withFileTypes: true });
+  await Promise.all(
+    entries.map(async (entry) => {
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        if (skipDirs.has(entry.name)) {
+          return;
+        }
+        await renderRecursive(fullPath, replacements, skipDirs);
+      } else if (entry.isFile()) {
+        await renderTemplateFile(fullPath, replacements);
+      }
+    })
+  );
+}

--- a/packages/create-agent-kit/src/template/render.ts
+++ b/packages/create-agent-kit/src/template/render.ts
@@ -1,0 +1,37 @@
+type RenderOptions = {
+  context: Record<string, string | undefined>;
+  onMissing?: (token: string) => string;
+};
+
+class MissingTemplateValueError extends Error {
+  token: string;
+
+  constructor(token: string) {
+    super(`Missing template value for token "${token}"`);
+    this.name = "MissingTemplateValueError";
+    this.token = token;
+  }
+}
+
+const TOKEN_PATTERN = /{{\s*([A-Z0-9_]+)\s*}}/g;
+
+export function renderTemplate(
+  template: string,
+  options: RenderOptions
+): string {
+  const { context, onMissing } = options;
+
+  return template.replace(TOKEN_PATTERN, (match, rawToken: string) => {
+    const token = String(rawToken).trim();
+    if (Object.prototype.hasOwnProperty.call(context, token)) {
+      const value = context[token];
+      return value ?? "";
+    }
+    if (onMissing) {
+      return onMissing(token);
+    }
+    throw new MissingTemplateValueError(token);
+  });
+}
+
+export { MissingTemplateValueError };

--- a/packages/create-agent-kit/templates/axllm-flow/template.json
+++ b/packages/create-agent-kit/templates/axllm-flow/template.json
@@ -1,5 +1,16 @@
 {
   "id": "axllm",
   "name": "AxLLM Bun Agent with Flow",
-  "description": "Fully-featured Bun HTTP agent with @lucid-dreams/agent-kit and @ax-llm/ax wired up and Flow for AxLLM."
+  "description": "Fully-featured Bun HTTP agent with @lucid-dreams/agent-kit and @ax-llm/ax wired up and Flow for AxLLM.",
+  "defaults": {
+    "AGENT_VERSION": "0.1.0",
+    "AGENT_DESCRIPTION": "AxLLM Flow example agent generated with create-agent-kit",
+    "ENTRYPOINT_KEY": "brainstorm",
+    "ENTRYPOINT_DESCRIPTION": "Summarise a topic and suggest three follow-up ideas using AxFlow.",
+    "PAYMENTS_FACILITATOR_URL": "https://facilitator.daydreams.systems",
+    "PAYMENTS_NETWORK": "base",
+    "PAYMENTS_PAY_TO": "0xb308ed39d67D0d4BAe5BC2FAEF60c66BBb6AE429",
+    "PAYMENTS_DEFAULT_PRICE": "0.1",
+    "ENTRYPOINT_PRICE": "0.1"
+  }
 }

--- a/packages/create-agent-kit/templates/axllm/template.json
+++ b/packages/create-agent-kit/templates/axllm/template.json
@@ -1,5 +1,16 @@
 {
   "id": "axllm",
   "name": "AxLLM Bun Agent",
-  "description": "Fully-featured Bun HTTP agent with @lucid-dreams/agent-kit and @ax-llm/ax wired up."
+  "description": "Fully-featured Bun HTTP agent with @lucid-dreams/agent-kit and @ax-llm/ax wired up.",
+  "defaults": {
+    "AGENT_VERSION": "0.1.0",
+    "AGENT_DESCRIPTION": "AxLLM example agent generated with create-agent-kit",
+    "ENTRYPOINT_KEY": "framework-stream",
+    "ENTRYPOINT_DESCRIPTION": "Proxy an Ax-compatible agent with streaming support.",
+    "PAYMENTS_FACILITATOR_URL": "https://facilitator.daydreams.systems",
+    "PAYMENTS_NETWORK": "base",
+    "PAYMENTS_PAY_TO": "0xb308ed39d67D0d4BAe5BC2FAEF60c66BBb6AE429",
+    "PAYMENTS_DEFAULT_PRICE": "0.1",
+    "ENTRYPOINT_PRICE": "0.1"
+  }
 }

--- a/packages/create-agent-kit/templates/blank/template.json
+++ b/packages/create-agent-kit/templates/blank/template.json
@@ -2,6 +2,17 @@
   "id": "blank",
   "name": "Blank Bun Agent",
   "description": "Start from a minimal Bun HTTP agent with @lucid-dreams/agent-kit wired up.",
+  "defaults": {
+    "AGENT_VERSION": "0.1.0",
+    "AGENT_DESCRIPTION": "Starter agent generated with create-agent-kit",
+    "ENTRYPOINT_KEY": "echo",
+    "ENTRYPOINT_DESCRIPTION": "Returns text that you send to the agent.",
+    "PAYMENTS_FACILITATOR_URL": "https://facilitator.daydreams.systems",
+    "PAYMENTS_NETWORK": "base-sepolia",
+    "PAYMENTS_PAY_TO": "0xb308ed39d67D0d4BAe5BC2FAEF60c66BBb6AE429",
+    "PAYMENTS_DEFAULT_PRICE": "1000",
+    "ENTRYPOINT_PRICE": "1000"
+  },
   "onboarding": {
     "prompts": [
       {


### PR DESCRIPTION
  - Summary: replace ad hoc placeholder replacement with shared renderer; auto-merge template defaults from template.json; render entire template trees; update existing templates to declare their own defaults.
  - Key files: packages/create-agent-kit/src/index.ts (scaffolder flow), new helpers in src/template/{defaults.ts,files.ts,render.ts}, updated template metadata (templates/blank, templates/axllm, templates/axllm-flow), and new unit tests under src/__tests__.
  - Tests: bunx tsc -p packages/create-agent-kit/tsconfig.json --noEmit; bun test packages/create-agent-kit/src/__tests__.
  - Notes: verifies scaffolding still works by rendering all files automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable defaults system for agent templates with pre-filled configuration values
  * Enhanced template rendering to intelligently replace placeholders across project directories while skipping system folders

* **Tests**
  * Added comprehensive test coverage for template defaults resolution and file rendering functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->