### PR TITLE
Bump x402 dependencies to 1.1.0

### DIFF
--- a/.changeset/bump-x402-deps.md
+++ b/.changeset/bump-x402-deps.md
@@ -1,0 +1,9 @@
+---
+"@lucid-agents/core": patch
+"@lucid-agents/payments": patch
+"@lucid-agents/hono": patch
+"@lucid-agents/express": patch
+"@lucid-agents/cli": patch
+---
+
+Bump x402 and x402-fetch dependencies to 1.1.0 across adapters and templates.


### PR DESCRIPTION
This adds a changeset for the x402 and x402-fetch 1.1.0 dependency bumps across the repo. It updates the release metadata for core, payments, hono, express, and the CLI templates. Testing not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to version 1.1.0 across all packages for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->