### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/migrate-x402-v2.md
+++ b/.changeset/migrate-x402-v2.md
@@ -1,27 +1,49 @@
 ---
 "@lucid-agents/payments": minor
+"@lucid-agents/express": minor
+"@lucid-agents/hono": minor
 ---
 
-Migrate to @x402/* packages (v2) for x402 protocol support
+Migrate to x402 v2 protocol and remove v1 backwards compatibility
 
-**Breaking change**: Replaced legacy `x402` and `x402-fetch` packages with new `@x402/*` packages:
+## Breaking Changes
+
+### x402 v1 protocol support removed
+
+The following v1 backwards compatibility has been removed:
+
+**Request headers no longer supported:**
+- `X-Price` - Use `PAYMENT-REQUIRED` header instead
+- `X-Pay-To` - Use `PAYMENT-REQUIRED` header instead
+- `X-Network` - Use `PAYMENT-REQUIRED` header instead
+- `X-Facilitator` - Use `PAYMENT-REQUIRED` header instead
+
+**Response headers no longer supported:**
+- `X-PAYMENT-RESPONSE` - Use `PAYMENT-RESPONSE` header instead
+
+**Payment requirements format:**
+- `maxAmountRequired` field removed - Use `amount` instead
+- Network must use CAIP-2 format (e.g., `eip155:84532` not `base-sepolia`)
+- `extra.name` and `extra.version` required for EIP-712 signing
+
+### Replaced legacy packages with @x402/* packages
+
 - `@x402/core` - Core x402 protocol types
 - `@x402/fetch` - Payment-wrapped fetch with `wrapFetchWithPayment` and `x402Client`
 - `@x402/evm` - EVM signer support with `ExactEvmScheme` and `toClientEvmSigner`
 
-**Why**: The server returns x402 v2 protocol format with CAIP-2 network identifiers (e.g., `eip155:8453`)
-which the legacy packages don't support. The new @x402/* packages handle this correctly.
+## Migration Guide
 
-**Migration guide for raw x402 usage**:
+### For raw x402 usage
 
-Before:
+Before (v1):
 ```typescript
 import { wrapFetchWithX402, createWallet } from 'x402-fetch';
 const wallet = createWallet(privateKey, 'base');
 const x402Fetch = wrapFetchWithX402(fetch, wallet);
 ```
 
-After:
+After (v2):
 ```typescript
 import { wrapFetchWithPayment, x402Client } from '@x402/fetch';
 import { ExactEvmScheme, toClientEvmSigner } from '@x402/evm';
@@ -34,10 +56,26 @@ const client = new x402Client()
 const x402Fetch = wrapFetchWithPayment(fetch, client);
 ```
 
+### For server-side payment handling
+
+Before (v1 headers):
+```typescript
+// Response with v1 headers
+res.setHeader('X-Price', '1.00');
+res.setHeader('X-Pay-To', '0x...');
+```
+
+After (v2 PAYMENT-REQUIRED header):
+```typescript
+// Payment requirements now in base64-encoded PAYMENT-REQUIRED header
+// This is handled automatically by the x402-express/x402-hono middleware
+```
+
 **No changes needed** if you use the `createX402Fetch` and `accountFromPrivateKey` helpers -
 they now use the new packages internally.
 
-Supported networks:
+## Supported Networks
+
 - `eip155:8453` - Base mainnet
 - `eip155:84532` - Base Sepolia
 - `eip155:1` - Ethereum mainnet


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * x402 v2 protocol removes v1 backwards compatibility; header usage and payment requirement formatting have changed.

* **Documentation**
  * Added comprehensive migration guide with before/after code examples for v1 to v2 upgrade.
  * Expanded supported networks list with additional CAIP-2 network examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->