### PR TITLE
Add facilitator bearer auth support across adapters

### DIFF
--- a/.changeset/facilitator-auth-token.md
+++ b/.changeset/facilitator-auth-token.md
@@ -1,0 +1,20 @@
+---
+'@lucid-agents/types': patch
+'@lucid-agents/payments': patch
+'@lucid-agents/hono': patch
+'@lucid-agents/express': patch
+'@lucid-agents/tanstack': patch
+'@lucid-agents/cli': patch
+---
+
+Add facilitator bearer token support for x402 flows and scaffold it in generated agent env files.
+
+- Add `facilitatorAuth?: string` to `PaymentsConfig`.
+- Extend `paymentsFromEnv()` to read facilitator auth from:
+  - `FACILITOR_AUTH`
+  - `FACILITATOR_AUTH`
+  - `PAYMENTS_FACILITATOR_AUTH`
+  - fallback: `DREAMS_AUTH_TOKEN`
+- Normalize facilitator auth to `Authorization: Bearer ...` and apply it to facilitator `verify`, `settle`, and `supported` requests.
+- Wire facilitator auth handling into Hono, Express, TanStack, and Next paywall paths.
+- Add `PAYMENTS_FACILITATOR_AUTH` to payment-enabled CLI templates so generated `.env` files include the key by default.

--- a/packages/cli/templates/axllm-flow/AGENTS.md
+++ b/packages/cli/templates/axllm-flow/AGENTS.md
@@ -40,6 +40,7 @@ This template accepts the following configuration arguments (see `template.schem
 - `AGENT_DESCRIPTION` - Human-readable description
 - `AGENT_VERSION` - Semantic version (e.g., "0.1.0")
 - `PAYMENTS_FACILITATOR_URL` - x402 facilitator endpoint
+- `PAYMENTS_FACILITATOR_AUTH` - Optional facilitator bearer token (defaults to `DREAMS_AUTH_TOKEN` at runtime)
 - `PAYMENTS_NETWORK` - Network identifier (e.g., "ethereum")
 - `PAYMENTS_RECEIVABLE_ADDRESS` - Address that receives payments
 - `PRIVATE_KEY` - Wallet private key (optional)
@@ -422,6 +423,7 @@ ANTHROPIC_API_KEY=sk-ant-...
 
 # Payment configuration
 PAYMENTS_FACILITATOR_URL=https://facilitator.daydreams.systems
+PAYMENTS_FACILITATOR_AUTH=
 PAYMENTS_NETWORK=ethereum
 PAYMENTS_RECEIVABLE_ADDRESS=0x...
 

--- a/packages/cli/templates/axllm-flow/template.json
+++ b/packages/cli/templates/axllm-flow/template.json
@@ -27,6 +27,12 @@
         "defaultValue": "https://facilitator.daydreams.systems"
       },
       {
+        "key": "PAYMENTS_FACILITATOR_AUTH",
+        "type": "input",
+        "message": "Facilitator auth token (optional, defaults to DREAMS_AUTH_TOKEN)",
+        "defaultValue": ""
+      },
+      {
         "key": "PAYMENTS_NETWORK",
         "type": "select",
         "message": "Payment network",

--- a/packages/cli/templates/axllm-flow/template.schema.json
+++ b/packages/cli/templates/axllm-flow/template.schema.json
@@ -26,6 +26,11 @@
       "default": "https://facilitator.daydreams.systems",
       "format": "uri"
     },
+    "PAYMENTS_FACILITATOR_AUTH": {
+      "type": "string",
+      "description": "Optional bearer token for facilitator requests. If empty, runtime falls back to DREAMS_AUTH_TOKEN when available.",
+      "default": ""
+    },
     "PAYMENTS_NETWORK": {
       "type": "string",
       "description": "Payment network (EVM or Solana)",

--- a/packages/cli/templates/axllm/AGENTS.md
+++ b/packages/cli/templates/axllm/AGENTS.md
@@ -40,6 +40,7 @@ This template accepts the following configuration arguments (see `template.schem
 - `AGENT_DESCRIPTION` - Human-readable description
 - `AGENT_VERSION` - Semantic version (e.g., "0.1.0")
 - `PAYMENTS_FACILITATOR_URL` - x402 facilitator endpoint
+- `PAYMENTS_FACILITATOR_AUTH` - Optional facilitator bearer token (defaults to `DREAMS_AUTH_TOKEN` at runtime)
 - `PAYMENTS_NETWORK` - Network identifier (e.g., "ethereum")
 - `PAYMENTS_RECEIVABLE_ADDRESS` - Address that receives payments
 - `PRIVATE_KEY` - Wallet private key (optional)
@@ -335,6 +336,7 @@ ANTHROPIC_API_KEY=sk-ant-...
 
 # Payment configuration
 PAYMENTS_FACILITATOR_URL=https://facilitator.daydreams.systems
+PAYMENTS_FACILITATOR_AUTH=
 PAYMENTS_NETWORK=ethereum
 PAYMENTS_RECEIVABLE_ADDRESS=0x...
 

--- a/packages/cli/templates/axllm/template.json
+++ b/packages/cli/templates/axllm/template.json
@@ -27,6 +27,12 @@
         "defaultValue": "https://facilitator.daydreams.systems"
       },
       {
+        "key": "PAYMENTS_FACILITATOR_AUTH",
+        "type": "input",
+        "message": "Facilitator auth token (optional, defaults to DREAMS_AUTH_TOKEN)",
+        "defaultValue": ""
+      },
+      {
         "key": "PAYMENTS_NETWORK",
         "type": "select",
         "message": "Payment network",

--- a/packages/cli/templates/axllm/template.schema.json
+++ b/packages/cli/templates/axllm/template.schema.json
@@ -26,6 +26,11 @@
       "default": "https://facilitator.daydreams.systems",
       "format": "uri"
     },
+    "PAYMENTS_FACILITATOR_AUTH": {
+      "type": "string",
+      "description": "Optional bearer token for facilitator requests. If empty, runtime falls back to DREAMS_AUTH_TOKEN when available.",
+      "default": ""
+    },
     "PAYMENTS_NETWORK": {
       "type": "string",
       "description": "Payment network (EVM or Solana)",

--- a/packages/cli/templates/blank/AGENTS.md
+++ b/packages/cli/templates/blank/AGENTS.md
@@ -36,6 +36,7 @@ This template accepts the following configuration arguments (see `template.schem
 - `AGENT_DESCRIPTION` - Human-readable description of the agent
 - `AGENT_VERSION` - Semantic version (e.g., "0.1.0")
 - `PAYMENTS_FACILITATOR_URL` - x402 facilitator endpoint
+- `PAYMENTS_FACILITATOR_AUTH` - Optional facilitator bearer token (defaults to `DREAMS_AUTH_TOKEN` at runtime)
 - `PAYMENTS_NETWORK` - Network identifier (e.g., "ethereum")
 - `PAYMENTS_RECEIVABLE_ADDRESS` - Address that receives payments
 - `PRIVATE_KEY` - Wallet private key (optional)
@@ -164,6 +165,7 @@ AGENT_DESCRIPTION=My custom agent
 
 # Optional: Payment configuration
 PAYMENTS_FACILITATOR_URL=https://facilitator.daydreams.systems
+PAYMENTS_FACILITATOR_AUTH=
 PAYMENTS_NETWORK=ethereum
 PAYMENTS_RECEIVABLE_ADDRESS=0x...
 

--- a/packages/cli/templates/blank/template.json
+++ b/packages/cli/templates/blank/template.json
@@ -27,6 +27,12 @@
         "defaultValue": "https://facilitator.daydreams.systems"
       },
       {
+        "key": "PAYMENTS_FACILITATOR_AUTH",
+        "type": "input",
+        "message": "Facilitator auth token (optional, defaults to DREAMS_AUTH_TOKEN)",
+        "defaultValue": ""
+      },
+      {
         "key": "PAYMENTS_NETWORK",
         "type": "select",
         "message": "Payment network",

--- a/packages/cli/templates/blank/template.schema.json
+++ b/packages/cli/templates/blank/template.schema.json
@@ -26,6 +26,11 @@
       "default": "https://facilitator.daydreams.systems",
       "format": "uri"
     },
+    "PAYMENTS_FACILITATOR_AUTH": {
+      "type": "string",
+      "description": "Optional bearer token for facilitator requests. If empty, runtime falls back to DREAMS_AUTH_TOKEN when available.",
+      "default": ""
+    },
     "PAYMENTS_NETWORK": {
       "type": "string",
       "description": "Payment network (EVM or Solana)",

--- a/packages/cli/templates/identity/AGENTS.md
+++ b/packages/cli/templates/identity/AGENTS.md
@@ -42,6 +42,7 @@ This template accepts the following configuration arguments (see `template.schem
 - `AGENT_VERSION` - Semantic version
 - `AGENT_DOMAIN` - Domain that hosts your agent (e.g., "agent.example.com")
 - `PAYMENTS_FACILITATOR_URL` - x402 facilitator endpoint
+- `PAYMENTS_FACILITATOR_AUTH` - Optional facilitator bearer token (defaults to `DREAMS_AUTH_TOKEN` at runtime)
 - `PAYMENTS_NETWORK` - Network identifier
 - `PAYMENTS_RECEIVABLE_ADDRESS` - Address for receiving payments
 - `RPC_URL` - Blockchain RPC endpoint (e.g., "https://sepolia.base.org")
@@ -390,6 +391,7 @@ const { app, addEntrypoint } = createAgentApp(
   {
     payments: {
       facilitatorUrl: process.env.PAYMENTS_FACILITATOR_URL,
+      facilitatorAuth: process.env.PAYMENTS_FACILITATOR_AUTH,
       payTo: process.env.PAYMENTS_RECEIVABLE_ADDRESS,
       network: process.env.PAYMENTS_NETWORK,
     },
@@ -426,6 +428,7 @@ IDENTITY_AUTO_REGISTER=true
 
 # Payment configuration
 PAYMENTS_FACILITATOR_URL=https://facilitator.daydreams.systems
+PAYMENTS_FACILITATOR_AUTH=
 PAYMENTS_NETWORK=ethereum
 PAYMENTS_RECEIVABLE_ADDRESS=0x...
 ```

--- a/packages/cli/templates/identity/template.json
+++ b/packages/cli/templates/identity/template.json
@@ -37,6 +37,12 @@
         "defaultValue": "https://facilitator.daydreams.systems"
       },
       {
+        "key": "PAYMENTS_FACILITATOR_AUTH",
+        "type": "input",
+        "message": "Facilitator auth token (optional, defaults to DREAMS_AUTH_TOKEN)",
+        "defaultValue": ""
+      },
+      {
         "key": "PAYMENTS_NETWORK",
         "type": "select",
         "message": "Payment network",

--- a/packages/cli/templates/identity/template.schema.json
+++ b/packages/cli/templates/identity/template.schema.json
@@ -32,6 +32,11 @@
       "default": "https://facilitator.daydreams.systems",
       "format": "uri"
     },
+    "PAYMENTS_FACILITATOR_AUTH": {
+      "type": "string",
+      "description": "Optional bearer token for facilitator requests. If empty, runtime falls back to DREAMS_AUTH_TOKEN when available.",
+      "default": ""
+    },
     "PAYMENTS_NETWORK": {
       "type": "string",
       "description": "Payment network (EVM or Solana)",

--- a/packages/cli/templates/trading-data-agent/AGENTS.md
+++ b/packages/cli/templates/trading-data-agent/AGENTS.md
@@ -35,6 +35,7 @@ The agent receives payments via x402:
 const appOptions = {
   payments: {
     facilitatorUrl: process.env.PAYMENTS_FACILITATOR_URL,
+    facilitatorAuth: process.env.PAYMENTS_FACILITATOR_AUTH,
     payTo: process.env.PAYMENTS_RECEIVABLE_ADDRESS,
     network: process.env.PAYMENTS_NETWORK,
   },
@@ -85,4 +86,3 @@ handler: async ctx => {
 - Add more data endpoints (indicators, order book, etc.)
 - Implement streaming for real-time data
 - Add data caching for performance
-

--- a/packages/cli/templates/trading-data-agent/README.md
+++ b/packages/cli/templates/trading-data-agent/README.md
@@ -24,6 +24,7 @@ bun run dev
 ### Environment Variables
 
 - `PAYMENTS_FACILITATOR_URL` - x402 facilitator endpoint
+- `PAYMENTS_FACILITATOR_AUTH` - Optional facilitator bearer token (defaults to `DREAMS_AUTH_TOKEN` at runtime)
 - `PAYMENTS_NETWORK` - Payment network (base-sepolia, base, solana-devnet, solana)
 - `PAYMENTS_RECEIVABLE_ADDRESS` - Address that receives payments
 
@@ -42,4 +43,3 @@ curl -X POST http://localhost:3000/entrypoints/getPrice/invoke \
 This agent is designed to work with the `trading-recommendation-agent` template, which buys data from this agent and generates trading signals.
 
 See `AGENTS.md` for detailed implementation guide.
-

--- a/packages/cli/templates/trading-data-agent/agent.ts.template
+++ b/packages/cli/templates/trading-data-agent/agent.ts.template
@@ -7,6 +7,7 @@ const payments = paymentsFromEnv();
 const appOptions = {
   payments: payments || {
     facilitatorUrl: process.env.PAYMENTS_FACILITATOR_URL as `${string}://${string}`,
+    facilitatorAuth: process.env.PAYMENTS_FACILITATOR_AUTH,
     payTo: process.env.PAYMENTS_RECEIVABLE_ADDRESS as `0x${string}`,
     network: process.env.PAYMENTS_NETWORK as any,
   },
@@ -104,4 +105,3 @@ addEntrypoint({
     };
   },
 });
-

--- a/packages/cli/templates/trading-data-agent/template.json
+++ b/packages/cli/templates/trading-data-agent/template.json
@@ -27,6 +27,12 @@
         "defaultValue": "https://facilitator.daydreams.systems"
       },
       {
+        "key": "PAYMENTS_FACILITATOR_AUTH",
+        "type": "input",
+        "message": "Facilitator auth token (optional, defaults to DREAMS_AUTH_TOKEN)",
+        "defaultValue": ""
+      },
+      {
         "key": "PAYMENTS_NETWORK",
         "type": "select",
         "message": "Payment network",
@@ -48,4 +54,3 @@
     ]
   }
 }
-

--- a/packages/cli/templates/trading-data-agent/template.schema.json
+++ b/packages/cli/templates/trading-data-agent/template.schema.json
@@ -17,6 +17,11 @@
       "format": "uri",
       "description": "x402 facilitator URL"
     },
+    "PAYMENTS_FACILITATOR_AUTH": {
+      "type": "string",
+      "description": "Optional bearer token for facilitator requests. If empty, runtime falls back to DREAMS_AUTH_TOKEN when available.",
+      "default": ""
+    },
     "PAYMENTS_NETWORK": {
       "type": "string",
       "enum": ["ethereum", "base", "base-sepolia", "solana", "solana-devnet"],
@@ -30,4 +35,3 @@
   },
   "required": ["AGENT_DESCRIPTION", "AGENT_VERSION"]
 }
-

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -210,6 +210,7 @@ describe('create-agent-kit CLI', () => {
     expect(envFile).toContain(
       'PAYMENTS_FACILITATOR_URL=https://facilitator.daydreams.systems'
     );
+    expect(envFile).toContain('PAYMENTS_FACILITATOR_AUTH=');
     expect(envFile).toContain(
       'PAYMENTS_RECEIVABLE_ADDRESS=0xabc0000000000000000000000000000000000000'
     );
@@ -419,6 +420,7 @@ describe('create-agent-kit CLI', () => {
     expect(env).toContain(
       'PAYMENTS_FACILITATOR_URL=https://facilitator.daydreams.systems'
     );
+    expect(env).toContain('PAYMENTS_FACILITATOR_AUTH=');
     expect(env).toContain('DEVELOPER_WALLET_PRIVATE_KEY=');
   });
 

--- a/packages/express/src/paywall.ts
+++ b/packages/express/src/paywall.ts
@@ -12,6 +12,7 @@ import {
 import type { EntrypointDef, AgentRuntime } from '@lucid-agents/types/core';
 import type { PaymentsConfig } from '@lucid-agents/types/payments';
 import {
+  createFacilitatorAuthHeaders,
   resolvePrice,
   validatePaymentsConfig,
   evaluateSender,
@@ -43,6 +44,25 @@ export type WithPaymentsParams = {
   runtime?: AgentRuntime;
 };
 
+function addFacilitatorAuth(
+  facilitator: FacilitatorConfig,
+  token?: string
+): FacilitatorConfig {
+  if (facilitator.createAuthHeaders) {
+    return facilitator;
+  }
+
+  const authHeaders = createFacilitatorAuthHeaders(token);
+  if (!authHeaders) {
+    return facilitator;
+  }
+
+  return {
+    ...facilitator,
+    createAuthHeaders: async () => authHeaders,
+  };
+}
+
 export function withPayments({
   app,
   path,
@@ -69,9 +89,13 @@ export function withPayments({
   const postMimeType =
     kind === 'stream' ? 'text/event-stream' : 'application/json';
 
-  const resolvedFacilitator: FacilitatorConfig =
+  const baseFacilitator: FacilitatorConfig =
     facilitator ??
     ({ url: payments.facilitatorUrl } satisfies FacilitatorConfig);
+  const resolvedFacilitator = addFacilitatorAuth(
+    baseFacilitator,
+    payments.facilitatorAuth
+  );
 
   const postRoute: RouteConfig = {
     accepts: {

--- a/packages/payments/src/__tests__/utils.test.ts
+++ b/packages/payments/src/__tests__/utils.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { createFacilitatorAuthHeaders, paymentsFromEnv } from '../utils';
+
+const ENV_KEYS = [
+  'PAYMENTS_RECEIVABLE_ADDRESS',
+  'FACILITATOR_URL',
+  'NETWORK',
+  'FACILITOR_AUTH',
+  'FACILITATOR_AUTH',
+  'PAYMENTS_FACILITATOR_AUTH',
+  'DREAMS_AUTH_TOKEN',
+] as const;
+
+const originalEnv: Record<string, string | undefined> = {};
+for (const key of ENV_KEYS) {
+  originalEnv[key] = process.env[key];
+}
+
+function resetEnv() {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv[key];
+    if (typeof value === 'undefined') {
+      delete process.env[key];
+      continue;
+    }
+    process.env[key] = value;
+  }
+}
+
+describe('paymentsFromEnv', () => {
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    resetEnv();
+  });
+
+  it('reads facilitator auth token from FACILITOR_AUTH', () => {
+    process.env.PAYMENTS_RECEIVABLE_ADDRESS =
+      '0xabc0000000000000000000000000000000000000';
+    process.env.FACILITATOR_URL = 'https://facilitator.test';
+    process.env.NETWORK = 'eip155:84532';
+    process.env.FACILITOR_AUTH = 'token-from-typo-env';
+
+    const config = paymentsFromEnv();
+
+    expect(config.facilitatorAuth).toBe('token-from-typo-env');
+  });
+
+  it('prefers explicit config override for facilitator auth token', () => {
+    process.env.PAYMENTS_RECEIVABLE_ADDRESS =
+      '0xabc0000000000000000000000000000000000000';
+    process.env.FACILITATOR_URL = 'https://facilitator.test';
+    process.env.NETWORK = 'eip155:84532';
+    process.env.FACILITOR_AUTH = 'env-token';
+
+    const config = paymentsFromEnv({
+      facilitatorAuth: 'override-token',
+    });
+
+    expect(config.facilitatorAuth).toBe('override-token');
+  });
+
+  it('falls back to DREAMS_AUTH_TOKEN when facilitator auth envs are not set', () => {
+    process.env.PAYMENTS_RECEIVABLE_ADDRESS =
+      '0xabc0000000000000000000000000000000000000';
+    process.env.FACILITATOR_URL = 'https://facilitator.test';
+    process.env.NETWORK = 'eip155:84532';
+    process.env.DREAMS_AUTH_TOKEN = 'dreams-token';
+
+    const config = paymentsFromEnv();
+
+    expect(config.facilitatorAuth).toBe('dreams-token');
+  });
+});
+
+describe('createFacilitatorAuthHeaders', () => {
+  it('creates bearer headers for verify/settle/supported', () => {
+    const headers = createFacilitatorAuthHeaders('secret-token');
+    expect(headers?.verify.Authorization).toBe('Bearer secret-token');
+    expect(headers?.settle.Authorization).toBe('Bearer secret-token');
+    expect(headers?.supported.Authorization).toBe('Bearer secret-token');
+  });
+
+  it('normalizes existing bearer prefix', () => {
+    const headers = createFacilitatorAuthHeaders('bearer existing-token');
+    expect(headers?.verify.Authorization).toBe('Bearer existing-token');
+  });
+});

--- a/packages/payments/src/index.ts
+++ b/packages/payments/src/index.ts
@@ -17,6 +17,7 @@ export {
 } from './runtime';
 export {
   paymentsFromEnv,
+  createFacilitatorAuthHeaders,
   encodePaymentRequiredHeader,
   decodePaymentRequiredHeader,
   type PaymentRequiredHeaderDetails,

--- a/packages/payments/src/utils.ts
+++ b/packages/payments/src/utils.ts
@@ -12,12 +12,50 @@ export function paymentsFromEnv(
   const baseConfig: PaymentsConfig = {
     payTo: configOverrides?.payTo ?? (process.env.PAYMENTS_RECEIVABLE_ADDRESS as any),
     facilitatorUrl: configOverrides?.facilitatorUrl ?? (process.env.FACILITATOR_URL as any),
+    facilitatorAuth:
+      configOverrides?.facilitatorAuth ??
+      process.env.FACILITOR_AUTH ??
+      process.env.FACILITATOR_AUTH ??
+      process.env.PAYMENTS_FACILITATOR_AUTH ??
+      process.env.DREAMS_AUTH_TOKEN,
     network: configOverrides?.network ?? (process.env.NETWORK as any),
   };
 
   return {
     ...baseConfig,
     ...configOverrides,
+  };
+}
+
+function normalizeBearerToken(token?: string | null): string | undefined {
+  if (!token) return undefined;
+
+  const trimmed = token.trim();
+  if (!trimmed) return undefined;
+
+  if (/^bearer\s+/i.test(trimmed)) {
+    return `Bearer ${trimmed.replace(/^bearer\s+/i, '')}`;
+  }
+
+  return `Bearer ${trimmed}`;
+}
+
+export function createFacilitatorAuthHeaders(
+  token?: string | null
+): {
+  verify: Record<string, string>;
+  settle: Record<string, string>;
+  supported: Record<string, string>;
+} | undefined {
+  const authorization = normalizeBearerToken(token);
+  if (!authorization) {
+    return undefined;
+  }
+
+  return {
+    verify: { Authorization: authorization },
+    settle: { Authorization: authorization },
+    supported: { Authorization: authorization },
   };
 }
 

--- a/packages/types/src/payments/index.ts
+++ b/packages/types/src/payments/index.ts
@@ -141,6 +141,8 @@ export type PaymentStorageConfig = {
 export type PaymentsConfig = {
   payTo: `0x${string}` | SolanaAddress;
   facilitatorUrl: Resource;
+  /** Optional bearer token used to authenticate facilitator requests. */
+  facilitatorAuth?: string;
   network: Network;
   /** Optional policy groups for payment controls and limits */
   policyGroups?: PaymentPolicyGroup[];


### PR DESCRIPTION
This PR adds facilitator bearer token support to x402 paywall flows across Hono, Express, TanStack, and Next integration paths. It adds facilitatorAuth to payments config, normalizes bearer headers, and supports env resolution via FACILITOR_AUTH, FACILITATOR_AUTH, PAYMENTS_FACILITATOR_AUTH, and DREAMS_AUTH_TOKEN. It also updates payment-enabled CLI templates to include PAYMENTS_FACILITATOR_AUTH in generated .env files and docs. Tests were added for payments env/auth helper behavior and adapter/template wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional facilitator bearer token authentication support for payment flows.
  * Introduced `PAYMENTS_FACILITATOR_AUTH` configuration option across all payment integrations with automatic fallback to `DREAMS_AUTH_TOKEN`.

* **Documentation**
  * Updated CLI templates and agent documentation to include facilitator authentication token configuration.

* **Tests**
  * Added test coverage for facilitator bearer token authentication across payment adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->