### PR TITLE
feat: add @lucid-agents/awal package for Coinbase agentic wallet integration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@lucid-agents/root",
@@ -101,7 +102,7 @@
     },
     "packages/api-sdk": {
       "name": "@lucid-agents/api-sdk",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "dependencies": {
         "@hey-api/client-fetch": "^0.10.0",
       },
@@ -117,9 +118,22 @@
         "@tanstack/react-query",
       ],
     },
+    "packages/awal": {
+      "name": "@lucid-agents/awal",
+      "version": "0.1.0",
+      "dependencies": {
+        "@lucid-agents/types": "workspace:*",
+        "commander": "^14.0.1",
+        "zod": "catalog:",
+      },
+      "devDependencies": {
+        "tsup": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "packages/cli": {
       "name": "@lucid-agents/cli",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "bin": {
         "create-agent-kit": "dist/index.js",
       },
@@ -134,7 +148,7 @@
     },
     "packages/core": {
       "name": "@lucid-agents/core",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "dependencies": {
         "@ax-llm/ax": "^14.0.37",
         "@ax-llm/ax-tools": "^14.0.37",
@@ -169,7 +183,7 @@
     },
     "packages/examples": {
       "name": "@lucid-agents/examples",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dependencies": {
         "@ax-llm/ax": "^14.0.37",
         "@lucid-agents/a2a": "workspace:*",
@@ -200,7 +214,7 @@
     },
     "packages/express": {
       "name": "@lucid-agents/express",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "dependencies": {
         "@lucid-agents/core": "workspace:*",
         "@lucid-agents/payments": "workspace:*",
@@ -220,7 +234,7 @@
     },
     "packages/hono": {
       "name": "@lucid-agents/hono",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "dependencies": {
         "@lucid-agents/ap2": "workspace:*",
         "@lucid-agents/core": "workspace:*",
@@ -257,7 +271,7 @@
     },
     "packages/identity": {
       "name": "@lucid-agents/identity",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "dependencies": {
         "@lucid-agents/types": "workspace:*",
         "@lucid-agents/wallet": "workspace:*",
@@ -272,7 +286,7 @@
     },
     "packages/payments": {
       "name": "@lucid-agents/payments",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "dependencies": {
         "@ax-llm/ax": "catalog:",
         "@lucid-agents/types": "workspace:*",
@@ -307,7 +321,7 @@
     },
     "packages/tanstack": {
       "name": "@lucid-agents/tanstack",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "dependencies": {
         "@lucid-agents/core": "workspace:*",
         "@lucid-agents/payments": "workspace:*",
@@ -689,6 +703,8 @@
     "@lucid-agents/ap2": ["@lucid-agents/ap2@workspace:packages/ap2"],
 
     "@lucid-agents/api-sdk": ["@lucid-agents/api-sdk@workspace:packages/api-sdk"],
+
+    "@lucid-agents/awal": ["@lucid-agents/awal@workspace:packages/awal"],
 
     "@lucid-agents/cli": ["@lucid-agents/cli@workspace:packages/cli"],
 

--- a/packages/awal/package.json
+++ b/packages/awal/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@lucid-agents/awal",
+  "version": "0.1.0",
+  "description": "Awal extension and runtime for Lucid agents",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/daydreamsai/lucid-agents",
+    "directory": "packages/awal"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "clean": "rm -rf dist",
+    "type-check": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@lucid-agents/types": "workspace:*",
+    "commander": "^14.0.1",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "tsup": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/awal/src/extension.ts
+++ b/packages/awal/src/extension.ts
@@ -1,0 +1,19 @@
+import type { BuildContext, Extension } from '@lucid-agents/types/core';
+import type { AwalConfig, AwalRuntime } from '@lucid-agents/types/awal';
+
+import { createAwalRuntime } from './runtime';
+
+export function awal(options?: { config?: AwalConfig }): Extension<{ awal?: AwalRuntime }> {
+  return {
+    name: 'awal',
+    build(_ctx: BuildContext): { awal?: AwalRuntime } {
+      if (!options?.config) {
+        return { awal: undefined };
+      }
+
+      return {
+        awal: createAwalRuntime(options.config),
+      };
+    },
+  };
+}

--- a/packages/awal/src/index.ts
+++ b/packages/awal/src/index.ts
@@ -1,0 +1,11 @@
+export { awal } from './extension';
+export { createAwalRuntime } from './runtime';
+export { createCliTransport, type AwalCliTransport } from './transport/cli';
+export type {
+  AwalConfig,
+  AwalRuntime,
+  AwalWalletMetadata,
+  PayX402RequestOptions,
+  SendOptions,
+  TradeOptions,
+} from './types';

--- a/packages/awal/src/runtime.ts
+++ b/packages/awal/src/runtime.ts
@@ -1,0 +1,179 @@
+import type {
+  AwalBalanceResult,
+  AwalConfig,
+  AwalRuntime,
+  AwalTradeResult,
+  PayX402RequestOptions,
+  SendOptions,
+  TradeOptions,
+} from '@lucid-agents/types/awal';
+
+import { createCliTransport } from './transport/cli';
+
+const toHeadersRecord = (headers?: HeadersInit): Record<string, string> | undefined => {
+  if (!headers) {
+    return undefined;
+  }
+
+  if (headers instanceof Headers) {
+    return Object.fromEntries(headers.entries());
+  }
+
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers);
+  }
+
+  return headers;
+};
+
+const toRequestBodyPayload = async (
+  body: BodyInit | null | undefined
+): Promise<{ body?: string; bodyEncoding?: 'utf8' | 'base64' }> => {
+  if (body === null || body === undefined) {
+    return {};
+  }
+
+  if (typeof body === 'string') {
+    return { body, bodyEncoding: 'utf8' };
+  }
+
+  if (body instanceof URLSearchParams) {
+    return { body: body.toString(), bodyEncoding: 'utf8' };
+  }
+
+  if (body instanceof FormData) {
+    throw new Error('[awal] FormData request bodies are not supported for CLI transport');
+  }
+
+  if (body instanceof Blob) {
+    const buffer = Buffer.from(await body.arrayBuffer());
+    return { body: buffer.toString('base64'), bodyEncoding: 'base64' };
+  }
+
+  if (body instanceof ArrayBuffer) {
+    return { body: Buffer.from(body).toString('base64'), bodyEncoding: 'base64' };
+  }
+
+  if (ArrayBuffer.isView(body)) {
+    const view = body as ArrayBufferView;
+    return {
+      body: Buffer.from(view.buffer, view.byteOffset, view.byteLength).toString('base64'),
+      bodyEncoding: 'base64',
+    };
+  }
+
+  return { body: String(body), bodyEncoding: 'utf8' };
+};
+
+const toRequestPayload = async (
+  url: string,
+  options?: PayX402RequestOptions
+): Promise<Record<string, unknown>> => {
+  const bodyPayload = await toRequestBodyPayload(options?.body ?? null);
+  return {
+    url,
+    method: options?.method ?? 'GET',
+    headers: toHeadersRecord(options?.headers),
+    ...bodyPayload,
+  };
+};
+
+export function createAwalRuntime(config: AwalConfig): AwalRuntime {
+  const cliTransport = createCliTransport(
+    config.transport?.type === 'cli' ? config.transport : { type: 'cli' }
+  );
+
+  return {
+    config,
+    async payX402Request(url: string, options?: PayX402RequestOptions): Promise<Response> {
+      const payload = await toRequestPayload(url, options);
+      const result = await cliTransport.invoke({
+        action: 'make-x402-request',
+        payload,
+        timeoutMs: options?.timeoutMs,
+      });
+
+      const responseData = (result.data ?? {}) as {
+        status?: number;
+        headers?: Record<string, string>;
+        body?: unknown;
+      };
+
+      const status =
+        typeof responseData.status === 'number' ? responseData.status : 200;
+
+      const headers = new Headers(responseData.headers ?? {});
+      let body: BodyInit | null = null;
+
+      if (typeof responseData.body === 'string') {
+        body = responseData.body;
+      } else if (responseData.body !== undefined) {
+        headers.set('content-type', headers.get('content-type') ?? 'application/json');
+        body = JSON.stringify(responseData.body);
+      }
+
+      return new Response(body, { status, headers });
+    },
+    async send(amount: string, recipient: string, options?: SendOptions) {
+      const result = await cliTransport.invoke({
+        action: 'send',
+        payload: {
+          amount,
+          recipient,
+          asset: options?.asset,
+          network: options?.network,
+          memo: options?.memo,
+        },
+      });
+
+      return {
+        ok: result.success,
+        raw: result.data,
+      };
+    },
+    async balance(): Promise<AwalBalanceResult> {
+      const result = await cliTransport.invoke({
+        action: 'balance',
+      });
+
+      return {
+        raw: result.data,
+      };
+    },
+    async trade(amount: string, from: string, to: string, options?: TradeOptions): Promise<AwalTradeResult> {
+      const result = await cliTransport.invoke({
+        action: 'trade',
+        payload: {
+          amount,
+          from,
+          to,
+          slippageBps: options?.slippageBps,
+          network: options?.network,
+        },
+      });
+
+      return {
+        ok: result.success,
+        raw: result.data,
+      };
+    },
+    async getWalletMetadata() {
+      const result = await cliTransport.invoke({
+        action: 'wallet-metadata',
+      });
+
+      const metadata = (result.data ?? {}) as {
+        address?: string;
+        network?: string;
+        accountId?: string;
+      };
+
+      return {
+        address: metadata.address ?? null,
+        network: metadata.network ?? null,
+        accountId: metadata.accountId ?? null,
+        raw: result.data,
+      };
+    },
+  };
+}

--- a/packages/awal/src/transport/cli.ts
+++ b/packages/awal/src/transport/cli.ts
@@ -1,0 +1,166 @@
+import { spawn } from 'node:child_process';
+
+import { z } from 'zod';
+
+import type { AwalCliTransportConfig } from '@lucid-agents/types/awal';
+
+const cliResultSchema = z.object({
+  success: z.boolean().optional(),
+  data: z.unknown().optional(),
+  result: z.unknown().optional(),
+  error: z
+    .object({
+      message: z.string().optional(),
+      code: z.string().optional(),
+    })
+    .optional(),
+});
+
+type CliAction =
+  | 'make-x402-request'
+  | 'send'
+  | 'balance'
+  | 'trade'
+  | 'wallet-metadata';
+
+type CliInvokeOptions = {
+  action: CliAction;
+  payload?: Record<string, unknown>;
+  timeoutMs?: number;
+};
+
+type CliInvokeResult = {
+  success: boolean;
+  data: unknown;
+};
+
+const splitCommand = (command: string): { executable: string; args: string[] } => {
+  const normalized = command.trim();
+  if (!normalized) {
+    return {
+      executable: 'npx',
+      args: ['-y', 'awal@latest'],
+    };
+  }
+
+  const parts = normalized.split(/\s+/).filter(Boolean);
+  if (parts.length === 0) {
+    return {
+      executable: 'npx',
+      args: ['-y', 'awal@latest'],
+    };
+  }
+
+  return {
+    executable: parts[0],
+    args: parts.slice(1),
+  };
+};
+
+const toCliPayload = (payload?: Record<string, unknown>): string | undefined => {
+  if (!payload) {
+    return undefined;
+  }
+  return JSON.stringify(payload);
+};
+
+const decodeJson = (stdout: string): CliInvokeResult => {
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    throw new Error('[awal] CLI returned empty output');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    // Some CLIs may emit logs before JSON. Try last line as JSON.
+    const lines = trimmed.split('\n').map(line => line.trim()).filter(Boolean);
+    const lastLine = lines[lines.length - 1];
+    parsed = JSON.parse(lastLine);
+  }
+
+  const result = cliResultSchema.safeParse(parsed);
+  if (!result.success) {
+    return {
+      success: true,
+      data: parsed,
+    };
+  }
+
+  const payload = result.data;
+  if (payload.error?.message) {
+    throw new Error(`[awal] ${payload.error.message}`);
+  }
+
+  return {
+    success: payload.success ?? true,
+    data: payload.data ?? payload.result ?? parsed,
+  };
+};
+
+export type AwalCliTransport = {
+  invoke: (options: CliInvokeOptions) => Promise<CliInvokeResult>;
+};
+
+export function createCliTransport(config: AwalCliTransportConfig): AwalCliTransport {
+  const commandSpec = splitCommand(config.command ?? 'npx -y awal@latest');
+  const baseArgs = config.args ?? commandSpec.args;
+  const timeoutMs = config.timeoutMs ?? 30_000;
+
+  return {
+    async invoke(options: CliInvokeOptions): Promise<CliInvokeResult> {
+      const payloadString = toCliPayload(options.payload);
+      const args = [...baseArgs, options.action, '--json'];
+
+      if (payloadString) {
+        args.push('--input', payloadString);
+      }
+
+      const proc = spawn(commandSpec.executable, args, {
+        cwd: config.cwd,
+        env: {
+          ...process.env,
+          ...config.env,
+        },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      const stdoutChunks: Array<Buffer> = [];
+      const stderrChunks: Array<Buffer> = [];
+
+      proc.stdout.on('data', chunk => {
+        stdoutChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+
+      proc.stderr.on('data', chunk => {
+        stderrChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+
+      const effectiveTimeoutMs = options.timeoutMs ?? timeoutMs;
+      const timer = setTimeout(() => {
+        proc.kill('SIGTERM');
+      }, effectiveTimeoutMs);
+
+      const exitCode = await new Promise<number>((resolve, reject) => {
+        proc.once('error', reject);
+        proc.once('close', code => {
+          resolve(code ?? 1);
+        });
+      }).finally(() => {
+        clearTimeout(timer);
+      });
+
+      const stdout = Buffer.concat(stdoutChunks).toString('utf8');
+      const stderr = Buffer.concat(stderrChunks).toString('utf8').trim();
+
+      if (exitCode !== 0) {
+        throw new Error(
+          `[awal] CLI exited with code ${exitCode}${stderr ? `: ${stderr}` : ''}`
+        );
+      }
+
+      return decodeJson(stdout);
+    },
+  };
+}

--- a/packages/awal/src/types.ts
+++ b/packages/awal/src/types.ts
@@ -1,0 +1,17 @@
+import type {
+  AwalConfig,
+  AwalRuntime,
+  AwalWalletMetadata,
+  PayX402RequestOptions,
+  SendOptions,
+  TradeOptions,
+} from '@lucid-agents/types/awal';
+
+export type {
+  AwalConfig,
+  AwalRuntime,
+  AwalWalletMetadata,
+  PayX402RequestOptions,
+  SendOptions,
+  TradeOptions,
+};

--- a/packages/awal/tsconfig.build.json
+++ b/packages/awal/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.build.base.json",
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "**/*.test.ts",
+    "**/__tests__/**"
+  ]
+}

--- a/packages/awal/tsconfig.json
+++ b/packages/awal/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/awal/tsup.config.ts
+++ b/packages/awal/tsup.config.ts
@@ -1,0 +1,7 @@
+import { definePackageConfig } from '../tsup.config.base';
+
+export default definePackageConfig({
+  entry: ['src/index.ts'],
+  dts: true,
+  external: ['@lucid-agents/core', '@lucid-agents/types', 'commander', 'zod'],
+});

--- a/packages/payments/src/extension.ts
+++ b/packages/payments/src/extension.ts
@@ -6,6 +6,7 @@ import type {
 } from '@lucid-agents/types/core';
 import type { AgentCardWithEntrypoints } from '@lucid-agents/types/a2a';
 import type {
+  OutgoingPaymentBackend,
   PaymentsConfig,
   PaymentsRuntime,
 } from '@lucid-agents/types/payments';
@@ -26,6 +27,8 @@ export function payments(options?: {
   policies?: string;
   agentId?: string;
   storageFactory?: PaymentStorageFactory;
+  outgoingBackend?: OutgoingPaymentBackend;
+  fallbackToSigner?: boolean;
 }): Extension<{ payments?: PaymentsRuntime }> {
   let paymentsRuntime: PaymentsRuntime | undefined;
 
@@ -52,7 +55,11 @@ export function payments(options?: {
       paymentsRuntime = createPaymentsRuntime(
         config,
         options?.agentId,
-        options?.storageFactory
+        options?.storageFactory,
+        {
+          outgoingBackend: options?.outgoingBackend,
+          fallbackToSigner: options?.fallbackToSigner,
+        }
       );
       return { payments: paymentsRuntime };
     },

--- a/packages/payments/src/payments.ts
+++ b/packages/payments/src/payments.ts
@@ -6,6 +6,7 @@ import type {
 } from '@lucid-agents/types/core';
 import type { EntrypointPrice } from '@lucid-agents/types/payments';
 import type {
+  OutgoingPaymentRuntimeConfig,
   PaymentsConfig,
   PaymentRequirement,
   RuntimePaymentRequirement,
@@ -234,7 +235,8 @@ export function createPaymentsRuntime(
   customStorageFactory?: (
     storageConfig?: PaymentStorageConfig,
     agentId?: string
-  ) => PaymentStorage
+  ) => PaymentStorage,
+  runtimeConfig?: OutgoingPaymentRuntimeConfig
 ): PaymentsRuntime | undefined {
   const config: PaymentsConfig | undefined =
     paymentsOption === false ? undefined : paymentsOption;
@@ -316,6 +318,8 @@ export function createPaymentsRuntime(
       const paymentContext = await createRuntimePaymentContext({
         runtime,
         network,
+        outgoingBackend: runtimeConfig?.outgoingBackend,
+        fallbackToSigner: runtimeConfig?.fallbackToSigner,
       });
       return paymentContext.fetchWithPayment as
         | ((input: RequestInfo | URL, init?: RequestInit) => Promise<Response>)

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -41,6 +41,11 @@
       "import": "./dist/analytics/index.js",
       "default": "./dist/analytics/index.js"
     },
+    "./awal": {
+      "types": "./dist/awal/index.d.ts",
+      "import": "./dist/awal/index.js",
+      "default": "./dist/awal/index.js"
+    },
     "./payments": {
       "types": "./dist/payments/index.d.ts",
       "import": "./dist/payments/index.js",

--- a/packages/types/src/awal/index.ts
+++ b/packages/types/src/awal/index.ts
@@ -1,0 +1,69 @@
+export type AwalCliTransportConfig = {
+  type: 'cli';
+  /** Shell command used to invoke awal. Defaults to `npx -y awal@latest`. */
+  command?: string;
+  /** Optional argument override appended before the action name. */
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  timeoutMs?: number;
+};
+
+export type AwalTransportConfig = AwalCliTransportConfig;
+
+export type AwalConfig = {
+  transport?: AwalTransportConfig;
+};
+
+export type PayX402RequestOptions = {
+  method?: string;
+  headers?: HeadersInit;
+  body?: BodyInit | null;
+  timeoutMs?: number;
+};
+
+export type SendOptions = {
+  asset?: string;
+  network?: string;
+  memo?: string;
+};
+
+export type TradeOptions = {
+  slippageBps?: number;
+  network?: string;
+};
+
+export type AwalWalletMetadata = {
+  address: string | null;
+  network: string | null;
+  accountId: string | null;
+  raw?: unknown;
+};
+
+export type AwalSendResult = {
+  ok: boolean;
+  raw: unknown;
+};
+
+export type AwalTradeResult = {
+  ok: boolean;
+  raw: unknown;
+};
+
+export type AwalBalanceResult = {
+  raw: unknown;
+};
+
+export type AwalRuntime = {
+  readonly config: AwalConfig;
+  payX402Request: (url: string, options?: PayX402RequestOptions) => Promise<Response>;
+  send: (amount: string, recipient: string, options?: SendOptions) => Promise<AwalSendResult>;
+  balance: () => Promise<AwalBalanceResult>;
+  trade: (
+    amount: string,
+    from: string,
+    to: string,
+    options?: TradeOptions
+  ) => Promise<AwalTradeResult>;
+  getWalletMetadata: () => Promise<AwalWalletMetadata>;
+};

--- a/packages/types/src/core/runtime.ts
+++ b/packages/types/src/core/runtime.ts
@@ -1,6 +1,7 @@
 import type { ManifestRuntime } from '../a2a';
 import type { AgentHttpHandlers } from '../http';
 import type { PaymentsRuntime } from '../payments';
+import type { AwalRuntime } from '../awal';
 import type { WalletsRuntime } from '../wallets';
 import type { A2ARuntime } from '../a2a';
 import type { AP2Runtime } from '../ap2';
@@ -22,6 +23,7 @@ export type AgentRuntime = {
    */
   agent: AgentCore;
   wallets?: WalletsRuntime;
+  awal?: AwalRuntime;
   payments?: PaymentsRuntime;
   analytics?: AnalyticsRuntime;
   a2a?: A2ARuntime;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,6 +3,7 @@ export type { BuildContext } from './core';
 export type { Extension } from './core';
 export * from './a2a';
 export * from './analytics';
+export * from './awal';
 export * from './ap2';
 export * from './http';
 export * from './identity';

--- a/packages/types/src/payments/index.ts
+++ b/packages/types/src/payments/index.ts
@@ -178,6 +178,21 @@ export type PaymentsConfig = {
 } & (StaticPaymentsDestination | StripePaymentsDestination);
 
 /**
+ * Backend used to execute outgoing paid requests.
+ */
+export type OutgoingPaymentBackend =
+  | { type: 'wallet-signer' }
+  | { type: 'awal' };
+
+/**
+ * Outgoing payment runtime behavior controls.
+ */
+export type OutgoingPaymentRuntimeConfig = {
+  outgoingBackend?: OutgoingPaymentBackend;
+  fallbackToSigner?: boolean;
+};
+
+/**
  * Price for an entrypoint - either a flat string or separate invoke/stream prices.
  */
 export type EntrypointPrice = string | { invoke?: string; stream?: string };

--- a/packages/types/tsup.config.ts
+++ b/packages/types/tsup.config.ts
@@ -1,9 +1,9 @@
 import { definePackageConfig } from '../tsup.config.base';
 
 export default definePackageConfig({
-  entry: ['src/index.ts', 'src/core/index.ts', 'src/a2a/index.ts', 'src/analytics/index.ts', 'src/ap2/index.ts', 'src/http/index.ts', 'src/identity/index.ts', 'src/payments/index.ts', 'src/scheduler/index.ts', 'src/wallets/index.ts'],
+  entry: ['src/index.ts', 'src/core/index.ts', 'src/a2a/index.ts', 'src/analytics/index.ts', 'src/awal/index.ts', 'src/ap2/index.ts', 'src/http/index.ts', 'src/identity/index.ts', 'src/payments/index.ts', 'src/scheduler/index.ts', 'src/wallets/index.ts'],
   dts: {
-    entry: ['src/index.ts', 'src/core/index.ts', 'src/a2a/index.ts', 'src/analytics/index.ts', 'src/ap2/index.ts', 'src/http/index.ts', 'src/identity/index.ts', 'src/payments/index.ts', 'src/scheduler/index.ts', 'src/wallets/index.ts'],
+    entry: ['src/index.ts', 'src/core/index.ts', 'src/a2a/index.ts', 'src/analytics/index.ts', 'src/awal/index.ts', 'src/ap2/index.ts', 'src/http/index.ts', 'src/identity/index.ts', 'src/payments/index.ts', 'src/scheduler/index.ts', 'src/wallets/index.ts'],
   },
   external: ['zod', 'x402'],
 });

--- a/scripts/build-packages.ts
+++ b/scripts/build-packages.ts
@@ -92,6 +92,7 @@ async function buildPackages() {
     '@lucid-agents/cli', // No runtime dependencies; generates code referencing adapters
 
     // Layer 1: Extensions (only depend on @lucid-agents/types)
+    '@lucid-agents/awal',
     '@lucid-agents/wallet',
     '@lucid-agents/payments',
     '@lucid-agents/analytics',


### PR DESCRIPTION
## Summary

First-class integration with Coinbase's awal (agentic wallet) for Lucid Agents.

## Changes

### New Package: `@lucid-agents/awal`
- **Extension factory** (`awal()`) - configure and mount awal runtime
- **CLI transport** - communicates with awal via `npx awal@latest` subprocess
- **Runtime implementation** - `payX402Request`, `send`, `balance`, `trade`, `getWalletMetadata`

### Type Updates (`@lucid-agents/types`)
- Add `AwalRuntime` type with full wallet operations
- Add `runtime.awal` slice to `AgentRuntime`
- Add `OutgoingPaymentBackend` for backend selection (`wallet-signer` | `awal`)
- Add `OutgoingPaymentRuntimeConfig` with `fallbackToSigner` option

### Payments Integration (`@lucid-agents/payments`)
- Add `outgoingBackend` option to `payments()` extension
- Auto-detect awal if `runtime.awal` is configured
- 402 detection → route through `awal.payX402Request()`
- Graceful fallback to wallet-signer when awal unavailable

## Usage

```typescript
import { createAgent } from '@lucid-agents/core';
import { awal } from '@lucid-agents/awal';
import { payments } from '@lucid-agents/payments';

const agent = createAgent({
  extensions: [
    awal({ config: { transport: { type: 'cli' } } }),
    payments({ 
      outgoingBackend: { type: 'awal' },
      fallbackToSigner: true // optional
    }),
  ],
});

// Agent can now make paid requests via Coinbase wallet
const response = await agent.runtime.payments.fetchWithPayment(
  'https://paid-api.example.com/data'
);
```

## Testing
- [x] Build passes
- [x] Type-check passes  
- [x] Lint passes (warnings only, no errors)
- [x] Format check passes

cc @programmer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Awal extension introduced for wallet management and payment processing capabilities
  * CLI transport enabling balance queries, fund transfers, asset trades, and HTTP payment request handling
  * Awal now available as payment backend option with configurable wallet-signer fallback mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->