### PR TITLE
feat: add prediction market agent template (Baozi/Solana)

### DIFF
--- a/packages/cli/templates/prediction-market-agent/AGENTS.md
+++ b/packages/cli/templates/prediction-market-agent/AGENTS.md
@@ -239,7 +239,7 @@ Agents can earn passive income by referring other agents and users to bet on mar
 3. `owner` — Signer (writable)
 4. `system_program`
 
-Args: `code` (string, 1-32 chars unique referral code)
+Args: `code` (string, 1-16 chars unique referral code)
 
 **Betting with affiliate:** `place_bet_sol_with_affiliate` (IDL-verified, 8 accounts)
 
@@ -655,7 +655,7 @@ These IDL instructions exist on-chain and could be added to the agent:
 - **cancelLabMarket fails:** Creator can only cancel if no bets placed yet, or pool < 0.5 SOL. Admin can cancel anytime.
 - **claimRefund fails:** Market must be in `cancelled` status. Check market status first with `getMarketOdds`.
 - **"Invalid SOLANA_PRIVATE_KEY":** Must be a base58-encoded 64-byte secret key (not a mnemonic or hex)
-- **registerAffiliate fails:** Affiliate code must be unique (1-32 chars). If the code is taken, choose a different one.
+- **registerAffiliate fails:** Affiliate code must be unique (1-16 chars). If the code is taken, choose a different one.
 - **placeBetWithAffiliate fails:** The affiliate wallet must have a registered Affiliate PDA. Verify the affiliate has called `registerAffiliate` first.
 - **claimAffiliateEarnings fails:** No pending earnings. Affiliate commission accrues when referred bettors claim winnings.
 - **closeMarket fails:** Market must be past its closing time and in `active` status. Cannot close already-closed/resolved/cancelled markets.

--- a/packages/cli/templates/prediction-market-agent/AGENTS.md
+++ b/packages/cli/templates/prediction-market-agent/AGENTS.md
@@ -46,7 +46,7 @@ Account data is parsed using a cursor-based `BorshReader` that walks through the
 
 Unlike order-book markets, pari-mutuel markets determine payouts from pool ratios:
 
-- **Boolean market:** P(Yes) = noPool / totalPool, P(No) = yesPool / totalPool
+- **Boolean market:** P(Yes) = yesPool / totalPool, P(No) = noPool / totalPool
 - **Race market:** Probabilities normalized across all outcome pools
 - **Payout if correct:** totalPool / winningOutcomePool (minus fees)
 
@@ -285,7 +285,7 @@ All fees apply to gross winnings (stake + profit) at claim time:
 | Private | 2% | 0.01 SOL | Up to 0.5% |
 
 **Fee split per claim:**
-```
+```text
 Platform Fee (e.g. 3% for Lab)
 ├── Affiliate Share (1.0%)  → SolTreasury
 ├── Creator Share (0.5%)    → SolTreasury

--- a/packages/cli/templates/prediction-market-agent/AGENTS.md
+++ b/packages/cli/templates/prediction-market-agent/AGENTS.md
@@ -1,6 +1,6 @@
 # Prediction Market Agent - AI Implementation Guide
 
-This template creates an agent that reads and trades on-chain Solana prediction markets via the Baozi protocol.
+This template creates an agent that reads, trades, and creates on-chain Solana prediction markets via the Baozi protocol.
 
 ## Architecture
 
@@ -12,7 +12,19 @@ This template creates an agent that reads and trades on-chain Solana prediction 
 
 ## Key Concepts
 
-### 1. On-Chain Data Reading
+### 1. Market Layers
+
+Baozi has three market layers — this is a core concept for understanding the protocol:
+
+| Layer | Value | Who Creates | Fee | Resolution | Description |
+|-------|-------|------------|-----|------------|-------------|
+| **Official** | 0 | Admin/Guardian **only** | 2.5% | BaoziTvs (oracle) | Protocol-managed, highest trust |
+| **Lab** | 1 | Anyone with CreatorProfile | 3% | HostOracle | Community-created, open access |
+| **Private** | 2 | Anyone with CreatorProfile | 2% | Creator or Oracle | Invite-only, whitelist gated |
+
+**Important:** Official markets (`create_market_sol`) can only be created by the protocol admin. This agent exposes Lab market creation (`create_lab_market_sol`) which is permissionless — anyone with a CreatorProfile can create them.
+
+### 2. On-Chain Data Reading
 
 All market data is fetched via `getProgramAccounts` with discriminator filters:
 
@@ -28,9 +40,9 @@ connection.getProgramAccounts(PROGRAM_ID, {
 });
 ```
 
-Account data is parsed using a cursor-based `BorshReader` that walks through the binary layout field by field.
+Account data is parsed using a cursor-based `BorshReader` that walks through the binary layout field by field. A `BorshWriter` serializes instruction data for transactions.
 
-### 2. Pari-Mutuel Pricing
+### 3. Pari-Mutuel Pricing
 
 Unlike order-book markets, pari-mutuel markets determine payouts from pool ratios:
 
@@ -38,34 +50,99 @@ Unlike order-book markets, pari-mutuel markets determine payouts from pool ratio
 - **Race market:** Probabilities normalized across all outcome pools
 - **Payout if correct:** totalPool / winningOutcomePool (minus fees)
 
-### 3. Market Types
+### 4. Market Types
 
-| Type | Outcomes | ID Prefix | Pool Structure |
-|------|----------|-----------|----------------|
-| Boolean | 2 (Yes/No) | `market` | yesPool + noPool |
-| Race | 2–10 | `race` | outcomePools[10] array |
+| Type | Outcomes | PDA Seed | Pool Structure |
+|------|----------|----------|----------------|
+| Boolean | 2 (Yes/No) | `"market"` | yesPool + noPool |
+| Race | 2–10 | `"race"` | outcomePools[10] array |
 
-### 4. Market Layers
+### 5. PDA Seeds Reference
 
-| Layer | Value | Description |
-|-------|-------|-------------|
-| Official | 0 | Admin-created, highest trust |
-| Lab | 1 | Community-created |
-| Private | 2 | Invite-only |
+All Program Derived Addresses used by this agent:
 
-### 5. Trading (placeBet)
+| PDA | Seeds | Used For |
+|-----|-------|----------|
+| GlobalConfig | `["config"]` | Protocol settings, market counter |
+| Market | `["market", market_id_u64_le]` | Boolean market accounts |
+| RaceMarket | `["race", market_id_u64_le]` | Race market accounts |
+| UserPosition | `["position", market_id_u64_le, user_pubkey]` | Boolean bet positions |
+| RacePosition | `["race_position", market_id_u64_le, user_pubkey]` | Race bet positions |
+| SolTreasury | `["sol_treasury"]` | Protocol treasury (receives creation fees) |
+| CreatorProfile | `["creator_profile", owner_pubkey]` | Creator reputation + fee settings |
 
-The `placeBet` entrypoint constructs a Solana transaction using the program's `place_bet_sol` (boolean) or `bet_on_race_outcome_sol` (race) instructions. Required accounts are derived as PDAs from deterministic seeds.
+**Note:** Both boolean and race markets share a single `market_count` counter in GlobalConfig. The PDA namespace is different (`"market"` vs `"race"`), so they don't collide.
 
-**Account structure for place_bet_sol:**
-1. `config` — GlobalConfig PDA (`["config"]`)
+### 6. Trading (placeBet)
+
+The `placeBet` entrypoint constructs a Solana transaction using the program's `place_bet_sol` (boolean) or `bet_on_race_outcome_sol` (race) instructions.
+
+**Account structure for `place_bet_sol` (IDL-verified, 6 accounts):**
+1. `config` — GlobalConfig PDA `["config"]` (read-only)
 2. `market` — Market account (writable)
-3. `position` — UserPosition PDA (`["position", market_id, user]`, writable, init_if_needed)
-4. `whitelist` — Optional whitelist PDA (program ID if not needed)
-5. `pointsConfig` — PointsConfig PDA (`["points_config"]`)
-6. `userPoints` — UserPoints PDA (`["user_points", user]`, writable, init_if_needed)
-7. `user` — Signer (writable)
-8. `systemProgram` — System Program
+3. `position` — UserPosition PDA `["position", market_id, user]` (writable, init_if_needed)
+4. `whitelist` — Optional, pass PROGRAM_ID if not needed (read-only)
+5. `user` — Signer (writable)
+6. `system_program` — System Program
+
+**Account structure for `bet_on_race_outcome_sol` (IDL-verified, 6 accounts):**
+1. `config` — GlobalConfig PDA (read-only)
+2. `race_market` — RaceMarket account (writable)
+3. `position` — RacePosition PDA `["race_position", market_id, user]` (writable, init_if_needed)
+4. `whitelist` — Optional, pass PROGRAM_ID if not needed (read-only)
+5. `user` — Signer (writable)
+6. `system_program` — System Program
+
+### 7. Market Creation (Labs)
+
+Lab market creation requires two steps:
+
+**Step 1: Create a CreatorProfile (one-time)**
+
+Account structure for `create_creator_profile` (3 accounts):
+1. `creator_profile` — PDA `["creator_profile", owner]` (writable, init)
+2. `owner` — Signer (writable)
+3. `system_program`
+
+Args: `display_name` (string), `default_fee_bps` (u16)
+
+**Step 2a: Create a Boolean Lab Market**
+
+Account structure for `create_lab_market_sol` (6 accounts):
+1. `config` — GlobalConfig PDA (writable)
+2. `market` — Market PDA `["market", config.market_count]` (writable, init)
+3. `treasury` — SolTreasury PDA `["sol_treasury"]` (writable)
+4. `creator` — Signer (writable)
+5. `creator_profile` — Optional CreatorProfile PDA (writable)
+6. `system_program`
+
+Args: `question` (string), `closing_time` (i64), `resolution_buffer` (i64), `auto_stop_buffer` (i64), `resolution_mode` (u8), `council` (vec\<pubkey\>), `council_threshold` (u8)
+
+**Step 2b: Create a Race Lab Market**
+
+Account structure for `create_race_market_sol` (6 accounts):
+1. `config` — GlobalConfig PDA (writable)
+2. `race_market` — RaceMarket PDA `["race", config.market_count]` (writable, init)
+3. `creator_profile` — Optional CreatorProfile PDA (read-only)
+4. `treasury` — SolTreasury PDA (writable)
+5. `creator` — Signer (writable)
+6. `system_program`
+
+Args: `question` (string), `outcome_labels` (vec\<string\>), `closing_time` (i64), `resolution_buffer` (i64), `auto_stop_buffer` (i64), `layer` (u8), `resolution_mode` (u8), `access_gate` (u8), `council` (option\<vec\<pubkey\>\>), `council_threshold` (option\<u8\>)
+
+**Important:** Note the different account ordering between boolean and race market creation. The `creator_profile` account appears at position 5 for boolean but position 3 for race markets.
+
+### 8. Instruction Discriminators
+
+All instruction discriminators are hardcoded from the IDL (not computed at runtime):
+
+| Instruction | Discriminator |
+|-------------|--------------|
+| `place_bet_sol` | `[137, 137, 247, 253, 233, 243, 48, 170]` |
+| `bet_on_race_outcome_sol` | `[195, 181, 151, 159, 105, 100, 234, 244]` |
+| `create_creator_profile` | `[139, 244, 127, 145, 95, 172, 140, 154]` |
+| `create_lab_market_sol` | `[35, 159, 50, 67, 31, 134, 199, 157]` |
+| `create_race_market_sol` | `[94, 237, 40, 47, 63, 233, 25, 67]` |
 
 ## Customization
 
@@ -94,7 +171,7 @@ This agent can be discovered by other Lucid agents via the A2A protocol. The age
 const markets = await agent.a2a?.client.invoke(
   predictionMarketCard,
   'getMarkets',
-  { status: 'active', limit: 10 }
+  { status: 'active', layer: 'official', limit: 10 }
 );
 ```
 
@@ -102,24 +179,118 @@ const markets = await agent.a2a?.client.invoke(
 
 All fees apply to gross winnings (stake + profit) at claim time:
 
-| Layer | Platform Fee |
-|-------|-------------|
-| Official | 2.5% |
-| Lab | 3% |
-| Private | 2% |
+| Layer | Platform Fee | Creation Fee | Creator Fee (optional) |
+|-------|-------------|-------------|----------------------|
+| Official | 2.5% | 0.01 SOL | Up to 0.5% |
+| Lab | 3% | 0.01 SOL | Up to 0.5% |
+| Private | 2% | 0.01 SOL | Up to 0.5% |
+
+**Fee split per claim:**
+```
+Platform Fee (e.g. 3% for Lab)
+├── Affiliate Share (1.0%)  → SolTreasury
+├── Creator Share (0.5%)    → SolTreasury
+└── Protocol Share (1.5%)   → Staking Vault (if active) or SolTreasury
+```
+
+**Solvency Rule:** `creator_fee_bps + affiliate_fee_bps <= platform_fee_bps`
 
 ## Entrypoint Reference
 
 | Key | Read/Write | Description |
 |-----|-----------|-------------|
-| `getMarkets` | Read | List markets with filters and odds |
+| `getMarkets` | Read | List markets with filters (status, layer, query) and odds |
 | `getMarketOdds` | Read | Single market probabilities |
-| `getPortfolio` | Read | Wallet positions and P&L |
+| `getPortfolio` | Read | Wallet positions |
 | `placeBet` | Write | Execute on-chain bet transaction |
 | `analyzeMarket` | Read | Statistical market summary |
+| `createCreatorProfile` | Write | Create on-chain creator profile |
+| `createLabMarket` | Write | Create boolean Lab market |
+| `createLabRaceMarket` | Write | Create multi-outcome Lab race market |
+
+## Parimutuel Rules v6.3 — Market Creation Guardrails
+
+All Lab markets MUST comply with these rules. The agent validates every market creation against these rules **before** submitting the on-chain transaction. Markets that violate mandatory rules are **BLOCKED**.
+
+### Rule A: Event-Based Markets
+Markets about specific events (sports, elections, announcements):
+- Betting MUST close **at least 12 hours BEFORE** the event
+- Recommended buffer: 18-24 hours
+- Prevents late-breaking information advantage
+
+### Rule B: Measurement-Period Markets
+Markets about measured values (prices, temperatures, metrics):
+- Betting MUST close **BEFORE** the measurement period starts
+- Prevents betting with foreknowledge of outcomes
+
+### Rule C: Objective Verifiability
+Outcomes MUST be objectively verifiable by a third party using public records.
+
+**Blocked terms** (market will be rejected):
+- `"ai agent"`, `"an agent"`, `"autonomously"`
+- `"will I"`, `"will we"`, `"will my"`, `"will our"` (self-referential)
+- `"become popular"`, `"go viral"`, `"be successful"`, `"perform well"`, `"be the best"`, `"breakthrough"`, `"revolutionary"`
+
+### Rule D: Manipulation Prevention
+Creators CANNOT make markets about outcomes they can directly influence.
+
+**Blocked terms:**
+- `"will someone"`, `"will anyone"`, `"will a person"`, `"will a user"`
+- `"purchase proxies"`, `"buy proxies"`, `"x402 payment"`, `"using credits"`
+
+### Rule E: Approved Data Sources (Required)
+Markets MUST reference or imply a verifiable data source:
+
+| Category | Approved Sources |
+|----------|-----------------|
+| Crypto | CoinGecko, CoinMarketCap, Binance, Coinbase, TradingView |
+| Sports | ESPN, UFC, UEFA, FIFA, NBA, NFL, MLB, NHL, ATP, WTA |
+| Weather | NWS, JMA, Met Office, Weather.gov, AccuWeather |
+| Politics | AP News, Reuters, Official Government |
+| Finance | SEC, NASDAQ, NYSE, Yahoo Finance, Bloomberg |
+
+Markets can reference sources explicitly `"(Source: CoinGecko)"` or implicitly by mentioning recognized entities (BTC, NBA, Tokyo, etc.).
+
+### Examples
+
+| Question | Status | Why |
+|----------|--------|-----|
+| "Will BTC be above $120k at 00:00 UTC Mar 1? (Source: CoinGecko)" | Allowed | Clear threshold, approved source, verifiable |
+| "Will Real Madrid win Champions League 2026?" | Allowed | Implied ESPN/UEFA source, binary outcome |
+| "Will it snow in Tokyo on Feb 14?" | Allowed | Implied JMA source, binary outcome |
+| "Will an AI agent autonomously purchase proxies?" | **BLOCKED** | Unverifiable, subjective, manipulation risk |
+| "Will crypto go up?" | **BLOCKED** | No threshold, no source |
+| "Will I become successful?" | **BLOCKED** | Self-referential, subjective |
+
+## Resolution & Oracle Proofs
+
+Markets are resolved by different authorities depending on their layer:
+
+| Layer | Resolution Authority | How It Works |
+|-------|---------------------|--------------|
+| Official | Oracle (Grandma Mei) | Automated oracle proposes resolution, 6h dispute window |
+| Lab | Host Oracle | Market creator or oracle resolves |
+| Private | Creator or Oracle | Creator resolves, or oracle if creator is inactive |
+
+**Lab markets created by this agent use HostOracle resolution mode.** This means the market creator's wallet (the agent's wallet) can resolve the market, or the protocol oracle can resolve it.
+
+### AI Agent Proof Submission
+
+AI agents can submit resolution proofs to Grandma Mei (the protocol oracle). The proof system works as follows:
+
+1. **Agent gathers evidence** — screenshots, API data, official results
+2. **Agent posts proof** to the oracle API at `https://baozi.bet/agents/proof`
+3. **Grandma Mei reviews** the proof and makes it publicly visible
+4. **Oracle resolves** the market on-chain based on the verified proof
+5. **6-hour dispute window** — anyone can challenge the resolution
+
+This creates a transparent resolution pipeline where AI agents act as data gatherers and the oracle acts as the trusted resolver. All proofs are publicly visible at [baozi.bet/agents/proof](https://baozi.bet/agents/proof).
 
 ## Troubleshooting
 
 - **Empty market list:** Check `SOLANA_RPC_URL` is reachable. Public RPCs rate-limit heavily — use a dedicated provider (Helius, QuickNode, etc.)
 - **placeBet fails:** Ensure `SOLANA_PRIVATE_KEY` is set and the wallet has sufficient SOL (bet amount + ~0.01 SOL for fees)
+- **"Market is closed":** The market has passed its closing time. Bets are rejected client-side before sending the transaction.
+- **createLabMarket fails:** Ensure you've called `createCreatorProfile` first. Each wallet needs a profile before creating markets.
+- **"Invalid SOLANA_PRIVATE_KEY":** Must be a base58-encoded 64-byte secret key (not a mnemonic or hex)
 - **Stale data:** Market list is cached for 30 seconds. Call `getMarketOdds` for real-time single-market data

--- a/packages/cli/templates/prediction-market-agent/AGENTS.md
+++ b/packages/cli/templates/prediction-market-agent/AGENTS.md
@@ -1,0 +1,125 @@
+# Prediction Market Agent - AI Implementation Guide
+
+This template creates an agent that reads and trades on-chain Solana prediction markets via the Baozi protocol.
+
+## Architecture
+
+**Data Source:** Solana blockchain (program `FWyTPzm5cfJwRKzfkscxozatSxF6Qu78JQovQUwKPruJ`)
+**Parsing:** Direct Borsh deserialization from on-chain account data
+**Pricing:** Pari-mutuel (pool-based implied probabilities)
+**Caching:** 30-second TTL for market list queries
+**Dependencies:** `@solana/web3.js`, `bs58` only
+
+## Key Concepts
+
+### 1. On-Chain Data Reading
+
+All market data is fetched via `getProgramAccounts` with discriminator filters:
+
+```typescript
+// Boolean markets (YES/NO)
+connection.getProgramAccounts(PROGRAM_ID, {
+  filters: [{ memcmp: { offset: 0, bytes: MARKET_DISCRIMINATOR_BS58 } }],
+});
+
+// Race markets (multi-outcome)
+connection.getProgramAccounts(PROGRAM_ID, {
+  filters: [{ memcmp: { offset: 0, bytes: RACE_MARKET_DISCRIMINATOR_BS58 } }],
+});
+```
+
+Account data is parsed using a cursor-based `BorshReader` that walks through the binary layout field by field.
+
+### 2. Pari-Mutuel Pricing
+
+Unlike order-book markets, pari-mutuel markets determine payouts from pool ratios:
+
+- **Boolean market:** P(Yes) = noPool / totalPool, P(No) = yesPool / totalPool
+- **Race market:** Probabilities normalized across all outcome pools
+- **Payout if correct:** totalPool / winningOutcomePool (minus fees)
+
+### 3. Market Types
+
+| Type | Outcomes | ID Prefix | Pool Structure |
+|------|----------|-----------|----------------|
+| Boolean | 2 (Yes/No) | `market` | yesPool + noPool |
+| Race | 2–10 | `race` | outcomePools[10] array |
+
+### 4. Market Layers
+
+| Layer | Value | Description |
+|-------|-------|-------------|
+| Official | 0 | Admin-created, highest trust |
+| Lab | 1 | Community-created |
+| Private | 2 | Invite-only |
+
+### 5. Trading (placeBet)
+
+The `placeBet` entrypoint constructs a Solana transaction using the program's `place_bet_sol` (boolean) or `bet_on_race_outcome_sol` (race) instructions. Required accounts are derived as PDAs from deterministic seeds.
+
+**Account structure for place_bet_sol:**
+1. `config` — GlobalConfig PDA (`["config"]`)
+2. `market` — Market account (writable)
+3. `position` — UserPosition PDA (`["position", market_id, user]`, writable, init_if_needed)
+4. `whitelist` — Optional whitelist PDA (program ID if not needed)
+5. `pointsConfig` — PointsConfig PDA (`["points_config"]`)
+6. `userPoints` — UserPoints PDA (`["user_points", user]`, writable, init_if_needed)
+7. `user` — Signer (writable)
+8. `systemProgram` — System Program
+
+## Customization
+
+### Adding Real-Time Price Feeds
+
+```typescript
+// Example: Add Pyth price oracle data to market analysis
+import { PythHttpClient } from '@pythnetwork/client';
+
+addEntrypoint({
+  key: 'getMarketWithPrice',
+  handler: async (ctx) => {
+    const market = await baozi.fetchMarket(ctx.input.marketId);
+    const pythPrice = await getPythPrice(ctx.input.asset);
+    return { output: { ...market, referencePrice: pythPrice } };
+  },
+});
+```
+
+### Connecting to Other Agents (A2A)
+
+This agent can be discovered by other Lucid agents via the A2A protocol. The agent card at `/.well-known/agent-card.json` advertises all entrypoints.
+
+```typescript
+// Another agent buying market data from this one:
+const markets = await agent.a2a?.client.invoke(
+  predictionMarketCard,
+  'getMarkets',
+  { status: 'active', limit: 10 }
+);
+```
+
+### Fee Structure
+
+All fees apply to gross winnings (stake + profit) at claim time:
+
+| Layer | Platform Fee |
+|-------|-------------|
+| Official | 2.5% |
+| Lab | 3% |
+| Private | 2% |
+
+## Entrypoint Reference
+
+| Key | Read/Write | Description |
+|-----|-----------|-------------|
+| `getMarkets` | Read | List markets with filters and odds |
+| `getMarketOdds` | Read | Single market probabilities |
+| `getPortfolio` | Read | Wallet positions and P&L |
+| `placeBet` | Write | Execute on-chain bet transaction |
+| `analyzeMarket` | Read | Statistical market summary |
+
+## Troubleshooting
+
+- **Empty market list:** Check `SOLANA_RPC_URL` is reachable. Public RPCs rate-limit heavily — use a dedicated provider (Helius, QuickNode, etc.)
+- **placeBet fails:** Ensure `SOLANA_PRIVATE_KEY` is set and the wallet has sufficient SOL (bet amount + ~0.01 SOL for fees)
+- **Stale data:** Market list is cached for 30 seconds. Call `getMarketOdds` for real-time single-market data

--- a/packages/cli/templates/prediction-market-agent/README.md
+++ b/packages/cli/templates/prediction-market-agent/README.md
@@ -1,6 +1,6 @@
 ## Prediction Market Agent
 
-AI agent that reads and trades on-chain Solana prediction markets ([Baozi](https://baozi.bet)). Fetches live market data directly from the blockchain with zero backend dependency.
+AI agent that reads and trades on-chain Solana prediction markets ([Baozi](https://baozi.bet)). Fetches live market data directly from the blockchain with zero backend dependency. Supports reading all market layers and creating community (Lab) markets.
 
 ### Quick Start
 
@@ -11,10 +11,24 @@ cd my-pm-agent
 bun run dev
 ```
 
+### Market Layers
+
+Baozi has three market layers with different trust levels and permissions:
+
+| Layer | Who Can Create | Platform Fee | Description |
+|-------|---------------|-------------|-------------|
+| **Official** | Admin only | 2.5% | Highest trust — created by protocol team |
+| **Lab** | Anyone with CreatorProfile | 3% | Community-created markets |
+| **Private** | Anyone with CreatorProfile | 2% | Invite-only, whitelist access |
+
+This agent can **read and bet on all layers**, but can only **create** Lab markets (Official is admin-only, Private requires whitelist setup).
+
 ### Entrypoints
 
+#### Read (no wallet required)
+
 - **`getMarkets`** — List active prediction markets with current odds
-  - Parameters: `status` (active/closed/all), `query` (search), `limit`
+  - Parameters: `status` (active/closed/all), `layer` (official/lab/private/all), `query` (search), `limit`
 
 - **`getMarketOdds`** — Implied probabilities and pool sizes for a market
   - Parameters: `marketId` (base58 public key)
@@ -22,32 +36,63 @@ bun run dev
 - **`getPortfolio`** — View positions for a wallet
   - Parameters: `wallet` (base58 address)
 
-- **`placeBet`** — Place a bet on a market outcome (requires `SOLANA_PRIVATE_KEY`)
-  - Parameters: `marketId`, `outcome` (index), `amountSol` (0.01–100)
-
 - **`analyzeMarket`** — Statistical summary with odds breakdown
   - Parameters: `marketId`
+
+#### Write (requires `SOLANA_PRIVATE_KEY`)
+
+- **`placeBet`** — Place a bet on any market outcome
+  - Parameters: `marketId`, `outcome` (index), `amountSol` (0.01–100)
+
+- **`createCreatorProfile`** — Create an on-chain creator profile (required before creating markets)
+  - Parameters: `displayName` (1–32 chars), `defaultFeeBps` (optional, default 50 = 0.5%)
+
+- **`createLabMarket`** — Create a boolean (Yes/No) Lab prediction market
+  - Parameters: `question` (10–200 chars), `closingTime` (ISO 8601)
+
+- **`createLabRaceMarket`** — Create a multi-outcome Lab race market (2–10 outcomes)
+  - Parameters: `question`, `closingTime`, `outcomes` (array of labels)
 
 ### Environment Variables
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `SOLANA_RPC_URL` | Yes | Solana RPC endpoint (mainnet or devnet) |
-| `SOLANA_PRIVATE_KEY` | For trading | Base58-encoded wallet private key |
+| `SOLANA_RPC_URL` | Yes | Solana RPC endpoint (use Helius, QuickNode — not public RPC) |
+| `SOLANA_PRIVATE_KEY` | For trading/creating | Base58-encoded wallet private key |
 | `DEFAULT_PRICE` | No | x402 price per entrypoint call (base units) |
 
 ### Testing
 
 ```sh
-# List active markets
+# List active markets (all layers)
 curl -X POST http://localhost:3000/entrypoints/getMarkets/invoke \
   -H "Content-Type: application/json" \
   -d '{"input": {"status": "active", "limit": 5}}'
+
+# List only Lab markets
+curl -X POST http://localhost:3000/entrypoints/getMarkets/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"status": "active", "layer": "lab", "limit": 10}}'
 
 # Get odds for a specific market
 curl -X POST http://localhost:3000/entrypoints/getMarketOdds/invoke \
   -H "Content-Type: application/json" \
   -d '{"input": {"marketId": "YOUR_MARKET_PUBKEY"}}'
+
+# Create a creator profile (one-time setup)
+curl -X POST http://localhost:3000/entrypoints/createCreatorProfile/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"displayName": "My Agent", "defaultFeeBps": 50}}'
+
+# Create a Lab market
+curl -X POST http://localhost:3000/entrypoints/createLabMarket/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"question": "Will ETH flip BTC by end of 2026?", "closingTime": "2026-12-31T23:59:59Z"}}'
+
+# Create a Lab race market
+curl -X POST http://localhost:3000/entrypoints/createLabRaceMarket/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"question": "Who will win the 2026 NBA MVP?", "closingTime": "2026-06-30T00:00:00Z", "outcomes": ["Luka", "Jokic", "Giannis", "Shai"]}}'
 
 # View portfolio
 curl -X POST http://localhost:3000/entrypoints/getPortfolio/invoke \
@@ -63,5 +108,12 @@ curl http://localhost:3000/.well-known/agent-card.json
 The agent reads prediction market data directly from the Solana blockchain using `getProgramAccounts` RPC calls. Market data is parsed from on-chain Borsh-serialized account data — no indexer or backend API required.
 
 **Pricing model:** Pari-mutuel (pool-based). Odds are derived from pool ratios: the implied probability of an outcome equals the proportion of funds bet on the *other* side(s).
+
+**Market creation flow:**
+1. Create a CreatorProfile (one-time, costs ~0.01 SOL rent)
+2. Create a Lab market with a question and closing time
+3. The market goes live immediately — anyone can bet on it
+4. After closing, the oracle resolves the outcome
+5. Winners claim their winnings (minus 3% platform fee)
 
 See `AGENTS.md` for detailed implementation guide.

--- a/packages/cli/templates/prediction-market-agent/README.md
+++ b/packages/cli/templates/prediction-market-agent/README.md
@@ -59,6 +59,12 @@ This agent can **read and bet on all layers**, but can only **create and manage*
 - **`claimRefund`** — Claim your refund from a cancelled market
   - Parameters: `marketId`
 
+- **`claimWinnings`** — Claim SOL winnings from a resolved market (boolean or race)
+  - Parameters: `marketId`
+
+- **`finalizeResolution`** — Finalize resolution after 6h dispute window (permissionless, anyone can call)
+  - Parameters: `marketId`
+
 ### Environment Variables
 
 | Variable | Required | Description |
@@ -110,6 +116,16 @@ curl -X POST http://localhost:3000/entrypoints/claimRefund/invoke \
   -H "Content-Type: application/json" \
   -d '{"input": {"marketId": "CANCELLED_MARKET_PUBKEY"}}'
 
+# Claim winnings from resolved market
+curl -X POST http://localhost:3000/entrypoints/claimWinnings/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"marketId": "RESOLVED_MARKET_PUBKEY"}}'
+
+# Finalize resolution after dispute window
+curl -X POST http://localhost:3000/entrypoints/finalizeResolution/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"marketId": "PENDING_RESOLUTION_MARKET_PUBKEY"}}'
+
 # View portfolio
 curl -X POST http://localhost:3000/entrypoints/getPortfolio/invoke \
   -H "Content-Type: application/json" \
@@ -125,13 +141,14 @@ The agent reads prediction market data directly from the Solana blockchain using
 
 **Pricing model:** Pari-mutuel (pool-based). Odds are derived from pool ratios: the implied probability of an outcome equals the proportion of funds bet on the *other* side(s).
 
-**Market lifecycle:**
+**Full market lifecycle (all steps supported by this agent):**
 1. Create a CreatorProfile (one-time, costs ~0.01 SOL rent)
 2. Create a Lab market with a question, closing time, and timing proof (Type A or B)
 3. The market goes live immediately — anyone can bet on it
-4. Creator can cancel before resolution if needed (full refund to all bettors)
-5. After closing, the oracle resolves the outcome
-6. Winners claim their winnings (minus 3% platform fee)
+4. Creator can cancel before resolution if needed (full 100% refund to all bettors)
+5. After closing, the oracle proposes resolution (6h dispute window)
+6. Anyone calls `finalizeResolution` after dispute window closes
+7. Winners call `claimWinnings` to collect payout (minus 3% platform fee)
 
 **Parimutuel Rules v6.3:** Every market creation is validated against strict timing and content rules before the on-chain transaction is sent. This prevents unfair markets (late betting, unverifiable outcomes, manipulation).
 

--- a/packages/cli/templates/prediction-market-agent/README.md
+++ b/packages/cli/templates/prediction-market-agent/README.md
@@ -1,6 +1,6 @@
 ## Prediction Market Agent
 
-AI agent that reads, trades, creates, and manages on-chain Solana prediction markets ([Baozi](https://baozi.bet)). Fetches live market data directly from the blockchain with zero backend dependency. Supports all market layers and creating community (Lab) markets with full lifecycle management.
+AI agent that reads, trades, creates, and manages on-chain Solana prediction markets ([Baozi](https://baozi.bet)). Fetches live market data directly from the blockchain with zero backend dependency. Supports all market layers, community (Lab) market lifecycle, affiliate referrals, and creator reputation.
 
 ### Quick Start
 
@@ -21,11 +21,11 @@ Baozi has three market layers with different trust levels and permissions:
 | **Lab** | Anyone with CreatorProfile | 3% | Community-created markets |
 | **Private** | Anyone with CreatorProfile | 2% | Invite-only, whitelist access |
 
-This agent can **read and bet on all layers**, but can only **create and manage** Lab markets (Official is admin-only, Private requires whitelist setup).
+This agent can **read and bet on all layers**, and **create, manage, and resolve** Lab markets.
 
-### Entrypoints
+### Entrypoints (22 total)
 
-#### Read (no wallet required)
+#### Read (5 — no wallet required)
 
 - **`getMarkets`** — List active prediction markets with current odds
   - Parameters: `status` (active/closed/all), `layer` (official/lab/private/all), `query` (search), `limit`
@@ -39,10 +39,26 @@ This agent can **read and bet on all layers**, but can only **create and manage*
 - **`analyzeMarket`** — Statistical summary with odds breakdown
   - Parameters: `marketId`
 
-#### Write (requires `SOLANA_PRIVATE_KEY`)
+- **`getCreatorProfile`** — View creator profile, stats, earnings, and reputation
+  - Parameters: `wallet` (base58 address)
+
+#### Trading (2 — requires `SOLANA_PRIVATE_KEY`)
 
 - **`placeBet`** — Place a bet on any market outcome (boolean or race)
   - Parameters: `marketId`, `outcome` (index), `amountSol` (0.01–100)
+
+- **`placeBetWithAffiliate`** — Place a bet with affiliate referral tracking (1% commission to referrer)
+  - Parameters: `marketId`, `outcome`, `amountSol`, `affiliateWallet`
+
+#### Affiliate System (2)
+
+- **`registerAffiliate`** — Register as an affiliate to earn 1% referral commission
+  - Parameters: `code` (unique referral code, 1–32 chars)
+
+- **`claimAffiliateEarnings`** — Claim accumulated affiliate SOL earnings
+  - Parameters: none
+
+#### Market Creation (3)
 
 - **`createCreatorProfile`** — Create an on-chain creator profile (required before creating markets)
   - Parameters: `displayName` (1–32 chars), `defaultFeeBps` (optional, default 50 = 0.5%)
@@ -53,8 +69,27 @@ This agent can **read and bet on all layers**, but can only **create and manage*
 - **`createLabRaceMarket`** — Create a multi-outcome Lab race market (2–10 outcomes)
   - Parameters: `question`, `closingTime`, `outcomes` (array of labels), `marketType`, `eventTime` or `measurementStart`+`measurementEnd`
 
+#### Market Management (5)
+
+- **`updateCreatorProfile`** — Update display name and default creator fee
+  - Parameters: `displayName`, `defaultFeeBps`
+
+- **`claimCreatorFees`** — Claim pending creator fee earnings from your markets
+  - Parameters: none
+
 - **`cancelLabMarket`** — Cancel a Lab market you created (full 100% refund to all bettors)
   - Parameters: `marketId`, `reason` (1–200 chars)
+
+- **`closeMarket`** — Close a market after closing time (permissionless, takes pool snapshot)
+  - Parameters: `marketId`
+
+- **`proposeResolutionHost`** — Creator resolves own Lab boolean market (6h dispute window)
+  - Parameters: `marketId`, `winningOutcome` (true=Yes, false=No)
+
+- **`proposeRaceResolution`** — Creator resolves own Lab race market (6h dispute window)
+  - Parameters: `marketId`, `winningOutcome` (outcome index)
+
+#### Claims & Reputation (4)
 
 - **`claimRefund`** — Claim your refund from a cancelled market
   - Parameters: `marketId`
@@ -62,8 +97,47 @@ This agent can **read and bet on all layers**, but can only **create and manage*
 - **`claimWinnings`** — Claim SOL winnings from a resolved market (boolean or race)
   - Parameters: `marketId`
 
-- **`finalizeResolution`** — Finalize resolution after 6h dispute window (permissionless, anyone can call)
+- **`finalizeResolution`** — Finalize resolution after 6h dispute window (permissionless)
   - Parameters: `marketId`
+
+- **`voteCreatorReputation`** — Vote +1/-1 on creator reputation (requires bet position)
+  - Parameters: `marketId`, `vote` (+1 or -1)
+
+### Affiliate System — Agent-to-Agent Recruitment
+
+Agents can earn passive income by referring other agents and users to bet on markets:
+
+```
+Agent A (affiliate)          Agent B (bettor)
+    │                            │
+    ├── registerAffiliate ──►    │
+    │   (code: "agent-a")        │
+    │                            │
+    │   Shares wallet address    │
+    │   ─────────────────────►   │
+    │                            ├── placeBetWithAffiliate
+    │                            │   (affiliateWallet: Agent A)
+    │                            │
+    │   ... Agent B wins ...     │
+    │                            ├── claimWinnings
+    │   1% commission accrues    │   (3% platform fee)
+    │   ◄────────────────────    │
+    │                            │
+    ├── claimAffiliateEarnings   │
+    │   (collects 1% SOL)        │
+```
+
+Commission comes from the platform fee split — bettors pay the same amount.
+
+### Fee Structure
+
+| Layer | Platform Fee | Creator Cut | Affiliate Cut | Protocol |
+|-------|-------------|-------------|---------------|----------|
+| Official | 2.5% | 0.5% | 1.0% | 1.0% |
+| Lab | 3.0% | 0.5% | 1.0% | 1.5% |
+| Private | 2.0% | 0.5% | 1.0% | 0.5% |
+
+**Solvency rule:** `creator_fee + affiliate_fee <= platform_fee`
 
 ### Environment Variables
 
@@ -81,55 +155,45 @@ curl -X POST http://localhost:3000/entrypoints/getMarkets/invoke \
   -H "Content-Type: application/json" \
   -d '{"input": {"status": "active", "limit": 5}}'
 
-# List only Lab markets
-curl -X POST http://localhost:3000/entrypoints/getMarkets/invoke \
+# Register as affiliate
+curl -X POST http://localhost:3000/entrypoints/registerAffiliate/invoke \
   -H "Content-Type: application/json" \
-  -d '{"input": {"status": "active", "layer": "lab", "limit": 10}}'
+  -d '{"input": {"code": "my-agent"}}'
 
-# Get odds for a specific market
-curl -X POST http://localhost:3000/entrypoints/getMarketOdds/invoke \
+# Bet with affiliate tracking
+curl -X POST http://localhost:3000/entrypoints/placeBetWithAffiliate/invoke \
   -H "Content-Type: application/json" \
-  -d '{"input": {"marketId": "YOUR_MARKET_PUBKEY"}}'
+  -d '{"input": {"marketId": "MARKET_PUBKEY", "outcome": 0, "amountSol": 0.1, "affiliateWallet": "AFFILIATE_WALLET"}}'
 
-# Create a creator profile (one-time setup)
-curl -X POST http://localhost:3000/entrypoints/createCreatorProfile/invoke \
+# Claim affiliate earnings
+curl -X POST http://localhost:3000/entrypoints/claimAffiliateEarnings/invoke \
   -H "Content-Type: application/json" \
-  -d '{"input": {"displayName": "My Agent", "defaultFeeBps": 50}}'
+  -d '{"input": {}}'
 
-# Create a Lab market (event-based, e.g. esports match)
-curl -X POST http://localhost:3000/entrypoints/createLabMarket/invoke \
+# View creator profile
+curl -X POST http://localhost:3000/entrypoints/getCreatorProfile/invoke \
   -H "Content-Type: application/json" \
-  -d '{"input": {"question": "Will NaVi win CS2 Major Copenhagen Grand Final?", "closingTime": "2026-03-14T06:00:00Z", "marketType": "event", "eventTime": "2026-03-15T14:00:00Z"}}'
+  -d '{"input": {"wallet": "CREATOR_WALLET"}}'
 
-# Create a Lab race market (multi-outcome)
-curl -X POST http://localhost:3000/entrypoints/createLabRaceMarket/invoke \
+# Close market after closing time
+curl -X POST http://localhost:3000/entrypoints/closeMarket/invoke \
   -H "Content-Type: application/json" \
-  -d '{"input": {"question": "Who wins IEM Katowice 2026?", "closingTime": "2026-03-01T00:00:00Z", "outcomes": ["NaVi", "FaZe", "G2", "Vitality"], "marketType": "event", "eventTime": "2026-03-02T12:00:00Z"}}'
+  -d '{"input": {"marketId": "MARKET_PUBKEY"}}'
 
-# Cancel a Lab market you created
-curl -X POST http://localhost:3000/entrypoints/cancelLabMarket/invoke \
+# Creator resolves own boolean Lab market
+curl -X POST http://localhost:3000/entrypoints/proposeResolutionHost/invoke \
   -H "Content-Type: application/json" \
-  -d '{"input": {"marketId": "YOUR_MARKET_PUBKEY", "reason": "Event postponed"}}'
+  -d '{"input": {"marketId": "MARKET_PUBKEY", "winningOutcome": true}}'
 
-# Claim refund from cancelled market
-curl -X POST http://localhost:3000/entrypoints/claimRefund/invoke \
+# Creator resolves own race Lab market
+curl -X POST http://localhost:3000/entrypoints/proposeRaceResolution/invoke \
   -H "Content-Type: application/json" \
-  -d '{"input": {"marketId": "CANCELLED_MARKET_PUBKEY"}}'
+  -d '{"input": {"marketId": "MARKET_PUBKEY", "winningOutcome": 2}}'
 
-# Claim winnings from resolved market
-curl -X POST http://localhost:3000/entrypoints/claimWinnings/invoke \
+# Vote on creator reputation
+curl -X POST http://localhost:3000/entrypoints/voteCreatorReputation/invoke \
   -H "Content-Type: application/json" \
-  -d '{"input": {"marketId": "RESOLVED_MARKET_PUBKEY"}}'
-
-# Finalize resolution after dispute window
-curl -X POST http://localhost:3000/entrypoints/finalizeResolution/invoke \
-  -H "Content-Type: application/json" \
-  -d '{"input": {"marketId": "PENDING_RESOLUTION_MARKET_PUBKEY"}}'
-
-# View portfolio
-curl -X POST http://localhost:3000/entrypoints/getPortfolio/invoke \
-  -H "Content-Type: application/json" \
-  -d '{"input": {"wallet": "YOUR_WALLET_ADDRESS"}}'
+  -d '{"input": {"marketId": "RESOLVED_MARKET_PUBKEY", "vote": 1}}'
 
 # Agent card
 curl http://localhost:3000/.well-known/agent-card.json
@@ -139,17 +203,20 @@ curl http://localhost:3000/.well-known/agent-card.json
 
 The agent reads prediction market data directly from the Solana blockchain using `getProgramAccounts` RPC calls. Market data is parsed from on-chain Borsh-serialized account data — no indexer or backend API required.
 
-**Pricing model:** Pari-mutuel (pool-based). Odds are derived from pool ratios: the implied probability of an outcome equals the proportion of funds bet on the *other* side(s).
+**Pricing model:** Pari-mutuel (pool-based). `P(outcome) = pool_for_outcome / total_pool`.
 
 **Full market lifecycle (all steps supported by this agent):**
 1. Create a CreatorProfile (one-time, costs ~0.01 SOL rent)
-2. Create a Lab market with a question, closing time, and timing proof (Type A or B)
-3. The market goes live immediately — anyone can bet on it
-4. Creator can cancel before resolution if needed (full 100% refund to all bettors)
-5. After closing, the oracle proposes resolution (6h dispute window)
-6. Anyone calls `finalizeResolution` after dispute window closes
-7. Winners call `claimWinnings` to collect payout (minus 3% platform fee)
+2. Register as affiliate (optional, to earn referral commissions)
+3. Create a Lab market with a question, closing time, and timing proof (Type A or B)
+4. The market goes live — anyone can bet (with or without affiliate tracking)
+5. Creator can cancel before resolution if needed (full 100% refund)
+6. After closing time, call `closeMarket` (permissionless) to take snapshot
+7. Creator calls `proposeResolutionHost` / `proposeRaceResolution` (6h dispute window)
+8. Anyone calls `finalizeResolution` after dispute window closes
+9. Winners call `claimWinnings`, creator calls `claimCreatorFees`, affiliates call `claimAffiliateEarnings`
+10. Bettors vote on creator reputation with `voteCreatorReputation`
 
-**Parimutuel Rules v6.3:** Every market creation is validated against strict timing and content rules before the on-chain transaction is sent. This prevents unfair markets (late betting, unverifiable outcomes, manipulation).
+**Parimutuel Rules v6.3:** Every market creation is validated against strict timing and content rules before the on-chain transaction is sent.
 
 See `AGENTS.md` for detailed implementation guide.

--- a/packages/cli/templates/prediction-market-agent/README.md
+++ b/packages/cli/templates/prediction-market-agent/README.md
@@ -1,0 +1,67 @@
+## Prediction Market Agent
+
+AI agent that reads and trades on-chain Solana prediction markets ([Baozi](https://baozi.bet)). Fetches live market data directly from the blockchain with zero backend dependency.
+
+### Quick Start
+
+```sh
+bunx @lucid-agents/create-agent-kit my-pm-agent --template=prediction-market-agent --adapter=hono
+cd my-pm-agent
+# Edit .env with your Solana RPC URL
+bun run dev
+```
+
+### Entrypoints
+
+- **`getMarkets`** — List active prediction markets with current odds
+  - Parameters: `status` (active/closed/all), `query` (search), `limit`
+
+- **`getMarketOdds`** — Implied probabilities and pool sizes for a market
+  - Parameters: `marketId` (base58 public key)
+
+- **`getPortfolio`** — View positions for a wallet
+  - Parameters: `wallet` (base58 address)
+
+- **`placeBet`** — Place a bet on a market outcome (requires `SOLANA_PRIVATE_KEY`)
+  - Parameters: `marketId`, `outcome` (index), `amountSol` (0.01–100)
+
+- **`analyzeMarket`** — Statistical summary with odds breakdown
+  - Parameters: `marketId`
+
+### Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `SOLANA_RPC_URL` | Yes | Solana RPC endpoint (mainnet or devnet) |
+| `SOLANA_PRIVATE_KEY` | For trading | Base58-encoded wallet private key |
+| `DEFAULT_PRICE` | No | x402 price per entrypoint call (base units) |
+
+### Testing
+
+```sh
+# List active markets
+curl -X POST http://localhost:3000/entrypoints/getMarkets/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"status": "active", "limit": 5}}'
+
+# Get odds for a specific market
+curl -X POST http://localhost:3000/entrypoints/getMarketOdds/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"marketId": "YOUR_MARKET_PUBKEY"}}'
+
+# View portfolio
+curl -X POST http://localhost:3000/entrypoints/getPortfolio/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"wallet": "YOUR_WALLET_ADDRESS"}}'
+
+# Agent card
+curl http://localhost:3000/.well-known/agent-card.json
+```
+
+### How It Works
+
+The agent reads prediction market data directly from the Solana blockchain using `getProgramAccounts` RPC calls. Market data is parsed from on-chain Borsh-serialized account data — no indexer or backend API required.
+
+**Pricing model:** Pari-mutuel (pool-based). Odds are derived from pool ratios: the implied probability of an outcome equals the proportion of funds bet on the *other* side(s).
+
+See `AGENTS.md` for detailed implementation guide.

--- a/packages/cli/templates/prediction-market-agent/README.md
+++ b/packages/cli/templates/prediction-market-agent/README.md
@@ -69,7 +69,7 @@ This agent can **read and bet on all layers**, and **create, manage, and resolve
 - **`createLabRaceMarket`** — Create a multi-outcome Lab race market (2–10 outcomes)
   - Parameters: `question`, `closingTime`, `outcomes` (array of labels), `marketType`, `eventTime` or `measurementStart`+`measurementEnd`
 
-#### Market Management (5)
+#### Market Management (6)
 
 - **`updateCreatorProfile`** — Update display name and default creator fee
   - Parameters: `displayName`, `defaultFeeBps`
@@ -100,14 +100,14 @@ This agent can **read and bet on all layers**, and **create, manage, and resolve
 - **`finalizeResolution`** — Finalize resolution after 6h dispute window (permissionless)
   - Parameters: `marketId`
 
-- **`voteCreatorReputation`** — Vote +1/-1 on creator reputation (requires bet position)
+- **`voteCreatorReputation`** — Vote +1/-1 on creator reputation for boolean markets only (requires bet position)
   - Parameters: `marketId`, `vote` (+1 or -1)
 
 ### Affiliate System — Agent-to-Agent Recruitment
 
 Agents can earn passive income by referring other agents and users to bet on markets:
 
-```
+```text
 Agent A (affiliate)          Agent B (bettor)
     │                            │
     ├── registerAffiliate ──►    │

--- a/packages/cli/templates/prediction-market-agent/agent.ts.template
+++ b/packages/cli/templates/prediction-market-agent/agent.ts.template
@@ -134,6 +134,7 @@ interface Market {
   url: string;
   rawMarketId: string;
   creator: string;
+  rawCreatorProfile: string | null;
 }
 
 interface Position {
@@ -175,11 +176,11 @@ function parseMarket(data: Buffer | Uint8Array) {
   r.optBytes(32); // invite_hash
   const creatorFeeBps = r.u16();
   r.u64(); // total_creator_fees
-  r.optPubkey(); // creator_profile
+  const creatorProfile = r.optPubkey(); // creator_profile PDA (if Lab/Private)
   const platformFeeBpsAtCreation = r.u16();
-  r.u16(); r.i64(); // affiliate_fee_bps, betting_freeze_seconds
+  const affiliateFeeBps = r.u16(); r.i64(); // affiliate_fee_bps, betting_freeze_seconds
   const hasBets = r.bool();
-  return { marketId, question, closingTime, resolutionTime, yesPool, noPool, status, winningOutcome, layer, creator, creatorFeeBps, platformFeeBpsAtCreation, hasBets, lastBetTime };
+  return { marketId, question, closingTime, resolutionTime, yesPool, noPool, status, winningOutcome, layer, creator, creatorFeeBps, creatorProfile, affiliateFeeBps, platformFeeBpsAtCreation, hasBets, lastBetTime };
 }
 
 function parseRaceMarket(data: Buffer | Uint8Array) {
@@ -206,14 +207,18 @@ function parseRaceMarket(data: Buffer | Uint8Array) {
   const creator = r.pubkey();
   r.optPubkey(); r.skip(160); r.u8(); r.skip(10); r.u8(); // oracle, council
   const creatorFeeBps = r.u16();
-  r.optPubkey(); // creator_profile
+  const creatorProfile = r.optPubkey(); // creator_profile PDA (if Lab/Private)
   const platformFeeBpsAtCreation = r.u16();
-  return { marketId, question, closingTime, resolutionTime, outcomeCount, outcomeLabels: outcomeLabels.slice(0, outcomeCount), outcomePools: outcomePools.slice(0, outcomeCount), totalPool, status, winningOutcome, layer, creator, creatorFeeBps, platformFeeBpsAtCreation, lastBetTime };
+  return { marketId, question, closingTime, resolutionTime, outcomeCount, outcomeLabels: outcomeLabels.slice(0, outcomeCount), outcomePools: outcomePools.slice(0, outcomeCount), totalPool, status, winningOutcome, layer, creator, creatorFeeBps, creatorProfile, platformFeeBpsAtCreation, lastBetTime };
 }
 
 function parseUserPosition(data: Buffer | Uint8Array) {
   const r = new BorshReader(data); r.skip(8);
-  return { user: r.pubkey(), marketId: r.u64(), yesAmount: r.u64(), noAmount: r.u64(), claimed: r.bool() };
+  const user = r.pubkey(); const marketId = r.u64();
+  const yesAmount = r.u64(); const noAmount = r.u64();
+  const claimed = r.bool(); r.u8(); // bump
+  const referredBy = r.optPubkey(); // Option<Pubkey> — affiliate owner who referred this user
+  return { user, marketId, yesAmount, noAmount, claimed, referredBy };
 }
 
 function parseRacePosition(data: Buffer | Uint8Array) {
@@ -345,7 +350,7 @@ function boolToMarket(raw: ReturnType<typeof parseMarket>, pk: string): Market {
     totalPoolSol: s, status: STATUS_NAMES[raw.status] ?? 'unknown',
     layer: layerName(raw.layer), closingTime: new Date(Number(raw.closingTime) * 1000).toISOString(),
     url: `https://baozi.bet/market/${pk}`, rawMarketId: raw.marketId.toString(),
-    creator: raw.creator,
+    creator: raw.creator, rawCreatorProfile: raw.creatorProfile,
   };
 }
 
@@ -362,7 +367,7 @@ function raceToMarket(raw: ReturnType<typeof parseRaceMarket>, pk: string): Mark
     status: STATUS_NAMES[raw.status] ?? 'unknown', layer: layerName(raw.layer),
     closingTime: new Date(Number(raw.closingTime) * 1000).toISOString(),
     url: `https://baozi.bet/market/${pk}`, rawMarketId: raw.marketId.toString(),
-    creator: raw.creator,
+    creator: raw.creator, rawCreatorProfile: raw.creatorProfile,
   };
 }
 
@@ -835,34 +840,56 @@ class BaoziClient {
 
     const mPk = new PublicKey(params.marketPubkey);
     const rawId = BigInt(market.rawMarketId);
+
+    // Resolve optional accounts from on-chain state.
+    // The program REQUIRES affiliate PDA when position.referred_by is set (error 6251),
+    // and creator_profile PDA when market has creator fees (error 6262).
+    const creatorProfileKey = market.rawCreatorProfile ? new PublicKey(market.rawCreatorProfile) : PROGRAM_ID;
     let ix: TransactionInstruction;
 
     if (market.type === 'boolean') {
-      // claim_winnings_sol: 10 accounts (4 optional — pass PROGRAM_ID for None)
       const pos = positionPda(rawId, this.wallet.publicKey);
+      // Fetch position to check if referred_by is set
+      const posInfo = await this.conn.getAccountInfo(pos);
+      let affKey: PublicKey = PROGRAM_ID;
+      if (posInfo) {
+        const posData = parseUserPosition(posInfo.data);
+        if (posData.referredBy) affKey = affiliatePda(new PublicKey(posData.referredBy));
+      }
       ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
         { pubkey: configPda(), isSigner: false, isWritable: false },
         { pubkey: mPk, isSigner: false, isWritable: true },
         { pubkey: pos, isSigner: false, isWritable: true },
         { pubkey: treasuryPda(), isSigner: false, isWritable: true },
-        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },  // affiliate: None
-        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },  // creator_profile: None
+        { pubkey: affKey, isSigner: false, isWritable: affKey !== PROGRAM_ID },
+        { pubkey: creatorProfileKey, isSigner: false, isWritable: creatorProfileKey !== PROGRAM_ID },
         { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },  // revenue_config: None
         { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },  // staking_vault: None
         { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
         { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
       ], data: CLAIM_WINNINGS_DISC });
     } else {
-      // claim_race_winnings_sol: 11 accounts (5 optional — pass PROGRAM_ID for None)
       const pos = racePosPda(rawId, this.wallet.publicKey);
+      // Check if RaceReferral PDA exists for this user+market
+      const raceRefPda = raceReferralPda(mPk, this.wallet.publicKey);
+      const raceRefInfo = await this.conn.getAccountInfo(raceRefPda);
+      let affKey: PublicKey = PROGRAM_ID;
+      let raceRefKey: PublicKey = PROGRAM_ID;
+      if (raceRefInfo && raceRefInfo.data.length > 0) {
+        raceRefKey = raceRefPda;
+        // Parse race_referral to get referred_by field: skip disc(8) + race_market(32) + user(32) = offset 72
+        const rr = new BorshReader(raceRefInfo.data); rr.skip(8 + 32 + 32);
+        const referredBy = rr.pubkey();
+        affKey = affiliatePda(new PublicKey(referredBy));
+      }
       ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
         { pubkey: configPda(), isSigner: false, isWritable: false },
         { pubkey: mPk, isSigner: false, isWritable: true },
         { pubkey: pos, isSigner: false, isWritable: true },
         { pubkey: treasuryPda(), isSigner: false, isWritable: true },
-        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },  // affiliate: None
-        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },  // race_referral: None
-        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },  // creator_profile: None
+        { pubkey: affKey, isSigner: false, isWritable: affKey !== PROGRAM_ID },
+        { pubkey: raceRefKey, isSigner: false, isWritable: false },
+        { pubkey: creatorProfileKey, isSigner: false, isWritable: creatorProfileKey !== PROGRAM_ID },
         { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },  // revenue_config: None
         { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },  // staking_vault: None
         { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
@@ -1668,7 +1695,7 @@ HOW IT WORKS:
 
 Commission comes from the platform fee split — bettors pay the same amount regardless.`,
   input: z.object({
-    code: z.string().min(1).max(32).describe('Unique referral code (e.g. your agent name)'),
+    code: z.string().min(1).max(16).describe('Unique referral code (e.g. your agent name, max 16 chars)'),
   }),
   output: z.object({
     signature: z.string(),

--- a/packages/cli/templates/prediction-market-agent/agent.ts.template
+++ b/packages/cli/templates/prediction-market-agent/agent.ts.template
@@ -692,6 +692,8 @@ class BaoziClient {
     if (!market) throw new Error(`Market not found: ${params.marketPubkey}`);
     if (market.status === 'cancelled') throw new Error('Market is already cancelled');
     if (market.status === 'resolved') throw new Error('Market is already resolved — cannot cancel');
+    if (market.status === 'resolved_pending') throw new Error('Market has a pending resolution (6h dispute window active) — cannot cancel after oracle has proposed outcome');
+    if (market.status === 'disputed') throw new Error('Market is under dispute — cannot cancel while dispute is active');
 
     const mPk = new PublicKey(params.marketPubkey);
     const w = new BorshWriter();

--- a/packages/cli/templates/prediction-market-agent/agent.ts.template
+++ b/packages/cli/templates/prediction-market-agent/agent.ts.template
@@ -35,6 +35,9 @@ const MARKET_DISC_B58 = bs58.encode(MARKET_DISC);
 const RACE_DISC_B58 = bs58.encode(RACE_DISC);
 const POS_DISC_B58 = bs58.encode(POS_DISC);
 const RACE_POS_DISC_B58 = bs58.encode(RACE_POS_DISC);
+const AFFILIATE_DISC = Buffer.from([136, 95, 107, 149, 36, 195, 146, 35]);
+const CREATOR_PROFILE_DISC = Buffer.from([251, 250, 184, 111, 214, 178, 32, 221]);
+const CREATOR_REP_DISC = Buffer.from([76, 107, 128, 9, 3, 235, 176, 152]);
 
 // -- Instruction Discriminators (hardcoded from IDL) ------------------------
 
@@ -51,6 +54,17 @@ const CLAIM_WINNINGS_DISC = Buffer.from([64, 158, 207, 116, 128, 129, 169, 76]);
 const CLAIM_RACE_WINNINGS_DISC = Buffer.from([46, 120, 202, 194, 126, 72, 22, 52]);
 const FINALIZE_RESOLUTION_DISC = Buffer.from([191, 74, 94, 214, 45, 150, 152, 125]);
 const FINALIZE_RACE_RESOLUTION_DISC = Buffer.from([19, 232, 81, 138, 191, 218, 54, 200]);
+const REGISTER_AFFILIATE_DISC = Buffer.from([87, 121, 99, 184, 126, 63, 103, 217]);
+const BET_WITH_AFFILIATE_DISC = Buffer.from([197, 186, 187, 145, 252, 239, 101, 96]);
+const RACE_BET_WITH_AFFILIATE_DISC = Buffer.from([26, 224, 14, 181, 67, 52, 24, 0]);
+const CLAIM_AFFILIATE_DISC = Buffer.from([125, 18, 164, 112, 216, 207, 197, 201]);
+const CLAIM_CREATOR_DISC = Buffer.from([21, 25, 164, 47, 81, 156, 199, 103]);
+const UPDATE_PROFILE_DISC = Buffer.from([8, 240, 162, 55, 110, 46, 177, 108]);
+const CLOSE_MARKET_DISC = Buffer.from([88, 154, 248, 186, 48, 14, 123, 244]);
+const CLOSE_RACE_MARKET_DISC = Buffer.from([39, 189, 166, 118, 134, 37, 102, 41]);
+const PROPOSE_RESOLUTION_HOST_DISC = Buffer.from([116, 231, 75, 185, 127, 129, 46, 124]);
+const PROPOSE_RACE_RESOLUTION_DISC = Buffer.from([14, 204, 17, 188, 243, 49, 107, 255]);
+const VOTE_REPUTATION_DISC = Buffer.from([70, 64, 70, 238, 141, 95, 102, 221]);
 
 const STATUS_NAMES: Record<number, string> = {
   0: 'active', 1: 'closed', 2: 'resolved', 3: 'cancelled',
@@ -91,6 +105,7 @@ class BorshWriter {
   u16(v: number) { const b = Buffer.alloc(2); b.writeUInt16LE(v); this.parts.push(b); return this; }
   u32(v: number) { const b = Buffer.alloc(4); b.writeUInt32LE(v); this.parts.push(b); return this; }
   u64(v: bigint) { const b = Buffer.alloc(8); b.writeBigUInt64LE(v); this.parts.push(b); return this; }
+  i8(v: number) { const b = Buffer.alloc(1); b.writeInt8(v); this.parts.push(b); return this; }
   i64(v: bigint) { const b = Buffer.alloc(8); b.writeBigInt64LE(v); this.parts.push(b); return this; }
   bool(v: boolean) { return this.u8(v ? 1 : 0); }
   string(s: string) { const buf = Buffer.from(s, 'utf8'); this.u32(buf.length); this.parts.push(buf); return this; }
@@ -118,6 +133,7 @@ interface Market {
   closingTime: string;
   url: string;
   rawMarketId: string;
+  creator: string;
 }
 
 interface Position {
@@ -223,6 +239,44 @@ function parseGlobalConfig(data: Buffer | Uint8Array): GlobalConfigData {
   return { marketCount };
 }
 
+function parseCreatorProfile(data: Buffer | Uint8Array) {
+  const r = new BorshReader(data);
+  r.skip(8); // discriminator
+  const owner = r.pubkey();
+  const displayName = r.string();
+  const isVerified = r.bool();
+  const verificationType = r.u8();
+  const totalMarketsCreated = r.u64();
+  const totalVolumeSol = r.u64();
+  r.u64(); // _reserved_total_volume_usdc
+  const marketsResolved = r.u64();
+  const disputesLost = r.u64();
+  const createdAt = r.i64();
+  const lastMarketAt = r.i64();
+  const defaultCreatorFeeBps = r.u16();
+  const totalEarningsSol = r.u64();
+  r.u64(); // _reserved_total_earnings_usdc
+  const pendingSol = r.u64();
+  return { owner, displayName, isVerified, verificationType, totalMarketsCreated, totalVolumeSol, marketsResolved, disputesLost, createdAt, lastMarketAt, defaultCreatorFeeBps, totalEarningsSol, pendingSol };
+}
+
+function parseAffiliate(data: Buffer | Uint8Array) {
+  const r = new BorshReader(data);
+  r.skip(8); // discriminator
+  const owner = r.pubkey();
+  const code = r.string();
+  const totalReferredUsers = r.u64();
+  const totalVolumeSol = r.u64();
+  r.u64(); // _reserved_total_volume_usdc
+  const totalEarningsSol = r.u64();
+  r.u64(); // _reserved_total_earnings_usdc
+  const pendingSol = r.u64();
+  r.u64(); // _reserved_pending_usdc
+  const createdAt = r.i64();
+  const isActive = r.bool();
+  return { owner, code, totalReferredUsers, totalVolumeSol, totalEarningsSol, pendingSol, createdAt, isActive };
+}
+
 // -- PDA Derivation ---------------------------------------------------------
 
 function configPda() {
@@ -256,6 +310,22 @@ function revenueConfigPda() {
 function disputeMetaPda(marketPubkey: PublicKey) {
   return PublicKey.findProgramAddressSync([Buffer.from('dispute_meta'), marketPubkey.toBuffer()], PROGRAM_ID)[0];
 }
+function affiliatePda(owner: PublicKey) {
+  return PublicKey.findProgramAddressSync([Buffer.from('affiliate'), owner.toBuffer()], PROGRAM_ID)[0];
+}
+function referredUserPda(user: PublicKey) {
+  return PublicKey.findProgramAddressSync([Buffer.from('referred'), user.toBuffer()], PROGRAM_ID)[0];
+}
+function raceReferralPda(raceMarket: PublicKey, user: PublicKey) {
+  return PublicKey.findProgramAddressSync([Buffer.from('race_referral'), raceMarket.toBuffer(), user.toBuffer()], PROGRAM_ID)[0];
+}
+function creatorRepPda(creator: PublicKey) {
+  return PublicKey.findProgramAddressSync([Buffer.from('creator_rep'), creator.toBuffer()], PROGRAM_ID)[0];
+}
+function repVotePda(voter: PublicKey, creator: PublicKey, marketId: bigint) {
+  const b = Buffer.alloc(8); b.writeBigUInt64LE(marketId);
+  return PublicKey.findProgramAddressSync([Buffer.from('rep_vote'), voter.toBuffer(), creator.toBuffer(), b], PROGRAM_ID)[0];
+}
 
 // -- Helpers ----------------------------------------------------------------
 
@@ -275,6 +345,7 @@ function boolToMarket(raw: ReturnType<typeof parseMarket>, pk: string): Market {
     totalPoolSol: s, status: STATUS_NAMES[raw.status] ?? 'unknown',
     layer: layerName(raw.layer), closingTime: new Date(Number(raw.closingTime) * 1000).toISOString(),
     url: `https://baozi.bet/market/${pk}`, rawMarketId: raw.marketId.toString(),
+    creator: raw.creator,
   };
 }
 
@@ -291,6 +362,7 @@ function raceToMarket(raw: ReturnType<typeof parseRaceMarket>, pk: string): Mark
     status: STATUS_NAMES[raw.status] ?? 'unknown', layer: layerName(raw.layer),
     closingTime: new Date(Number(raw.closingTime) * 1000).toISOString(),
     url: `https://baozi.bet/market/${pk}`, rawMarketId: raw.marketId.toString(),
+    creator: raw.creator,
   };
 }
 
@@ -832,6 +904,251 @@ class BaoziClient {
     this.invalidateCache();
     return sig;
   }
+
+  // -- Affiliate System -------------------------------------------------------
+
+  async registerAffiliate(params: { code: string }): Promise<{ signature: string; affiliateAddress: string }> {
+    if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY.');
+    const affPda = affiliatePda(this.wallet.publicKey);
+    const w = new BorshWriter();
+    w.raw(REGISTER_AFFILIATE_DISC);
+    w.string(params.code);
+    const ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+      { pubkey: configPda(), isSigner: false, isWritable: false },
+      { pubkey: affPda, isSigner: false, isWritable: true },
+      { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ], data: w.toBuffer() });
+    const sig = await this.sendTx(ix);
+    return { signature: sig, affiliateAddress: affPda.toString() };
+  }
+
+  async placeBetWithAffiliate(params: { marketPubkey: string; outcome: number; amountSol: number; affiliateWallet: string }): Promise<string> {
+    if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY.');
+    const market = await this.fetchMarket(params.marketPubkey);
+    if (!market) throw new Error(`Market not found: ${params.marketPubkey}`);
+    if (market.status !== 'active') throw new Error(`Market is ${market.status}, not active — cannot place bet`);
+    if (new Date(market.closingTime).getTime() <= Date.now()) throw new Error('Market has passed its closing time — cannot place bet');
+
+    if (market.type === 'boolean' && (params.outcome < 0 || params.outcome > 1))
+      throw new Error(`Boolean markets accept outcome 0 (Yes) or 1 (No), got ${params.outcome}`);
+    if (market.type === 'race' && (params.outcome < 0 || params.outcome >= market.outcomes.length))
+      throw new Error(`Race market has ${market.outcomes.length} outcomes (0-${market.outcomes.length - 1}), got index ${params.outcome}`);
+
+    const amt = BigInt(Math.round(params.amountSol * LAMPORTS_PER_SOL));
+    const mPk = new PublicKey(params.marketPubkey);
+    const rawId = BigInt(market.rawMarketId);
+    const affWallet = new PublicKey(params.affiliateWallet);
+    const affPda = affiliatePda(affWallet);
+
+    let ix: TransactionInstruction;
+    if (market.type === 'boolean') {
+      const pos = positionPda(rawId, this.wallet.publicKey);
+      const referred = referredUserPda(this.wallet.publicKey);
+      const data = Buffer.alloc(17);
+      BET_WITH_AFFILIATE_DISC.copy(data, 0);
+      data.writeUInt8(params.outcome === 0 ? 1 : 0, 8); // IDL: bool outcome (true=Yes, false=No)
+      data.writeBigUInt64LE(amt, 9);
+      ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+        { pubkey: configPda(), isSigner: false, isWritable: false },
+        { pubkey: mPk, isSigner: false, isWritable: true },
+        { pubkey: pos, isSigner: false, isWritable: true },
+        { pubkey: affPda, isSigner: false, isWritable: true },
+        { pubkey: referred, isSigner: false, isWritable: true },
+        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false }, // whitelist: None (optional)
+        { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+      ], data });
+    } else {
+      const pos = racePosPda(rawId, this.wallet.publicKey);
+      const raceRef = raceReferralPda(mPk, this.wallet.publicKey);
+      const data = Buffer.alloc(17);
+      RACE_BET_WITH_AFFILIATE_DISC.copy(data, 0);
+      data.writeUInt8(params.outcome, 8); // IDL: u8 outcome_index
+      data.writeBigUInt64LE(amt, 9);
+      ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+        { pubkey: configPda(), isSigner: false, isWritable: false },
+        { pubkey: mPk, isSigner: false, isWritable: true },
+        { pubkey: pos, isSigner: false, isWritable: true },
+        { pubkey: affPda, isSigner: false, isWritable: true },
+        { pubkey: raceRef, isSigner: false, isWritable: true },
+        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false }, // whitelist: None (optional)
+        { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+      ], data });
+    }
+
+    const sig = await this.sendTx(ix);
+    this.invalidateCache();
+    return sig;
+  }
+
+  async claimAffiliateEarnings(): Promise<string> {
+    if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY.');
+    const ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+      { pubkey: configPda(), isSigner: false, isWritable: true },
+      { pubkey: affiliatePda(this.wallet.publicKey), isSigner: false, isWritable: true },
+      { pubkey: treasuryPda(), isSigner: false, isWritable: true },
+      { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ], data: CLAIM_AFFILIATE_DISC });
+    return this.sendTx(ix);
+  }
+
+  async fetchAffiliate(wallet: string): Promise<ReturnType<typeof parseAffiliate> | null> {
+    const pk = new PublicKey(wallet);
+    const info = await this.conn.getAccountInfo(affiliatePda(pk));
+    if (!info) return null;
+    return parseAffiliate(info.data);
+  }
+
+  // -- Creator Management -----------------------------------------------------
+
+  async claimCreatorFees(): Promise<string> {
+    if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY.');
+    const ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+      { pubkey: configPda(), isSigner: false, isWritable: false },
+      { pubkey: creatorProfilePda(this.wallet.publicKey), isSigner: false, isWritable: true },
+      { pubkey: treasuryPda(), isSigner: false, isWritable: true },
+      { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ], data: CLAIM_CREATOR_DISC });
+    return this.sendTx(ix);
+  }
+
+  async updateCreatorProfile(params: { displayName: string; defaultFeeBps: number }): Promise<string> {
+    if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY.');
+    const w = new BorshWriter();
+    w.raw(UPDATE_PROFILE_DISC);
+    w.string(params.displayName);
+    w.u16(params.defaultFeeBps);
+    const ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+      { pubkey: creatorProfilePda(this.wallet.publicKey), isSigner: false, isWritable: true },
+      { pubkey: this.wallet.publicKey, isSigner: true, isWritable: false },
+    ], data: w.toBuffer() });
+    return this.sendTx(ix);
+  }
+
+  async fetchCreatorProfile(wallet: string): Promise<ReturnType<typeof parseCreatorProfile> | null> {
+    const pk = new PublicKey(wallet);
+    const info = await this.conn.getAccountInfo(creatorProfilePda(pk));
+    if (!info) return null;
+    return parseCreatorProfile(info.data);
+  }
+
+  // -- Market Lifecycle Management --------------------------------------------
+
+  async closeMarket(params: { marketPubkey: string }): Promise<string> {
+    if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY.');
+    const market = await this.fetchMarket(params.marketPubkey);
+    if (!market) throw new Error(`Market not found: ${params.marketPubkey}`);
+    if (market.status === 'resolved' || market.status === 'cancelled')
+      throw new Error(`Market is already ${market.status} — cannot close`);
+    if (market.status === 'closed')
+      throw new Error('Market is already closed');
+
+    const mPk = new PublicKey(params.marketPubkey);
+    let ix: TransactionInstruction;
+    if (market.type === 'boolean') {
+      ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+        { pubkey: configPda(), isSigner: false, isWritable: false },
+        { pubkey: mPk, isSigner: false, isWritable: true },
+        { pubkey: this.wallet.publicKey, isSigner: true, isWritable: false },
+      ], data: CLOSE_MARKET_DISC });
+    } else {
+      ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+        { pubkey: configPda(), isSigner: false, isWritable: false },
+        { pubkey: mPk, isSigner: false, isWritable: true },
+        { pubkey: this.wallet.publicKey, isSigner: true, isWritable: false },
+      ], data: CLOSE_RACE_MARKET_DISC });
+    }
+
+    const sig = await this.sendTx(ix);
+    this.invalidateCache();
+    return sig;
+  }
+
+  async proposeResolutionHost(params: { marketPubkey: string; winningOutcome: boolean }): Promise<string> {
+    if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY.');
+    const market = await this.fetchMarket(params.marketPubkey);
+    if (!market) throw new Error(`Market not found: ${params.marketPubkey}`);
+    if (market.status !== 'closed') throw new Error(`Market status is "${market.status}" — must be "closed" to propose resolution`);
+    if (market.type !== 'boolean') throw new Error('Use proposeRaceResolution for race markets');
+
+    const mPk = new PublicKey(params.marketPubkey);
+    const w = new BorshWriter();
+    w.raw(PROPOSE_RESOLUTION_HOST_DISC);
+    w.bool(params.winningOutcome);
+    const ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+      { pubkey: configPda(), isSigner: false, isWritable: false },
+      { pubkey: mPk, isSigner: false, isWritable: true },
+      { pubkey: disputeMetaPda(mPk), isSigner: false, isWritable: true },
+      { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ], data: w.toBuffer() });
+
+    const sig = await this.sendTx(ix);
+    this.invalidateCache();
+    return sig;
+  }
+
+  async proposeRaceResolution(params: { marketPubkey: string; winningOutcome: number }): Promise<string> {
+    if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY.');
+    const market = await this.fetchMarket(params.marketPubkey);
+    if (!market) throw new Error(`Market not found: ${params.marketPubkey}`);
+    if (market.status !== 'closed') throw new Error(`Market status is "${market.status}" — must be "closed" to propose resolution`);
+    if (market.type !== 'race') throw new Error('Use proposeResolutionHost for boolean markets');
+    if (params.winningOutcome < 0 || params.winningOutcome >= market.outcomes.length)
+      throw new Error(`Invalid outcome index ${params.winningOutcome} — market has ${market.outcomes.length} outcomes (0-${market.outcomes.length - 1})`);
+
+    const mPk = new PublicKey(params.marketPubkey);
+    const w = new BorshWriter();
+    w.raw(PROPOSE_RACE_RESOLUTION_DISC);
+    w.u8(params.winningOutcome);
+    const ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+      { pubkey: configPda(), isSigner: false, isWritable: false },
+      { pubkey: mPk, isSigner: false, isWritable: true },
+      { pubkey: disputeMetaPda(mPk), isSigner: false, isWritable: true },
+      { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ], data: w.toBuffer() });
+
+    const sig = await this.sendTx(ix);
+    this.invalidateCache();
+    return sig;
+  }
+
+  // -- Creator Reputation -----------------------------------------------------
+
+  async voteCreatorReputation(params: { marketPubkey: string; vote: 1 | -1 }): Promise<string> {
+    if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY.');
+    const market = await this.fetchMarket(params.marketPubkey);
+    if (!market) throw new Error(`Market not found: ${params.marketPubkey}`);
+    if (market.status !== 'resolved') throw new Error(`Market must be resolved to vote on creator reputation — current status: "${market.status}"`);
+    if (market.type !== 'boolean') throw new Error('Creator reputation voting is currently only supported for boolean markets');
+
+    const mPk = new PublicKey(params.marketPubkey);
+    const rawId = BigInt(market.rawMarketId);
+    const creatorPk = new PublicKey(market.creator);
+    const pos = positionPda(rawId, this.wallet.publicKey);
+    const repPda = creatorRepPda(creatorPk);
+    const votePda = repVotePda(this.wallet.publicKey, creatorPk, rawId);
+
+    const w = new BorshWriter();
+    w.raw(VOTE_REPUTATION_DISC);
+    w.i8(params.vote);
+    const ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+      { pubkey: configPda(), isSigner: false, isWritable: false },
+      { pubkey: mPk, isSigner: false, isWritable: false },
+      { pubkey: pos, isSigner: false, isWritable: false },
+      { pubkey: repPda, isSigner: false, isWritable: true },
+      { pubkey: votePda, isSigner: false, isWritable: true },
+      { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ], data: w.toBuffer() });
+
+    return this.sendTx(ix);
+  }
 }
 
 {{TEMPLATE_PRE_SETUP}}
@@ -855,23 +1172,41 @@ const agent = await createAgent({
 {{TEMPLATE_POST_SETUP}}
 
 /**
- * Prediction Market Agent — Baozi on Solana
+ * Prediction Market Agent — Baozi on Solana (22 entrypoints)
  *
  * Read entrypoints:
- *   getMarkets         — List markets with filters (status, layer, query)
- *   getMarketOdds      — Probabilities and pool sizes for one market
- *   getPortfolio       — Active positions for a wallet
- *   analyzeMarket      — Statistical market summary
+ *   getMarkets            — List markets with filters (status, layer, query)
+ *   getMarketOdds         — Probabilities and pool sizes for one market
+ *   getPortfolio          — Active positions for a wallet
+ *   analyzeMarket         — Statistical market summary
+ *   getCreatorProfile     — View creator profile, earnings, and reputation
  *
- * Write entrypoints:
- *   placeBet              — Place a bet (requires SOLANA_PRIVATE_KEY)
+ * Write entrypoints — Trading:
+ *   placeBet              — Place a bet on any market
+ *   placeBetWithAffiliate — Place a bet with affiliate referral tracking (1% commission)
+ *
+ * Write entrypoints — Affiliate System:
+ *   registerAffiliate     — Register as an affiliate to earn referral commissions
+ *   claimAffiliateEarnings — Claim accumulated affiliate SOL earnings
+ *
+ * Write entrypoints — Market Creation:
  *   createCreatorProfile  — Create on-chain creator profile (required for Labs)
  *   createLabMarket       — Create a Yes/No Lab market
  *   createLabRaceMarket   — Create a multi-outcome Lab race market
+ *
+ * Write entrypoints — Market Management:
+ *   updateCreatorProfile  — Update display name and default fee
+ *   claimCreatorFees      — Claim pending creator fee earnings
  *   cancelLabMarket       — Cancel a Lab market you created (full refund to bettors)
+ *   closeMarket           — Permissionless close after closing time (takes snapshot)
+ *   proposeResolutionHost — Creator resolves own Lab boolean market
+ *   proposeRaceResolution — Creator resolves own Lab race market
+ *   finalizeResolution    — Finalize resolution after dispute window (permissionless)
+ *
+ * Write entrypoints — Claims & Reputation:
  *   claimRefund           — Claim refund from a cancelled market
  *   claimWinnings         — Claim SOL winnings from a resolved market
- *   finalizeResolution    — Finalize resolution after dispute window (permissionless)
+ *   voteCreatorReputation — Vote +1/-1 on creator reputation after betting
  */
 
 const solPubkey = z.string().refine(s => { try { new PublicKey(s); return true; } catch { return false; } }, 'Invalid Solana public key');
@@ -1302,6 +1637,313 @@ Works for both boolean and race markets.`,
   price: process.env.DEFAULT_PRICE || undefined,
   handler: async (ctx) => {
     const sig = await baozi.finalizeResolution({ marketPubkey: ctx.input.marketId });
+    return {
+      output: {
+        signature: sig,
+        explorerUrl: `https://solscan.io/tx/${sig}`,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+// -- Affiliate System Entrypoints -------------------------------------------
+
+addEntrypoint({
+  key: 'registerAffiliate',
+  description: `Register as an affiliate to earn 1% referral commission on all bets placed through your link.
+
+HOW IT WORKS:
+1. Register with a unique code (your brand name, agent name, etc.)
+2. Share your wallet address with other agents/users
+3. They bet using placeBetWithAffiliate with your wallet as affiliateWallet
+4. You earn 1% of their winnings (paid from platform fee, NOT from bettor)
+5. Claim earnings anytime with claimAffiliateEarnings
+
+Commission comes from the platform fee split — bettors pay the same amount regardless.`,
+  input: z.object({
+    code: z.string().min(1).max(32).describe('Unique referral code (e.g. your agent name)'),
+  }),
+  output: z.object({
+    signature: z.string(),
+    affiliateAddress: z.string(),
+    explorerUrl: z.string(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const result = await baozi.registerAffiliate({ code: ctx.input.code });
+    return {
+      output: {
+        ...result,
+        explorerUrl: `https://solscan.io/tx/${result.signature}`,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+addEntrypoint({
+  key: 'placeBetWithAffiliate',
+  description: `Place a bet with affiliate referral tracking. The affiliate earns 1% commission on winnings.
+
+Identical to placeBet but includes the referring affiliate's wallet address for commission attribution.
+Works on all market types (boolean and race) across all layers (Official, Lab, Private).
+The bettor pays the same amount — affiliate commission comes from the platform fee split.`,
+  input: z.object({
+    marketId: solPubkey.describe('Market public key (base58)'),
+    outcome: z.number().describe('Outcome index (0=Yes/first, 1=No/second, etc.)'),
+    amountSol: z.number().min(0.01).max(100).describe('Bet amount in SOL'),
+    affiliateWallet: solPubkey.describe('Wallet address of the referring affiliate'),
+  }),
+  output: z.object({
+    signature: z.string(),
+    market: z.string(),
+    outcome: z.number(),
+    amountSol: z.number(),
+    affiliate: z.string(),
+    explorerUrl: z.string(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const { marketId, outcome, amountSol, affiliateWallet } = ctx.input;
+    const signature = await baozi.placeBetWithAffiliate({ marketPubkey: marketId, outcome, amountSol, affiliateWallet });
+    return {
+      output: {
+        signature,
+        market: marketId,
+        outcome,
+        amountSol,
+        affiliate: affiliateWallet,
+        explorerUrl: `https://solscan.io/tx/${signature}`,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+addEntrypoint({
+  key: 'claimAffiliateEarnings',
+  description: `Claim accumulated affiliate referral earnings (SOL). Transfers all pending earnings from the protocol treasury to your wallet.
+
+Check your pending earnings first with getCreatorProfile (affiliate earnings are tracked separately but visible there).`,
+  input: z.object({}),
+  output: z.object({
+    signature: z.string(),
+    explorerUrl: z.string(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const sig = await baozi.claimAffiliateEarnings();
+    return {
+      output: {
+        signature: sig,
+        explorerUrl: `https://solscan.io/tx/${sig}`,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+// -- Creator Management Entrypoints -----------------------------------------
+
+addEntrypoint({
+  key: 'updateCreatorProfile',
+  description: 'Update your on-chain creator profile display name and default fee. Requires an existing CreatorProfile.',
+  input: z.object({
+    displayName: z.string().min(1).max(32).describe('New display name'),
+    defaultFeeBps: z.number().min(0).max(200).describe('New default creator fee in basis points (50 = 0.5%)'),
+  }),
+  output: z.object({
+    signature: z.string(),
+    explorerUrl: z.string(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const sig = await baozi.updateCreatorProfile({ displayName: ctx.input.displayName, defaultFeeBps: ctx.input.defaultFeeBps });
+    return {
+      output: {
+        signature: sig,
+        explorerUrl: `https://solscan.io/tx/${sig}`,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+addEntrypoint({
+  key: 'claimCreatorFees',
+  description: `Claim pending creator fee earnings (SOL). When bettors claim winnings from your markets, a portion of the platform fee is allocated to you as the creator.
+
+Creator fee is set when creating the market (default 0.5%, max 2%). Earnings accumulate in your CreatorProfile and can be claimed anytime.`,
+  input: z.object({}),
+  output: z.object({
+    signature: z.string(),
+    explorerUrl: z.string(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const sig = await baozi.claimCreatorFees();
+    return {
+      output: {
+        signature: sig,
+        explorerUrl: `https://solscan.io/tx/${sig}`,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+addEntrypoint({
+  key: 'getCreatorProfile',
+  description: 'View a creator profile including display name, market stats, earnings, and reputation.',
+  input: z.object({
+    wallet: solPubkey.describe('Creator wallet address (base58)'),
+  }),
+  output: z.object({
+    owner: z.string(),
+    displayName: z.string(),
+    isVerified: z.boolean(),
+    totalMarketsCreated: z.number(),
+    marketsResolved: z.number(),
+    disputesLost: z.number(),
+    totalVolumeSol: z.number(),
+    totalEarningsSol: z.number(),
+    pendingSol: z.number(),
+    defaultCreatorFeeBps: z.number(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const profile = await baozi.fetchCreatorProfile(ctx.input.wallet);
+    if (!profile) throw new Error(`No creator profile found for wallet: ${ctx.input.wallet}`);
+    return {
+      output: {
+        owner: profile.owner,
+        displayName: profile.displayName,
+        isVerified: profile.isVerified,
+        totalMarketsCreated: Number(profile.totalMarketsCreated),
+        marketsResolved: Number(profile.marketsResolved),
+        disputesLost: Number(profile.disputesLost),
+        totalVolumeSol: Number(profile.totalVolumeSol) / LAMPORTS_PER_SOL,
+        totalEarningsSol: Number(profile.totalEarningsSol) / LAMPORTS_PER_SOL,
+        pendingSol: Number(profile.pendingSol) / LAMPORTS_PER_SOL,
+        defaultCreatorFeeBps: profile.defaultCreatorFeeBps,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+// -- Market Lifecycle Entrypoints -------------------------------------------
+
+addEntrypoint({
+  key: 'closeMarket',
+  description: `Close a market after its closing time has passed (permissionless — anyone can call).
+
+This transitions the market from "active" to "closed" and takes a pool snapshot for payout calculations.
+Markets auto-close when the first bet is attempted after closing_time, but this instruction allows explicit closing.`,
+  input: z.object({
+    marketId: solPubkey.describe('Market public key to close'),
+  }),
+  output: z.object({
+    signature: z.string(),
+    explorerUrl: z.string(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const sig = await baozi.closeMarket({ marketPubkey: ctx.input.marketId });
+    return {
+      output: {
+        signature: sig,
+        explorerUrl: `https://solscan.io/tx/${sig}`,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+addEntrypoint({
+  key: 'proposeResolutionHost',
+  description: `Propose resolution for a Lab boolean market you created (HostOracle mode).
+
+As the market creator, you determine the outcome. After proposing, a 6-hour dispute window opens.
+If no disputes are raised, anyone can call finalizeResolution to finalize the outcome.
+
+REQUIREMENTS:
+- You must be the market creator
+- Market must be in "closed" status
+- Only for boolean (Yes/No) markets — use proposeRaceResolution for race markets`,
+  input: z.object({
+    marketId: solPubkey.describe('Closed boolean market public key'),
+    winningOutcome: z.boolean().describe('true = Yes wins, false = No wins'),
+  }),
+  output: z.object({
+    signature: z.string(),
+    explorerUrl: z.string(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const sig = await baozi.proposeResolutionHost({ marketPubkey: ctx.input.marketId, winningOutcome: ctx.input.winningOutcome });
+    return {
+      output: {
+        signature: sig,
+        explorerUrl: `https://solscan.io/tx/${sig}`,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+addEntrypoint({
+  key: 'proposeRaceResolution',
+  description: `Propose resolution for a Lab race market you created.
+
+As the market creator, you determine which outcome won. After proposing, a 6-hour dispute window opens.
+If no disputes are raised, anyone can call finalizeResolution to finalize the outcome.
+
+REQUIREMENTS:
+- You must be the market creator (or authorized resolver)
+- Market must be in "closed" status
+- Only for race markets — use proposeResolutionHost for boolean markets`,
+  input: z.object({
+    marketId: solPubkey.describe('Closed race market public key'),
+    winningOutcome: z.number().min(0).max(9).describe('Index of winning outcome (0-based)'),
+  }),
+  output: z.object({
+    signature: z.string(),
+    explorerUrl: z.string(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const sig = await baozi.proposeRaceResolution({ marketPubkey: ctx.input.marketId, winningOutcome: ctx.input.winningOutcome });
+    return {
+      output: {
+        signature: sig,
+        explorerUrl: `https://solscan.io/tx/${sig}`,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+// -- Reputation Entrypoints -------------------------------------------------
+
+addEntrypoint({
+  key: 'voteCreatorReputation',
+  description: `Vote on a market creator's reputation after participating in their resolved market.
+
+Sybil-resistant: requires a position in the resolved market (you must have bet). One vote per market per creator per user.
+Vote +1 (upvote) for fair markets, -1 (downvote) for unfair resolution or poor quality.`,
+  input: z.object({
+    marketId: solPubkey.describe('Resolved boolean market public key'),
+    vote: z.union([z.literal(1), z.literal(-1)]).describe('+1 for upvote, -1 for downvote'),
+  }),
+  output: z.object({
+    signature: z.string(),
+    explorerUrl: z.string(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const sig = await baozi.voteCreatorReputation({ marketPubkey: ctx.input.marketId, vote: ctx.input.vote as 1 | -1 });
     return {
       output: {
         signature: sig,

--- a/packages/cli/templates/prediction-market-agent/agent.ts.template
+++ b/packages/cli/templates/prediction-market-agent/agent.ts.template
@@ -11,14 +11,20 @@ import {
   LAMPORTS_PER_SOL,
 } from '@solana/web3.js';
 import bs58 from 'bs58';
-import { createHash } from 'crypto';
 
 // ===========================================================================
 // Baozi On-Chain Client — Solana Prediction Markets
 // Program: FWyTPzm5cfJwRKzfkscxozatSxF6Qu78JQovQUwKPruJ
+//
+// Market Layers:
+//   Official (0) — Admin-created only, highest trust, 2.5% fee
+//   Lab      (1) — Community-created, anyone with CreatorProfile, 3% fee
+//   Private  (2) — Invite-only, whitelist access, 2% fee
 // ===========================================================================
 
 const PROGRAM_ID = new PublicKey('FWyTPzm5cfJwRKzfkscxozatSxF6Qu78JQovQUwKPruJ');
+
+// -- Account Discriminators (for getProgramAccounts filters) ----------------
 
 const MARKET_DISC = Buffer.from([219, 190, 213, 55, 0, 227, 198, 154]);
 const RACE_DISC = Buffer.from([235, 196, 111, 75, 230, 113, 118, 238]);
@@ -29,6 +35,14 @@ const MARKET_DISC_B58 = bs58.encode(MARKET_DISC);
 const RACE_DISC_B58 = bs58.encode(RACE_DISC);
 const POS_DISC_B58 = bs58.encode(POS_DISC);
 const RACE_POS_DISC_B58 = bs58.encode(RACE_POS_DISC);
+
+// -- Instruction Discriminators (hardcoded from IDL) ------------------------
+
+const PLACE_BET_DISC = Buffer.from([137, 137, 247, 253, 233, 243, 48, 170]);
+const RACE_BET_DISC = Buffer.from([195, 181, 151, 159, 105, 100, 234, 244]);
+const CREATE_PROFILE_DISC = Buffer.from([139, 244, 127, 145, 95, 172, 140, 154]);
+const CREATE_LAB_MARKET_DISC = Buffer.from([35, 159, 50, 67, 31, 134, 199, 157]);
+const CREATE_RACE_MARKET_DISC = Buffer.from([94, 237, 40, 47, 63, 233, 25, 67]);
 
 const STATUS_NAMES: Record<number, string> = {
   0: 'active', 1: 'closed', 2: 'resolved', 3: 'cancelled',
@@ -43,17 +57,42 @@ class BorshReader {
   constructor(buf: Buffer | Uint8Array) { this.buf = Buffer.from(buf); }
   u8() { const v = this.buf.readUInt8(this.off); this.off += 1; return v; }
   u16() { const v = this.buf.readUInt16LE(this.off); this.off += 2; return v; }
+  u32() { const v = this.buf.readUInt32LE(this.off); this.off += 4; return v; }
   u64() { const v = this.buf.readBigUInt64LE(this.off); this.off += 8; return v; }
   i64() { const v = this.buf.readBigInt64LE(this.off); this.off += 8; return v; }
   bool() { return this.u8() === 1; }
   pubkey() { const b = this.buf.subarray(this.off, this.off + 32); this.off += 32; return bs58.encode(b); }
-  string() { const len = this.buf.readUInt32LE(this.off); this.off += 4; const s = this.buf.subarray(this.off, this.off + len).toString('utf8'); this.off += len; return s; }
+  string() {
+    const len = this.buf.readUInt32LE(this.off); this.off += 4;
+    if (this.off + len > this.buf.length) throw new Error(`BorshReader: string length ${len} exceeds buffer at offset ${this.off}`);
+    const s = this.buf.subarray(this.off, this.off + len).toString('utf8'); this.off += len; return s;
+  }
   optBool(): boolean | null { if (!this.u8()) return null; return this.bool(); }
   optU8(): number | null { if (!this.u8()) return null; return this.u8(); }
   optPubkey(): string | null { if (!this.u8()) return null; return this.pubkey(); }
   bytes(n: number) { const b = Buffer.from(this.buf.subarray(this.off, this.off + n)); this.off += n; return b; }
   optBytes(n: number): Buffer | null { if (!this.u8()) return null; return this.bytes(n); }
   skip(n: number) { this.off += n; }
+}
+
+// -- Borsh Writer -----------------------------------------------------------
+
+class BorshWriter {
+  private parts: Buffer[] = [];
+  u8(v: number) { const b = Buffer.alloc(1); b.writeUInt8(v); this.parts.push(b); return this; }
+  u16(v: number) { const b = Buffer.alloc(2); b.writeUInt16LE(v); this.parts.push(b); return this; }
+  u32(v: number) { const b = Buffer.alloc(4); b.writeUInt32LE(v); this.parts.push(b); return this; }
+  u64(v: bigint) { const b = Buffer.alloc(8); b.writeBigUInt64LE(v); this.parts.push(b); return this; }
+  i64(v: bigint) { const b = Buffer.alloc(8); b.writeBigInt64LE(v); this.parts.push(b); return this; }
+  bool(v: boolean) { return this.u8(v ? 1 : 0); }
+  string(s: string) { const buf = Buffer.from(s, 'utf8'); this.u32(buf.length); this.parts.push(buf); return this; }
+  pubkey(pk: PublicKey) { this.parts.push(Buffer.from(pk.toBytes())); return this; }
+  raw(b: Buffer) { this.parts.push(b); return this; }
+  vecString(arr: string[]) { this.u32(arr.length); for (const s of arr) this.string(s); return this; }
+  vecPubkey(arr: PublicKey[]) { this.u32(arr.length); for (const pk of arr) this.pubkey(pk); return this; }
+  optU8(v: number | null) { if (v === null) { this.u8(0); } else { this.u8(1); this.u8(v); } return this; }
+  optVecPubkey(arr: PublicKey[] | null) { if (arr === null) { this.u8(0); } else { this.u8(1); this.vecPubkey(arr); } return this; }
+  toBuffer() { return Buffer.concat(this.parts); }
 }
 
 // -- Types ------------------------------------------------------------------
@@ -83,6 +122,10 @@ interface Position {
   bets?: { outcome: number; amountSol: number }[];
   totalBetSol: number;
   claimed: boolean;
+}
+
+interface GlobalConfigData {
+  marketCount: bigint;
 }
 
 // -- Parsers ----------------------------------------------------------------
@@ -156,17 +199,49 @@ function parseRacePosition(data: Buffer | Uint8Array) {
   return { user, marketId, bets, totalBet: r.u64(), claimed: r.bool() };
 }
 
+function parseGlobalConfig(data: Buffer | Uint8Array): GlobalConfigData {
+  const r = new BorshReader(data);
+  r.skip(8);  // discriminator
+  r.skip(32); // admin
+  r.skip(32); // treasury
+  r.skip(32); // guardian
+  r.skip(32); // _reserved_usdc_mint
+  r.skip(8);  // _reserved_creation_fee_usdc
+  r.skip(8);  // creation_fee_sol
+  r.skip(8);  // _reserved_market_bond_usdc
+  r.skip(8);  // market_bond_sol
+  r.skip(2);  // platform_fee_bps
+  const marketCount = r.u64();
+  return { marketCount };
+}
+
 // -- PDA Derivation ---------------------------------------------------------
 
-function configPda() { return PublicKey.findProgramAddressSync([Buffer.from('config')], PROGRAM_ID)[0]; }
-function positionPda(mid: bigint, user: PublicKey) { const b = Buffer.alloc(8); b.writeBigUInt64LE(mid); return PublicKey.findProgramAddressSync([Buffer.from('position'), b, user.toBuffer()], PROGRAM_ID)[0]; }
-function racePosPda(mid: bigint, user: PublicKey) { const b = Buffer.alloc(8); b.writeBigUInt64LE(mid); return PublicKey.findProgramAddressSync([Buffer.from('race_position'), b, user.toBuffer()], PROGRAM_ID)[0]; }
-function pointsConfigPda() { return PublicKey.findProgramAddressSync([Buffer.from('points_config')], PROGRAM_ID)[0]; }
-function userPointsPda(user: PublicKey) { return PublicKey.findProgramAddressSync([Buffer.from('user_points'), user.toBuffer()], PROGRAM_ID)[0]; }
-
-function ixDisc(name: string) { return createHash('sha256').update(`global:${name}`).digest().subarray(0, 8); }
-const PLACE_BET_DISC = ixDisc('place_bet_sol');
-const RACE_BET_DISC = ixDisc('bet_on_race_outcome_sol');
+function configPda() {
+  return PublicKey.findProgramAddressSync([Buffer.from('config')], PROGRAM_ID)[0];
+}
+function positionPda(mid: bigint, user: PublicKey) {
+  const b = Buffer.alloc(8); b.writeBigUInt64LE(mid);
+  return PublicKey.findProgramAddressSync([Buffer.from('position'), b, user.toBuffer()], PROGRAM_ID)[0];
+}
+function racePosPda(mid: bigint, user: PublicKey) {
+  const b = Buffer.alloc(8); b.writeBigUInt64LE(mid);
+  return PublicKey.findProgramAddressSync([Buffer.from('race_position'), b, user.toBuffer()], PROGRAM_ID)[0];
+}
+function treasuryPda() {
+  return PublicKey.findProgramAddressSync([Buffer.from('sol_treasury')], PROGRAM_ID)[0];
+}
+function creatorProfilePda(owner: PublicKey) {
+  return PublicKey.findProgramAddressSync([Buffer.from('creator_profile'), owner.toBuffer()], PROGRAM_ID)[0];
+}
+function marketPda(id: bigint) {
+  const b = Buffer.alloc(8); b.writeBigUInt64LE(id);
+  return PublicKey.findProgramAddressSync([Buffer.from('market'), b], PROGRAM_ID)[0];
+}
+function raceMarketPda(id: bigint) {
+  const b = Buffer.alloc(8); b.writeBigUInt64LE(id);
+  return PublicKey.findProgramAddressSync([Buffer.from('race'), b], PROGRAM_ID)[0];
+}
 
 // -- Helpers ----------------------------------------------------------------
 
@@ -195,7 +270,8 @@ function raceToMarket(raw: ReturnType<typeof parseRaceMarket>, pk: string): Mark
   for (let i = 0; i < raw.outcomeCount; i++) {
     const pool = raw.outcomePools[i];
     const other = raw.totalPool - pool;
-    const price = raw.totalPool > 0n ? Number(other) / (Number(raw.totalPool) * (raw.outcomeCount - 1)) : 1 / raw.outcomeCount;
+    const divisor = raw.outcomeCount > 1 ? raw.outcomeCount - 1 : 1;
+    const price = raw.totalPool > 0n ? Number(other) / (Number(raw.totalPool) * divisor) : 1 / raw.outcomeCount;
     outcomes.push({ label: raw.outcomeLabels[i] || `Outcome ${i + 1}`, probability: Math.min(Math.max(price, 0), 1), poolSol: Number(pool) / LAMPORTS_PER_SOL });
   }
   const sum = outcomes.reduce((a, o) => a + o.probability, 0);
@@ -208,6 +284,55 @@ function raceToMarket(raw: ReturnType<typeof parseRaceMarket>, pk: string): Mark
   };
 }
 
+// -- Parimutuel Rules v6.3 — Market Creation Guardrails --------------------
+
+const BLOCKED_SUBJECTIVE = [
+  'ai agent', 'an agent', 'autonomously', 'become popular', 'go viral',
+  'be successful', 'perform well', 'be the best', 'breakthrough',
+  'revolutionary', 'will i ', 'will we ', 'will my ', 'will our ',
+];
+const BLOCKED_MANIPULATION = [
+  'will someone', 'will anyone', 'will a person', 'will a user',
+  'purchase proxies', 'buy proxies', 'x402 payment', 'using credits',
+];
+const IMPLIED_SOURCES = [
+  /\b(btc|eth|sol|bitcoin|ethereum|solana|coingecko|coinmarketcap|binance|coinbase|tradingview)\b/i,
+  /\b(ufc|nba|nfl|mlb|nhl|champions league|world cup|super bowl|espn|uefa|fifa|atp|wta)\b/i,
+  /\b(tokyo|london|new york|los angeles|paris|snow|rain|temperature|nws|jma|weather)\b/i,
+  /\b(election|president|congress|parliament|vote|ap news|reuters|sec|nasdaq|nyse)\b/i,
+  /source:/i, /official/i,
+];
+
+function validateParimutuelRules(question: string): { valid: boolean; errors: string[]; warnings: string[] } {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const q = question.toLowerCase();
+
+  // Check subjective/unverifiable outcomes
+  const subjective = BLOCKED_SUBJECTIVE.filter(p => q.includes(p));
+  if (subjective.length > 0)
+    errors.push(`BLOCKED: Unverifiable/subjective terms detected: "${subjective.join('", "')}". Markets must have outcomes verifiable by third party using public records.`);
+
+  // Check manipulation risk
+  const manipulation = BLOCKED_MANIPULATION.filter(p => q.includes(p));
+  if (manipulation.length > 0)
+    errors.push(`BLOCKED: Manipulation risk — terms: "${manipulation.join('", "')}". Creators cannot make markets about outcomes they can directly influence.`);
+
+  // Check for implied/explicit data source
+  const hasSource = IMPLIED_SOURCES.some(r => r.test(question));
+  if (!hasSource)
+    errors.push('BLOCKED: No verifiable data source. Include a source like "(Source: CoinGecko)" or reference a known category (sports league, crypto asset, weather location). Approved: CoinGecko, ESPN, NWS, Reuters, SEC, etc.');
+
+  // Check clear criteria
+  const hasCriteria = /\$[\d,]+/.test(question) || /\d+%/.test(question) ||
+    /above|below|over|under|at least|more than|less than/i.test(question) ||
+    /will .+ (win|lose|defeat|advance|qualify|score|achieve|snow|rain|happen|launch|release|announce)/i.test(question);
+  if (!hasCriteria)
+    warnings.push('Recommended: Include clear numeric threshold or binary outcome (e.g. "above $X", "will Team A win").');
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
 // -- Cache ------------------------------------------------------------------
 
 class Cache<T> {
@@ -216,18 +341,22 @@ class Cache<T> {
   constructor(private ttl: number) {}
   get(): T | null { return this.data && Date.now() - this.ts < this.ttl ? this.data : null; }
   set(v: T) { this.data = v; this.ts = Date.now(); }
+  clear() { this.data = null; this.ts = 0; }
 }
 
 // -- Filter -----------------------------------------------------------------
 
-function applyFilters(markets: Market[], f?: { status?: string; query?: string; limit?: number }) {
+function applyFilters(markets: Market[], f?: { status?: string; query?: string; limit?: number; layer?: string }) {
   let r = [...markets];
   const status = f?.status || 'active';
   if (status !== 'all') {
-    const now = new Date().toISOString();
+    const nowMs = Date.now();
     r = status === 'active'
-      ? r.filter(m => m.closingTime > now && m.status === 'active')
-      : r.filter(m => m.closingTime <= now || m.status !== 'active');
+      ? r.filter(m => new Date(m.closingTime).getTime() > nowMs && m.status === 'active')
+      : r.filter(m => new Date(m.closingTime).getTime() <= nowMs || m.status !== 'active');
+  }
+  if (f?.layer && f.layer !== 'all') {
+    r = r.filter(m => m.layer === f.layer);
   }
   if (f?.query) { const q = f.query.toLowerCase(); r = r.filter(m => m.question.toLowerCase().includes(q)); }
   r.sort((a, b) => b.totalPoolSol - a.totalPoolSol);
@@ -243,11 +372,31 @@ class BaoziClient {
   private wallet?: Keypair;
 
   constructor(opts: { rpcUrl: string; privateKey?: string }) {
-    this.conn = new Connection(opts.rpcUrl, 'confirmed');
-    if (opts.privateKey) this.wallet = Keypair.fromSecretKey(bs58.decode(opts.privateKey));
+    this.conn = new Connection(opts.rpcUrl, {
+      commitment: 'confirmed',
+      confirmTransactionInitialTimeout: 30_000,
+    });
+    if (opts.privateKey) {
+      try { this.wallet = Keypair.fromSecretKey(bs58.decode(opts.privateKey)); }
+      catch { throw new Error('Invalid SOLANA_PRIVATE_KEY — must be a base58-encoded 64-byte secret key'); }
+    }
   }
 
-  async fetchMarkets(filter?: { status?: string; query?: string; limit?: number }): Promise<Market[]> {
+  private async sendTx(ix: TransactionInstruction): Promise<string> {
+    if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY to enable transactions.');
+    const { blockhash, lastValidBlockHeight } = await this.conn.getLatestBlockhash();
+    const tx = new Transaction().add(ix);
+    tx.feePayer = this.wallet.publicKey;
+    tx.recentBlockhash = blockhash;
+    tx.sign(this.wallet);
+    const sig = await this.conn.sendRawTransaction(tx.serialize());
+    await this.conn.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight }, 'confirmed');
+    return sig;
+  }
+
+  invalidateCache() { this.cache.clear(); }
+
+  async fetchMarkets(filter?: { status?: string; query?: string; limit?: number; layer?: string }): Promise<Market[]> {
     const cached = this.cache.get();
     if (cached && !filter?.query) return applyFilters(cached, filter);
 
@@ -257,14 +406,23 @@ class BaoziClient {
     ]);
 
     const markets: Market[] = [];
-    for (const a of ba) { try { markets.push(boolToMarket(parseMarket(a.account.data), a.pubkey.toString())); } catch {} }
-    for (const a of ra) { try { markets.push(raceToMarket(parseRaceMarket(a.account.data), a.pubkey.toString())); } catch {} }
+    for (const a of ba) {
+      try { markets.push(boolToMarket(parseMarket(a.account.data), a.pubkey.toString())); }
+      catch (e) { console.warn(`Failed to parse boolean market ${a.pubkey}:`, e); }
+    }
+    for (const a of ra) {
+      try { markets.push(raceToMarket(parseRaceMarket(a.account.data), a.pubkey.toString())); }
+      catch (e) { console.warn(`Failed to parse race market ${a.pubkey}:`, e); }
+    }
 
     this.cache.set(markets);
     return applyFilters(markets, filter);
   }
 
   async fetchMarket(pubkey: string): Promise<Market | null> {
+    const cached = this.cache.get();
+    if (cached) { const found = cached.find(m => m.id === pubkey); if (found) return found; }
+
     const info = await this.conn.getAccountInfo(new PublicKey(pubkey));
     if (!info) return null;
     const d = Buffer.from(info.data.subarray(0, 8));
@@ -284,13 +442,13 @@ class BaoziClient {
       try {
         const p = parseUserPosition(a.account.data);
         positions.push({ pubkey: a.pubkey.toString(), marketId: p.marketId.toString(), user: p.user, type: 'boolean', yesAmountSol: Number(p.yesAmount) / LAMPORTS_PER_SOL, noAmountSol: Number(p.noAmount) / LAMPORTS_PER_SOL, totalBetSol: Number(p.yesAmount + p.noAmount) / LAMPORTS_PER_SOL, claimed: p.claimed });
-      } catch {}
+      } catch (e) { console.warn(`Failed to parse boolean position ${a.pubkey}:`, e); }
     }
     for (const a of ra) {
       try {
         const p = parseRacePosition(a.account.data);
         positions.push({ pubkey: a.pubkey.toString(), marketId: p.marketId.toString(), user: p.user, type: 'race', bets: p.bets.map((b, i) => ({ outcome: i, amountSol: Number(b) / LAMPORTS_PER_SOL })), totalBetSol: Number(p.totalBet) / LAMPORTS_PER_SOL, claimed: p.claimed });
-      } catch {}
+      } catch (e) { console.warn(`Failed to parse race position ${a.pubkey}:`, e); }
     }
     return positions;
   }
@@ -300,27 +458,31 @@ class BaoziClient {
     const market = await this.fetchMarket(params.marketPubkey);
     if (!market) throw new Error(`Market not found: ${params.marketPubkey}`);
 
+    if (market.status !== 'active') throw new Error(`Market is ${market.status}, not active — cannot place bet`);
+    if (new Date(market.closingTime).getTime() <= Date.now()) throw new Error('Market has passed its closing time — cannot place bet');
+
+    if (market.type === 'boolean' && (params.outcome < 0 || params.outcome > 1))
+      throw new Error(`Boolean markets accept outcome 0 (Yes) or 1 (No), got ${params.outcome}`);
+    if (market.type === 'race' && (params.outcome < 0 || params.outcome >= market.outcomes.length))
+      throw new Error(`Race market has ${market.outcomes.length} outcomes (0-${market.outcomes.length - 1}), got index ${params.outcome}`);
+
     const amt = BigInt(Math.round(params.amountSol * LAMPORTS_PER_SOL));
     const mPk = new PublicKey(params.marketPubkey);
     const rawId = BigInt(market.rawMarketId);
     const cfg = configPda();
-    const ptsCfg = pointsConfigPda();
-    const uPts = userPointsPda(this.wallet.publicKey);
 
     let ix: TransactionInstruction;
     if (market.type === 'boolean') {
       const pos = positionPda(rawId, this.wallet.publicKey);
       const data = Buffer.alloc(17);
       PLACE_BET_DISC.copy(data, 0);
-      data.writeUInt8(params.outcome === 0 ? 1 : 0, 8);
+      data.writeUInt8(params.outcome === 0 ? 1 : 0, 8); // IDL: bool outcome (true=Yes, false=No)
       data.writeBigUInt64LE(amt, 9);
       ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
         { pubkey: cfg, isSigner: false, isWritable: false },
         { pubkey: mPk, isSigner: false, isWritable: true },
         { pubkey: pos, isSigner: false, isWritable: true },
-        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },
-        { pubkey: ptsCfg, isSigner: false, isWritable: false },
-        { pubkey: uPts, isSigner: false, isWritable: true },
+        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false }, // whitelist: None (optional)
         { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
         { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
       ], data });
@@ -328,40 +490,117 @@ class BaoziClient {
       const pos = racePosPda(rawId, this.wallet.publicKey);
       const data = Buffer.alloc(17);
       RACE_BET_DISC.copy(data, 0);
-      data.writeUInt8(params.outcome, 8);
+      data.writeUInt8(params.outcome, 8); // IDL: u8 outcome_index
       data.writeBigUInt64LE(amt, 9);
       ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
         { pubkey: cfg, isSigner: false, isWritable: false },
         { pubkey: mPk, isSigner: false, isWritable: true },
         { pubkey: pos, isSigner: false, isWritable: true },
-        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },
-        { pubkey: ptsCfg, isSigner: false, isWritable: false },
-        { pubkey: uPts, isSigner: false, isWritable: true },
+        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false }, // whitelist: None (optional)
         { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
         { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
       ], data });
     }
 
-    const tx = new Transaction().add(ix);
-    tx.feePayer = this.wallet.publicKey;
-    tx.recentBlockhash = (await this.conn.getLatestBlockhash()).blockhash;
-    tx.sign(this.wallet);
-    const sig = await this.conn.sendRawTransaction(tx.serialize());
-    await this.conn.confirmTransaction(sig, 'confirmed');
+    const sig = await this.sendTx(ix);
+    this.invalidateCache();
     return sig;
+  }
+
+  async fetchGlobalConfig(): Promise<GlobalConfigData> {
+    const info = await this.conn.getAccountInfo(configPda());
+    if (!info) throw new Error('GlobalConfig not found — program may not be initialized');
+    return parseGlobalConfig(info.data);
+  }
+
+  async createCreatorProfile(params: { displayName: string; defaultFeeBps: number }): Promise<{ signature: string; profileAddress: string }> {
+    if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY.');
+    const profilePda = creatorProfilePda(this.wallet.publicKey);
+    const w = new BorshWriter();
+    w.raw(CREATE_PROFILE_DISC);
+    w.string(params.displayName);
+    w.u16(params.defaultFeeBps);
+    const ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+      { pubkey: profilePda, isSigner: false, isWritable: true },
+      { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ], data: w.toBuffer() });
+    const sig = await this.sendTx(ix);
+    return { signature: sig, profileAddress: profilePda.toString() };
+  }
+
+  async createLabMarket(params: { question: string; closingTime: number }): Promise<{ signature: string; marketAddress: string; marketId: number }> {
+    if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY.');
+    const config = await this.fetchGlobalConfig();
+    const mPda = marketPda(config.marketCount);
+    const w = new BorshWriter();
+    w.raw(CREATE_LAB_MARKET_DISC);
+    w.string(params.question);
+    w.i64(BigInt(params.closingTime));
+    w.i64(86400n);  // resolution_buffer: 24 hours
+    w.i64(0n);      // auto_stop_buffer: none
+    w.u8(1);        // resolution_mode: 1 = HostOracle
+    w.vecPubkey([]); // council: empty
+    w.u8(0);        // council_threshold: 0
+    // IDL account order: config, market, treasury, creator, creator_profile (optional), system_program
+    const ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+      { pubkey: configPda(), isSigner: false, isWritable: true },
+      { pubkey: mPda, isSigner: false, isWritable: true },
+      { pubkey: treasuryPda(), isSigner: false, isWritable: true },
+      { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
+      { pubkey: creatorProfilePda(this.wallet.publicKey), isSigner: false, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ], data: w.toBuffer() });
+    const sig = await this.sendTx(ix);
+    this.invalidateCache();
+    return { signature: sig, marketAddress: mPda.toString(), marketId: Number(config.marketCount) };
+  }
+
+  async createLabRaceMarket(params: { question: string; closingTime: number; outcomes: string[] }): Promise<{ signature: string; marketAddress: string; marketId: number }> {
+    if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY.');
+    const config = await this.fetchGlobalConfig();
+    const rmPda = raceMarketPda(config.marketCount);
+    const w = new BorshWriter();
+    w.raw(CREATE_RACE_MARKET_DISC);
+    w.string(params.question);
+    w.vecString(params.outcomes);
+    w.i64(BigInt(params.closingTime));
+    w.i64(86400n);  // resolution_buffer: 24 hours
+    w.i64(0n);      // auto_stop_buffer: none
+    w.u8(1);        // layer: 1 = Lab
+    w.u8(1);        // resolution_mode: 1 = HostOracle
+    w.u8(0);        // access_gate: 0 = Open
+    w.optVecPubkey(null); // council: None
+    w.optU8(null);        // council_threshold: None
+    // IDL account order: config, race_market, creator_profile (optional), treasury, creator, system_program
+    const ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+      { pubkey: configPda(), isSigner: false, isWritable: true },
+      { pubkey: rmPda, isSigner: false, isWritable: true },
+      { pubkey: creatorProfilePda(this.wallet.publicKey), isSigner: false, isWritable: false },
+      { pubkey: treasuryPda(), isSigner: false, isWritable: true },
+      { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ], data: w.toBuffer() });
+    const sig = await this.sendTx(ix);
+    this.invalidateCache();
+    return { signature: sig, marketAddress: rmPda.toString(), marketId: Number(config.marketCount) };
   }
 }
 
 {{TEMPLATE_PRE_SETUP}}
+const rpcUrl = process.env.SOLANA_RPC_URL || 'https://api.mainnet-beta.solana.com';
+if (rpcUrl.includes('api.mainnet-beta.solana.com') || rpcUrl.includes('api.devnet.solana.com')) {
+  console.warn('Warning: Using public Solana RPC — expect rate limits. Set SOLANA_RPC_URL to a dedicated provider (Helius, QuickNode) for production.');
+}
 const baozi = new BaoziClient({
-  rpcUrl: process.env.SOLANA_RPC_URL || 'https://api.mainnet-beta.solana.com',
+  rpcUrl,
   privateKey: process.env.SOLANA_PRIVATE_KEY,
 });
 
 const agent = await createAgent({
   name: process.env.AGENT_NAME ?? "prediction-market-agent",
   version: process.env.AGENT_VERSION ?? "0.1.0",
-  description: process.env.AGENT_DESCRIPTION ?? "Prediction market data and trading agent",
+  description: process.env.AGENT_DESCRIPTION ?? "Prediction market data and trading agent for Baozi on Solana",
 })
   .use(http())
   .build();
@@ -371,13 +610,20 @@ const agent = await createAgent({
 /**
  * Prediction Market Agent — Baozi on Solana
  *
- * Entrypoints:
- *   getMarkets      — List active prediction markets with current odds
- *   getMarketOdds   — Probabilities and pool sizes for one market
- *   getPortfolio    — Active positions for a wallet
- *   placeBet        — Place a bet (requires SOLANA_PRIVATE_KEY)
- *   analyzeMarket   — Statistical market summary
+ * Read entrypoints:
+ *   getMarkets         — List markets with filters (status, layer, query)
+ *   getMarketOdds      — Probabilities and pool sizes for one market
+ *   getPortfolio       — Active positions for a wallet
+ *   analyzeMarket      — Statistical market summary
+ *
+ * Write entrypoints:
+ *   placeBet              — Place a bet (requires SOLANA_PRIVATE_KEY)
+ *   createCreatorProfile  — Create on-chain creator profile (required for Labs)
+ *   createLabMarket       — Create a Yes/No Lab market
+ *   createLabRaceMarket   — Create a multi-outcome Lab race market
  */
+
+const solPubkey = z.string().refine(s => { try { new PublicKey(s); return true; } catch { return false; } }, 'Invalid Solana public key');
 
 const marketSchema = z.object({
   id: z.string(),
@@ -397,9 +643,10 @@ const marketSchema = z.object({
 
 addEntrypoint({
   key: 'getMarkets',
-  description: 'Fetch active prediction markets from Solana with current odds',
+  description: 'Fetch prediction markets from Solana with current odds. Filter by status, layer, or search query.',
   input: z.object({
-    status: z.enum(['active', 'closed', 'all']).optional().describe('Filter by market status'),
+    status: z.enum(['active', 'closed', 'all']).optional().describe('Filter by market status (default: active)'),
+    layer: z.enum(['official', 'lab', 'private', 'all']).optional().describe('Filter by layer: official (admin), lab (community), private (invite-only)'),
     query: z.string().optional().describe('Search market titles'),
     limit: z.number().optional().describe('Max results to return'),
   }),
@@ -421,7 +668,7 @@ addEntrypoint({
   key: 'getMarketOdds',
   description: 'Get current odds (implied probabilities) and pool sizes for a specific market',
   input: z.object({
-    marketId: z.string().describe('Market public key (base58)'),
+    marketId: solPubkey.describe('Market public key (base58)'),
   }),
   output: z.object({
     marketId: z.string(),
@@ -453,7 +700,7 @@ addEntrypoint({
   key: 'getPortfolio',
   description: 'View active prediction market positions for a wallet',
   input: z.object({
-    wallet: z.string().describe('Solana wallet address (base58)'),
+    wallet: solPubkey.describe('Solana wallet address (base58)'),
   }),
   output: z.object({
     positions: z.array(z.object({
@@ -484,9 +731,9 @@ addEntrypoint({
 
 addEntrypoint({
   key: 'placeBet',
-  description: 'Place a bet on a prediction market outcome (requires SOLANA_PRIVATE_KEY)',
+  description: 'Place a bet on a prediction market outcome (requires SOLANA_PRIVATE_KEY). Works on Official, Lab, and Private markets.',
   input: z.object({
-    marketId: z.string().describe('Market public key (base58)'),
+    marketId: solPubkey.describe('Market public key (base58)'),
     outcome: z.number().describe('Outcome index (0=Yes/first, 1=No/second, etc.)'),
     amountSol: z.number().min(0.01).max(100).describe('Bet amount in SOL'),
   }),
@@ -518,7 +765,7 @@ addEntrypoint({
   key: 'analyzeMarket',
   description: 'Get a statistical summary and analysis of a prediction market',
   input: z.object({
-    marketId: z.string().describe('Market public key (base58)'),
+    marketId: solPubkey.describe('Market public key (base58)'),
   }),
   output: z.object({
     marketId: z.string(),
@@ -550,7 +797,7 @@ addEntrypoint({
       `Total pool: ${market.totalPoolSol.toFixed(2)} SOL`,
       `${market.outcomes.length} outcomes — favorite is "${fav.label}" at ${(fav.probability * 100).toFixed(1)}%`,
       `Status: ${market.status}, closes ${market.closingTime}`,
-      `Market type: ${market.type} (pari-mutuel pricing)`,
+      `Layer: ${market.layer}. Market type: ${market.type} (pari-mutuel pricing)`,
     ].join('. ');
 
     return {
@@ -562,6 +809,103 @@ addEntrypoint({
         totalPoolSol: market.totalPoolSol,
         status: market.status,
         closingTime: market.closingTime,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+addEntrypoint({
+  key: 'createCreatorProfile',
+  description: 'Create an on-chain creator profile (required before creating Lab or Private markets). Each wallet can have one profile.',
+  input: z.object({
+    displayName: z.string().min(1).max(32).describe('Display name shown on your markets'),
+    defaultFeeBps: z.number().min(0).max(500).optional().default(50).describe('Default creator fee in basis points (50 = 0.5%)'),
+  }),
+  output: z.object({
+    signature: z.string(),
+    profileAddress: z.string(),
+    explorerUrl: z.string(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const { displayName, defaultFeeBps } = ctx.input;
+    const result = await baozi.createCreatorProfile({ displayName, defaultFeeBps });
+    return {
+      output: {
+        ...result,
+        explorerUrl: `https://solscan.io/tx/${result.signature}`,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+addEntrypoint({
+  key: 'createLabMarket',
+  description: 'Create a boolean (Yes/No) Lab prediction market. Requires a CreatorProfile (call createCreatorProfile first). Lab markets use HostOracle resolution and charge 3% platform fee.',
+  input: z.object({
+    question: z.string().min(10).max(200).describe('The prediction question (e.g. "Will BTC hit $200k by March 2026?")'),
+    closingTime: z.string().describe('ISO 8601 closing time (e.g. "2026-03-01T00:00:00Z")'),
+  }),
+  output: z.object({
+    signature: z.string(),
+    marketAddress: z.string(),
+    marketId: z.number(),
+    explorerUrl: z.string(),
+    marketUrl: z.string(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    // Parimutuel v6.3 guardrails — validate before on-chain submission
+    const validation = validateParimutuelRules(ctx.input.question);
+    if (!validation.valid) throw new Error(`Market creation blocked by Parimutuel Rules v6.3:\n${validation.errors.join('\n')}`);
+    if (validation.warnings.length > 0) console.warn(`Parimutuel warnings: ${validation.warnings.join('; ')}`);
+
+    const closingTimestamp = Math.floor(new Date(ctx.input.closingTime).getTime() / 1000);
+    if (closingTimestamp <= Math.floor(Date.now() / 1000)) throw new Error('Closing time must be in the future');
+    const result = await baozi.createLabMarket({ question: ctx.input.question, closingTime: closingTimestamp });
+    return {
+      output: {
+        ...result,
+        explorerUrl: `https://solscan.io/tx/${result.signature}`,
+        marketUrl: `https://baozi.bet/market/${result.marketAddress}`,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+addEntrypoint({
+  key: 'createLabRaceMarket',
+  description: 'Create a multi-outcome Lab race market (2-10 outcomes). Requires a CreatorProfile. Lab markets use HostOracle resolution and charge 3% platform fee.',
+  input: z.object({
+    question: z.string().min(10).max(200).describe('The prediction question'),
+    closingTime: z.string().describe('ISO 8601 closing time'),
+    outcomes: z.array(z.string().max(32)).min(2).max(10).describe('Outcome labels (e.g. ["Trump", "DeSantis", "Newsom"])'),
+  }),
+  output: z.object({
+    signature: z.string(),
+    marketAddress: z.string(),
+    marketId: z.number(),
+    explorerUrl: z.string(),
+    marketUrl: z.string(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    // Parimutuel v6.3 guardrails — validate before on-chain submission
+    const validation = validateParimutuelRules(ctx.input.question);
+    if (!validation.valid) throw new Error(`Market creation blocked by Parimutuel Rules v6.3:\n${validation.errors.join('\n')}`);
+    if (validation.warnings.length > 0) console.warn(`Parimutuel warnings: ${validation.warnings.join('; ')}`);
+
+    const closingTimestamp = Math.floor(new Date(ctx.input.closingTime).getTime() / 1000);
+    if (closingTimestamp <= Math.floor(Date.now() / 1000)) throw new Error('Closing time must be in the future');
+    const result = await baozi.createLabRaceMarket({ question: ctx.input.question, closingTime: closingTimestamp, outcomes: ctx.input.outcomes });
+    return {
+      output: {
+        ...result,
+        explorerUrl: `https://solscan.io/tx/${result.signature}`,
+        marketUrl: `https://baozi.bet/market/${result.marketAddress}`,
       },
       usage: { total_tokens: 0 },
     };

--- a/packages/cli/templates/prediction-market-agent/agent.ts.template
+++ b/packages/cli/templates/prediction-market-agent/agent.ts.template
@@ -568,7 +568,7 @@ class BaoziClient {
 
   async fetchMarkets(filter?: { status?: string; query?: string; limit?: number; layer?: string }): Promise<Market[]> {
     const cached = this.cache.get();
-    if (cached && !filter?.query) return applyFilters(cached, filter);
+    if (cached) return applyFilters(cached, filter);
 
     const [ba, ra] = await Promise.all([
       this.conn.getProgramAccounts(PROGRAM_ID, { filters: [{ memcmp: { offset: 0, bytes: MARKET_DISC_B58 } }] }),
@@ -1046,6 +1046,12 @@ class BaoziClient {
       throw new Error(`Market is already ${market.status} — cannot close`);
     if (market.status === 'closed')
       throw new Error('Market is already closed');
+    if (market.status === 'resolved_pending')
+      throw new Error('Market has a pending resolution — cannot close after oracle has proposed outcome');
+    if (market.status === 'disputed')
+      throw new Error('Market is under dispute — cannot close while dispute is active');
+    if (market.status === 'paused')
+      throw new Error('Market is paused — cannot close a paused market');
 
     const mPk = new PublicKey(params.marketPubkey);
     let ix: TransactionInstruction;

--- a/packages/cli/templates/prediction-market-agent/agent.ts.template
+++ b/packages/cli/templates/prediction-market-agent/agent.ts.template
@@ -47,6 +47,10 @@ const CANCEL_MARKET_DISC = Buffer.from([205, 121, 84, 210, 222, 71, 150, 11]);
 const CANCEL_RACE_DISC = Buffer.from([223, 214, 232, 232, 43, 15, 165, 234]);
 const CLAIM_REFUND_DISC = Buffer.from([8, 82, 5, 144, 194, 114, 255, 20]);
 const CLAIM_RACE_REFUND_DISC = Buffer.from([174, 101, 101, 227, 171, 69, 173, 243]);
+const CLAIM_WINNINGS_DISC = Buffer.from([64, 158, 207, 116, 128, 129, 169, 76]);
+const CLAIM_RACE_WINNINGS_DISC = Buffer.from([46, 120, 202, 194, 126, 72, 22, 52]);
+const FINALIZE_RESOLUTION_DISC = Buffer.from([191, 74, 94, 214, 45, 150, 152, 125]);
+const FINALIZE_RACE_RESOLUTION_DISC = Buffer.from([19, 232, 81, 138, 191, 218, 54, 200]);
 
 const STATUS_NAMES: Record<number, string> = {
   0: 'active', 1: 'closed', 2: 'resolved', 3: 'cancelled',
@@ -245,6 +249,12 @@ function marketPda(id: bigint) {
 function raceMarketPda(id: bigint) {
   const b = Buffer.alloc(8); b.writeBigUInt64LE(id);
   return PublicKey.findProgramAddressSync([Buffer.from('race'), b], PROGRAM_ID)[0];
+}
+function revenueConfigPda() {
+  return PublicKey.findProgramAddressSync([Buffer.from('revenue_config')], PROGRAM_ID)[0];
+}
+function disputeMetaPda(marketPubkey: PublicKey) {
+  return PublicKey.findProgramAddressSync([Buffer.from('dispute_meta'), marketPubkey.toBuffer()], PROGRAM_ID)[0];
 }
 
 // -- Helpers ----------------------------------------------------------------
@@ -739,6 +749,82 @@ class BaoziClient {
     this.invalidateCache();
     return sig;
   }
+
+  async claimWinnings(params: { marketPubkey: string }): Promise<string> {
+    if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY.');
+    const market = await this.fetchMarket(params.marketPubkey);
+    if (!market) throw new Error(`Market not found: ${params.marketPubkey}`);
+    if (market.status !== 'resolved') throw new Error(`Market status is "${market.status}" — winnings can only be claimed from resolved markets`);
+
+    const mPk = new PublicKey(params.marketPubkey);
+    const rawId = BigInt(market.rawMarketId);
+    let ix: TransactionInstruction;
+
+    if (market.type === 'boolean') {
+      // claim_winnings_sol: 10 accounts (4 optional — pass PROGRAM_ID for None)
+      const pos = positionPda(rawId, this.wallet.publicKey);
+      ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+        { pubkey: configPda(), isSigner: false, isWritable: false },
+        { pubkey: mPk, isSigner: false, isWritable: true },
+        { pubkey: pos, isSigner: false, isWritable: true },
+        { pubkey: treasuryPda(), isSigner: false, isWritable: true },
+        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },  // affiliate: None
+        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },  // creator_profile: None
+        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },  // revenue_config: None
+        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },  // staking_vault: None
+        { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+      ], data: CLAIM_WINNINGS_DISC });
+    } else {
+      // claim_race_winnings_sol: 11 accounts (5 optional — pass PROGRAM_ID for None)
+      const pos = racePosPda(rawId, this.wallet.publicKey);
+      ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+        { pubkey: configPda(), isSigner: false, isWritable: false },
+        { pubkey: mPk, isSigner: false, isWritable: true },
+        { pubkey: pos, isSigner: false, isWritable: true },
+        { pubkey: treasuryPda(), isSigner: false, isWritable: true },
+        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },  // affiliate: None
+        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },  // race_referral: None
+        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },  // creator_profile: None
+        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },  // revenue_config: None
+        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },  // staking_vault: None
+        { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+      ], data: CLAIM_RACE_WINNINGS_DISC });
+    }
+
+    const sig = await this.sendTx(ix);
+    this.invalidateCache();
+    return sig;
+  }
+
+  async finalizeResolution(params: { marketPubkey: string }): Promise<string> {
+    if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY.');
+    const market = await this.fetchMarket(params.marketPubkey);
+    if (!market) throw new Error(`Market not found: ${params.marketPubkey}`);
+
+    const mPk = new PublicKey(params.marketPubkey);
+    const dMeta = disputeMetaPda(mPk);
+    let ix: TransactionInstruction;
+
+    if (market.type === 'boolean') {
+      ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+        { pubkey: mPk, isSigner: false, isWritable: true },
+        { pubkey: dMeta, isSigner: false, isWritable: true },
+        { pubkey: this.wallet.publicKey, isSigner: true, isWritable: false },
+      ], data: FINALIZE_RESOLUTION_DISC });
+    } else {
+      ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+        { pubkey: mPk, isSigner: false, isWritable: true },
+        { pubkey: dMeta, isSigner: false, isWritable: true },
+        { pubkey: this.wallet.publicKey, isSigner: true, isWritable: false },
+      ], data: FINALIZE_RACE_RESOLUTION_DISC });
+    }
+
+    const sig = await this.sendTx(ix);
+    this.invalidateCache();
+    return sig;
+  }
 }
 
 {{TEMPLATE_PRE_SETUP}}
@@ -777,6 +863,8 @@ const agent = await createAgent({
  *   createLabRaceMarket   — Create a multi-outcome Lab race market
  *   cancelLabMarket       — Cancel a Lab market you created (full refund to bettors)
  *   claimRefund           — Claim refund from a cancelled market
+ *   claimWinnings         — Claim SOL winnings from a resolved market
+ *   finalizeResolution    — Finalize resolution after dispute window (permissionless)
  */
 
 const solPubkey = z.string().refine(s => { try { new PublicKey(s); return true; } catch { return false; } }, 'Invalid Solana public key');
@@ -1152,6 +1240,61 @@ Requires the market to be in "cancelled" status. Each wallet can only claim once
   price: process.env.DEFAULT_PRICE || undefined,
   handler: async (ctx) => {
     const sig = await baozi.claimRefund({ marketPubkey: ctx.input.marketId });
+    return {
+      output: {
+        signature: sig,
+        explorerUrl: `https://solscan.io/tx/${sig}`,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+addEntrypoint({
+  key: 'claimWinnings',
+  description: `Claim SOL winnings from a resolved prediction market. Works for both boolean and race markets.
+
+The market must be in "resolved" status. Your payout is calculated from the pari-mutuel pool:
+  payout = (your_bet / winning_pool) * total_pool — platform_fee
+
+Each wallet can only claim once per market. Race market claims pay out based on total_bet on the winning outcome.`,
+  input: z.object({
+    marketId: solPubkey.describe('Resolved market public key'),
+  }),
+  output: z.object({
+    signature: z.string(),
+    explorerUrl: z.string(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const sig = await baozi.claimWinnings({ marketPubkey: ctx.input.marketId });
+    return {
+      output: {
+        signature: sig,
+        explorerUrl: `https://solscan.io/tx/${sig}`,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+addEntrypoint({
+  key: 'finalizeResolution',
+  description: `Finalize a market resolution after the 6-hour dispute window has passed. This is permissionless — anyone can call it.
+
+After an oracle proposes a resolution, there's a 6-hour window where anyone can raise a dispute. Once that window closes, this instruction finalizes the outcome and moves the market to "resolved" status, enabling winners to claim.
+
+Works for both boolean and race markets.`,
+  input: z.object({
+    marketId: solPubkey.describe('Market public key with pending resolution'),
+  }),
+  output: z.object({
+    signature: z.string(),
+    explorerUrl: z.string(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const sig = await baozi.finalizeResolution({ marketPubkey: ctx.input.marketId });
     return {
       output: {
         signature: sig,

--- a/packages/cli/templates/prediction-market-agent/agent.ts.template
+++ b/packages/cli/templates/prediction-market-agent/agent.ts.template
@@ -265,7 +265,7 @@ function boolToMarket(raw: ReturnType<typeof parseMarket>, pk: string): Market {
   const total = raw.yesPool + raw.noPool;
   const s = Number(total) / LAMPORTS_PER_SOL;
   let yp = 0.5, np = 0.5;
-  if (total > 0n) { yp = Number(raw.noPool) / Number(total); np = Number(raw.yesPool) / Number(total); }
+  if (total > 0n) { yp = Number(raw.yesPool) / Number(total); np = Number(raw.noPool) / Number(total); }
   return {
     id: pk, question: raw.question, type: 'boolean',
     outcomes: [
@@ -283,13 +283,9 @@ function raceToMarket(raw: ReturnType<typeof parseRaceMarket>, pk: string): Mark
   const outcomes: MarketOutcome[] = [];
   for (let i = 0; i < raw.outcomeCount; i++) {
     const pool = raw.outcomePools[i];
-    const other = raw.totalPool - pool;
-    const divisor = raw.outcomeCount > 1 ? raw.outcomeCount - 1 : 1;
-    const price = raw.totalPool > 0n ? Number(other) / (Number(raw.totalPool) * divisor) : 1 / raw.outcomeCount;
-    outcomes.push({ label: raw.outcomeLabels[i] || `Outcome ${i + 1}`, probability: Math.min(Math.max(price, 0), 1), poolSol: Number(pool) / LAMPORTS_PER_SOL });
+    const prob = raw.totalPool > 0n ? Number(pool) / Number(raw.totalPool) : 1 / raw.outcomeCount;
+    outcomes.push({ label: raw.outcomeLabels[i] || `Outcome ${i + 1}`, probability: prob, poolSol: Number(pool) / LAMPORTS_PER_SOL });
   }
-  const sum = outcomes.reduce((a, o) => a + o.probability, 0);
-  if (sum > 0) for (const o of outcomes) o.probability /= sum;
   return {
     id: pk, question: raw.question, type: 'race', outcomes, totalPoolSol: s,
     status: STATUS_NAMES[raw.status] ?? 'unknown', layer: layerName(raw.layer),
@@ -317,7 +313,10 @@ function raceToMarket(raw: ReturnType<typeof parseRaceMarket>, pk: string): Mark
 const BLOCKED_SUBJECTIVE = [
   'ai agent', 'an agent', 'autonomously', 'become popular', 'go viral',
   'be successful', 'perform well', 'be the best', 'breakthrough',
-  'revolutionary', 'will i ', 'will we ', 'will my ', 'will our ',
+  'revolutionary',
+];
+const BLOCKED_SUBJECTIVE_PATTERNS = [
+  /\bwill i\b/i, /\bwill we\b/i, /\bwill my\b/i, /\bwill our\b/i,
 ];
 const BLOCKED_MANIPULATION = [
   'will someone', 'will anyone', 'will a person', 'will a user',
@@ -355,8 +354,9 @@ function validateParimutuelRules(params: {
   // ---- Content validation ----
 
   const subjective = BLOCKED_SUBJECTIVE.filter(p => q.includes(p));
-  if (subjective.length > 0)
-    errors.push(`BLOCKED: Unverifiable/subjective terms: "${subjective.join('", "')}". Outcomes must be objectively verifiable by third party.`);
+  const subjectivePatterns = BLOCKED_SUBJECTIVE_PATTERNS.filter(p => p.test(params.question));
+  if (subjective.length > 0 || subjectivePatterns.length > 0)
+    errors.push(`BLOCKED: Unverifiable/subjective terms detected. Outcomes must be objectively verifiable by third party.`);
 
   const manipulation = BLOCKED_MANIPULATION.filter(p => q.includes(p));
   if (manipulation.length > 0)
@@ -384,14 +384,15 @@ function validateParimutuelRules(params: {
       if (isNaN(eventMs)) {
         errors.push('BLOCKED: Invalid eventTime — must be valid ISO 8601.');
       } else {
-        const bufferHours = (eventMs - closeMs) / (1000 * 60 * 60);
-        if (bufferHours < 8) {
-          errors.push(`BLOCKED: Betting closes only ${bufferHours.toFixed(1)}h before event. MINIMUM is 8h. Late bets create information advantage.`);
-        } else if (bufferHours < 12) {
-          warnings.push(`Buffer is ${bufferHours.toFixed(1)}h before event. Minimum met, but 12-24h recommended for operational safety.`);
-        }
         if (closeMs >= eventMs) {
           errors.push('BLOCKED: Betting closes AFTER the event! Bettors would already know the outcome.');
+        } else {
+          const bufferHours = (eventMs - closeMs) / (1000 * 60 * 60);
+          if (bufferHours < 8) {
+            errors.push(`BLOCKED: Betting closes only ${bufferHours.toFixed(1)}h before event. MINIMUM is 8h. Late bets create information advantage.`);
+          } else if (bufferHours < 12) {
+            warnings.push(`Buffer is ${bufferHours.toFixed(1)}h before event. Minimum met, but 12-24h recommended for operational safety.`);
+          }
         }
       }
     }
@@ -628,6 +629,8 @@ class BaoziClient {
 
   async createLabMarket(params: { question: string; closingTime: number }): Promise<{ signature: string; marketAddress: string; marketId: number }> {
     if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY.');
+    // Note: marketCount is read then used for PDA derivation. If another market is created
+    // between read and send, the tx will fail with account mismatch — retry in that case.
     const config = await this.fetchGlobalConfig();
     const mPda = marketPda(config.marketCount);
     const w = new BorshWriter();
@@ -802,6 +805,8 @@ class BaoziClient {
     if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY.');
     const market = await this.fetchMarket(params.marketPubkey);
     if (!market) throw new Error(`Market not found: ${params.marketPubkey}`);
+    if (market.status !== 'resolved_pending')
+      throw new Error(`Market status is "${market.status}" — finalizeResolution requires "resolved_pending" (after oracle proposal + 6h dispute window)`);
 
     const mPk = new PublicKey(params.marketPubkey);
     const dMeta = disputeMetaPda(mPk);
@@ -1064,7 +1069,7 @@ addEntrypoint({
   description: 'Create an on-chain creator profile (required before creating Lab or Private markets). Each wallet can have one profile.',
   input: z.object({
     displayName: z.string().min(1).max(32).describe('Display name shown on your markets'),
-    defaultFeeBps: z.number().min(0).max(500).optional().default(50).describe('Default creator fee in basis points (50 = 0.5%)'),
+    defaultFeeBps: z.number().min(0).max(200).optional().default(50).describe('Default creator fee in basis points (50 = 0.5%). Max 200 (2%) — must satisfy solvency rule: creator_fee + affiliate_fee <= platform_fee'),
   }),
   output: z.object({
     signature: z.string(),

--- a/packages/cli/templates/prediction-market-agent/agent.ts.template
+++ b/packages/cli/templates/prediction-market-agent/agent.ts.template
@@ -1,0 +1,569 @@
+{{TEMPLATE_IMPORTS}}
+import { createAgent } from "@lucid-agents/core";
+import { http } from "@lucid-agents/http";
+import {
+  Connection,
+  PublicKey,
+  Keypair,
+  Transaction,
+  TransactionInstruction,
+  SystemProgram,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+import bs58 from 'bs58';
+import { createHash } from 'crypto';
+
+// ===========================================================================
+// Baozi On-Chain Client — Solana Prediction Markets
+// Program: FWyTPzm5cfJwRKzfkscxozatSxF6Qu78JQovQUwKPruJ
+// ===========================================================================
+
+const PROGRAM_ID = new PublicKey('FWyTPzm5cfJwRKzfkscxozatSxF6Qu78JQovQUwKPruJ');
+
+const MARKET_DISC = Buffer.from([219, 190, 213, 55, 0, 227, 198, 154]);
+const RACE_DISC = Buffer.from([235, 196, 111, 75, 230, 113, 118, 238]);
+const POS_DISC = Buffer.from([251, 248, 209, 245, 83, 234, 17, 27]);
+const RACE_POS_DISC = Buffer.from([44, 182, 16, 1, 230, 14, 174, 46]);
+
+const MARKET_DISC_B58 = bs58.encode(MARKET_DISC);
+const RACE_DISC_B58 = bs58.encode(RACE_DISC);
+const POS_DISC_B58 = bs58.encode(POS_DISC);
+const RACE_POS_DISC_B58 = bs58.encode(RACE_POS_DISC);
+
+const STATUS_NAMES: Record<number, string> = {
+  0: 'active', 1: 'closed', 2: 'resolved', 3: 'cancelled',
+  4: 'paused', 5: 'resolved_pending', 6: 'disputed',
+};
+
+// -- Borsh Reader -----------------------------------------------------------
+
+class BorshReader {
+  private buf: Buffer;
+  private off = 0;
+  constructor(buf: Buffer | Uint8Array) { this.buf = Buffer.from(buf); }
+  u8() { const v = this.buf.readUInt8(this.off); this.off += 1; return v; }
+  u16() { const v = this.buf.readUInt16LE(this.off); this.off += 2; return v; }
+  u64() { const v = this.buf.readBigUInt64LE(this.off); this.off += 8; return v; }
+  i64() { const v = this.buf.readBigInt64LE(this.off); this.off += 8; return v; }
+  bool() { return this.u8() === 1; }
+  pubkey() { const b = this.buf.subarray(this.off, this.off + 32); this.off += 32; return bs58.encode(b); }
+  string() { const len = this.buf.readUInt32LE(this.off); this.off += 4; const s = this.buf.subarray(this.off, this.off + len).toString('utf8'); this.off += len; return s; }
+  optBool(): boolean | null { if (!this.u8()) return null; return this.bool(); }
+  optU8(): number | null { if (!this.u8()) return null; return this.u8(); }
+  optPubkey(): string | null { if (!this.u8()) return null; return this.pubkey(); }
+  bytes(n: number) { const b = Buffer.from(this.buf.subarray(this.off, this.off + n)); this.off += n; return b; }
+  optBytes(n: number): Buffer | null { if (!this.u8()) return null; return this.bytes(n); }
+  skip(n: number) { this.off += n; }
+}
+
+// -- Types ------------------------------------------------------------------
+
+interface MarketOutcome { label: string; probability: number; poolSol: number; }
+
+interface Market {
+  id: string;
+  question: string;
+  type: 'boolean' | 'race';
+  outcomes: MarketOutcome[];
+  totalPoolSol: number;
+  status: string;
+  layer: string;
+  closingTime: string;
+  url: string;
+  rawMarketId: string;
+}
+
+interface Position {
+  pubkey: string;
+  marketId: string;
+  user: string;
+  type: 'boolean' | 'race';
+  yesAmountSol?: number;
+  noAmountSol?: number;
+  bets?: { outcome: number; amountSol: number }[];
+  totalBetSol: number;
+  claimed: boolean;
+}
+
+// -- Parsers ----------------------------------------------------------------
+
+function parseMarket(data: Buffer | Uint8Array) {
+  const r = new BorshReader(data);
+  r.skip(8);
+  const marketId = r.u64(); const question = r.string();
+  const closingTime = r.i64(); const resolutionTime = r.i64();
+  r.i64(); // auto_stop_buffer
+  const yesPool = r.u64(); const noPool = r.u64();
+  r.u64(); r.u64(); // snapshots
+  const status = r.u8(); const winningOutcome = r.optBool();
+  r.u8(); r.skip(33); // currency_type + reserved
+  r.u64(); r.u64(); r.u64(); // creator_bond, total_claimed, platform_fee_collected
+  const lastBetTime = r.i64();
+  r.u8(); // bump
+  const layer = r.u8();
+  r.u8(); r.u8(); // resolution_mode, access_gate
+  const creator = r.pubkey();
+  r.optPubkey(); r.skip(160); r.skip(4); // oracle_host, council, council_meta
+  r.u64(); // total_affiliate_fees
+  r.optBytes(32); // invite_hash
+  const creatorFeeBps = r.u16();
+  r.u64(); // total_creator_fees
+  r.optPubkey(); // creator_profile
+  const platformFeeBpsAtCreation = r.u16();
+  r.u16(); r.i64(); // affiliate_fee_bps, betting_freeze_seconds
+  const hasBets = r.bool();
+  return { marketId, question, closingTime, resolutionTime, yesPool, noPool, status, winningOutcome, layer, creator, creatorFeeBps, platformFeeBpsAtCreation, hasBets, lastBetTime };
+}
+
+function parseRaceMarket(data: Buffer | Uint8Array) {
+  const r = new BorshReader(data);
+  r.skip(8);
+  const marketId = r.u64(); const question = r.string();
+  const closingTime = r.i64(); const resolutionTime = r.i64();
+  r.i64(); // auto_stop_buffer
+  const outcomeCount = r.u8();
+  const outcomeLabels: string[] = [];
+  for (let i = 0; i < 10; i++) {
+    const lb = r.bytes(32);
+    if (i < outcomeCount) outcomeLabels.push(Buffer.from(Array.from(lb).filter(b => b !== 0)).toString('utf8'));
+  }
+  const outcomePools: bigint[] = [];
+  for (let i = 0; i < 10; i++) outcomePools.push(r.u64());
+  const totalPool = r.u64();
+  r.skip(88); // snapshot_pools + snapshot_total
+  const status = r.u8(); const winningOutcome = r.optU8();
+  r.u8(); r.u64(); r.u64(); r.u64(); // currency, fees, claimed
+  const lastBetTime = r.i64();
+  r.u8(); const layer = r.u8();
+  r.u8(); r.u8(); // resolution_mode, access_gate
+  const creator = r.pubkey();
+  r.optPubkey(); r.skip(160); r.u8(); r.skip(10); r.u8(); // oracle, council
+  const creatorFeeBps = r.u16();
+  r.optPubkey(); // creator_profile
+  const platformFeeBpsAtCreation = r.u16();
+  return { marketId, question, closingTime, resolutionTime, outcomeCount, outcomeLabels: outcomeLabels.slice(0, outcomeCount), outcomePools: outcomePools.slice(0, outcomeCount), totalPool, status, winningOutcome, layer, creator, creatorFeeBps, platformFeeBpsAtCreation, lastBetTime };
+}
+
+function parseUserPosition(data: Buffer | Uint8Array) {
+  const r = new BorshReader(data); r.skip(8);
+  return { user: r.pubkey(), marketId: r.u64(), yesAmount: r.u64(), noAmount: r.u64(), claimed: r.bool() };
+}
+
+function parseRacePosition(data: Buffer | Uint8Array) {
+  const r = new BorshReader(data); r.skip(8);
+  const user = r.pubkey(); const marketId = r.u64();
+  const bets: bigint[] = []; for (let i = 0; i < 10; i++) bets.push(r.u64());
+  return { user, marketId, bets, totalBet: r.u64(), claimed: r.bool() };
+}
+
+// -- PDA Derivation ---------------------------------------------------------
+
+function configPda() { return PublicKey.findProgramAddressSync([Buffer.from('config')], PROGRAM_ID)[0]; }
+function positionPda(mid: bigint, user: PublicKey) { const b = Buffer.alloc(8); b.writeBigUInt64LE(mid); return PublicKey.findProgramAddressSync([Buffer.from('position'), b, user.toBuffer()], PROGRAM_ID)[0]; }
+function racePosPda(mid: bigint, user: PublicKey) { const b = Buffer.alloc(8); b.writeBigUInt64LE(mid); return PublicKey.findProgramAddressSync([Buffer.from('race_position'), b, user.toBuffer()], PROGRAM_ID)[0]; }
+function pointsConfigPda() { return PublicKey.findProgramAddressSync([Buffer.from('points_config')], PROGRAM_ID)[0]; }
+function userPointsPda(user: PublicKey) { return PublicKey.findProgramAddressSync([Buffer.from('user_points'), user.toBuffer()], PROGRAM_ID)[0]; }
+
+function ixDisc(name: string) { return createHash('sha256').update(`global:${name}`).digest().subarray(0, 8); }
+const PLACE_BET_DISC = ixDisc('place_bet_sol');
+const RACE_BET_DISC = ixDisc('bet_on_race_outcome_sol');
+
+// -- Helpers ----------------------------------------------------------------
+
+function layerName(l: number) { return ['official', 'lab', 'private'][l] ?? 'unknown'; }
+
+function boolToMarket(raw: ReturnType<typeof parseMarket>, pk: string): Market {
+  const total = raw.yesPool + raw.noPool;
+  const s = Number(total) / LAMPORTS_PER_SOL;
+  let yp = 0.5, np = 0.5;
+  if (total > 0n) { yp = Number(raw.noPool) / Number(total); np = Number(raw.yesPool) / Number(total); }
+  return {
+    id: pk, question: raw.question, type: 'boolean',
+    outcomes: [
+      { label: 'Yes', probability: yp, poolSol: Number(raw.yesPool) / LAMPORTS_PER_SOL },
+      { label: 'No', probability: np, poolSol: Number(raw.noPool) / LAMPORTS_PER_SOL },
+    ],
+    totalPoolSol: s, status: STATUS_NAMES[raw.status] ?? 'unknown',
+    layer: layerName(raw.layer), closingTime: new Date(Number(raw.closingTime) * 1000).toISOString(),
+    url: `https://baozi.bet/market/${pk}`, rawMarketId: raw.marketId.toString(),
+  };
+}
+
+function raceToMarket(raw: ReturnType<typeof parseRaceMarket>, pk: string): Market {
+  const s = Number(raw.totalPool) / LAMPORTS_PER_SOL;
+  const outcomes: MarketOutcome[] = [];
+  for (let i = 0; i < raw.outcomeCount; i++) {
+    const pool = raw.outcomePools[i];
+    const other = raw.totalPool - pool;
+    const price = raw.totalPool > 0n ? Number(other) / (Number(raw.totalPool) * (raw.outcomeCount - 1)) : 1 / raw.outcomeCount;
+    outcomes.push({ label: raw.outcomeLabels[i] || `Outcome ${i + 1}`, probability: Math.min(Math.max(price, 0), 1), poolSol: Number(pool) / LAMPORTS_PER_SOL });
+  }
+  const sum = outcomes.reduce((a, o) => a + o.probability, 0);
+  if (sum > 0) for (const o of outcomes) o.probability /= sum;
+  return {
+    id: pk, question: raw.question, type: 'race', outcomes, totalPoolSol: s,
+    status: STATUS_NAMES[raw.status] ?? 'unknown', layer: layerName(raw.layer),
+    closingTime: new Date(Number(raw.closingTime) * 1000).toISOString(),
+    url: `https://baozi.bet/market/${pk}`, rawMarketId: raw.marketId.toString(),
+  };
+}
+
+// -- Cache ------------------------------------------------------------------
+
+class Cache<T> {
+  private data: T | null = null;
+  private ts = 0;
+  constructor(private ttl: number) {}
+  get(): T | null { return this.data && Date.now() - this.ts < this.ttl ? this.data : null; }
+  set(v: T) { this.data = v; this.ts = Date.now(); }
+}
+
+// -- Filter -----------------------------------------------------------------
+
+function applyFilters(markets: Market[], f?: { status?: string; query?: string; limit?: number }) {
+  let r = [...markets];
+  const status = f?.status || 'active';
+  if (status !== 'all') {
+    const now = new Date().toISOString();
+    r = status === 'active'
+      ? r.filter(m => m.closingTime > now && m.status === 'active')
+      : r.filter(m => m.closingTime <= now || m.status !== 'active');
+  }
+  if (f?.query) { const q = f.query.toLowerCase(); r = r.filter(m => m.question.toLowerCase().includes(q)); }
+  r.sort((a, b) => b.totalPoolSol - a.totalPoolSol);
+  if (f?.limit && f.limit > 0) r = r.slice(0, f.limit);
+  return r;
+}
+
+// -- BaoziClient ------------------------------------------------------------
+
+class BaoziClient {
+  private conn: Connection;
+  private cache = new Cache<Market[]>(30_000);
+  private wallet?: Keypair;
+
+  constructor(opts: { rpcUrl: string; privateKey?: string }) {
+    this.conn = new Connection(opts.rpcUrl, 'confirmed');
+    if (opts.privateKey) this.wallet = Keypair.fromSecretKey(bs58.decode(opts.privateKey));
+  }
+
+  async fetchMarkets(filter?: { status?: string; query?: string; limit?: number }): Promise<Market[]> {
+    const cached = this.cache.get();
+    if (cached && !filter?.query) return applyFilters(cached, filter);
+
+    const [ba, ra] = await Promise.all([
+      this.conn.getProgramAccounts(PROGRAM_ID, { filters: [{ memcmp: { offset: 0, bytes: MARKET_DISC_B58 } }] }),
+      this.conn.getProgramAccounts(PROGRAM_ID, { filters: [{ memcmp: { offset: 0, bytes: RACE_DISC_B58 } }] }),
+    ]);
+
+    const markets: Market[] = [];
+    for (const a of ba) { try { markets.push(boolToMarket(parseMarket(a.account.data), a.pubkey.toString())); } catch {} }
+    for (const a of ra) { try { markets.push(raceToMarket(parseRaceMarket(a.account.data), a.pubkey.toString())); } catch {} }
+
+    this.cache.set(markets);
+    return applyFilters(markets, filter);
+  }
+
+  async fetchMarket(pubkey: string): Promise<Market | null> {
+    const info = await this.conn.getAccountInfo(new PublicKey(pubkey));
+    if (!info) return null;
+    const d = Buffer.from(info.data.subarray(0, 8));
+    if (d.equals(MARKET_DISC)) return boolToMarket(parseMarket(info.data), pubkey);
+    if (d.equals(RACE_DISC)) return raceToMarket(parseRaceMarket(info.data), pubkey);
+    return null;
+  }
+
+  async getPositions(wallet: string): Promise<Position[]> {
+    const pk = new PublicKey(wallet);
+    const [ba, ra] = await Promise.all([
+      this.conn.getProgramAccounts(PROGRAM_ID, { filters: [{ memcmp: { offset: 0, bytes: POS_DISC_B58 } }, { memcmp: { offset: 8, bytes: bs58.encode(pk.toBuffer()) } }] }),
+      this.conn.getProgramAccounts(PROGRAM_ID, { filters: [{ memcmp: { offset: 0, bytes: RACE_POS_DISC_B58 } }, { memcmp: { offset: 8, bytes: bs58.encode(pk.toBuffer()) } }] }),
+    ]);
+    const positions: Position[] = [];
+    for (const a of ba) {
+      try {
+        const p = parseUserPosition(a.account.data);
+        positions.push({ pubkey: a.pubkey.toString(), marketId: p.marketId.toString(), user: p.user, type: 'boolean', yesAmountSol: Number(p.yesAmount) / LAMPORTS_PER_SOL, noAmountSol: Number(p.noAmount) / LAMPORTS_PER_SOL, totalBetSol: Number(p.yesAmount + p.noAmount) / LAMPORTS_PER_SOL, claimed: p.claimed });
+      } catch {}
+    }
+    for (const a of ra) {
+      try {
+        const p = parseRacePosition(a.account.data);
+        positions.push({ pubkey: a.pubkey.toString(), marketId: p.marketId.toString(), user: p.user, type: 'race', bets: p.bets.map((b, i) => ({ outcome: i, amountSol: Number(b) / LAMPORTS_PER_SOL })), totalBetSol: Number(p.totalBet) / LAMPORTS_PER_SOL, claimed: p.claimed });
+      } catch {}
+    }
+    return positions;
+  }
+
+  async placeBet(params: { marketPubkey: string; outcome: number; amountSol: number }): Promise<string> {
+    if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY to enable trading.');
+    const market = await this.fetchMarket(params.marketPubkey);
+    if (!market) throw new Error(`Market not found: ${params.marketPubkey}`);
+
+    const amt = BigInt(Math.round(params.amountSol * LAMPORTS_PER_SOL));
+    const mPk = new PublicKey(params.marketPubkey);
+    const rawId = BigInt(market.rawMarketId);
+    const cfg = configPda();
+    const ptsCfg = pointsConfigPda();
+    const uPts = userPointsPda(this.wallet.publicKey);
+
+    let ix: TransactionInstruction;
+    if (market.type === 'boolean') {
+      const pos = positionPda(rawId, this.wallet.publicKey);
+      const data = Buffer.alloc(17);
+      PLACE_BET_DISC.copy(data, 0);
+      data.writeUInt8(params.outcome === 0 ? 1 : 0, 8);
+      data.writeBigUInt64LE(amt, 9);
+      ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+        { pubkey: cfg, isSigner: false, isWritable: false },
+        { pubkey: mPk, isSigner: false, isWritable: true },
+        { pubkey: pos, isSigner: false, isWritable: true },
+        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },
+        { pubkey: ptsCfg, isSigner: false, isWritable: false },
+        { pubkey: uPts, isSigner: false, isWritable: true },
+        { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+      ], data });
+    } else {
+      const pos = racePosPda(rawId, this.wallet.publicKey);
+      const data = Buffer.alloc(17);
+      RACE_BET_DISC.copy(data, 0);
+      data.writeUInt8(params.outcome, 8);
+      data.writeBigUInt64LE(amt, 9);
+      ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+        { pubkey: cfg, isSigner: false, isWritable: false },
+        { pubkey: mPk, isSigner: false, isWritable: true },
+        { pubkey: pos, isSigner: false, isWritable: true },
+        { pubkey: PROGRAM_ID, isSigner: false, isWritable: false },
+        { pubkey: ptsCfg, isSigner: false, isWritable: false },
+        { pubkey: uPts, isSigner: false, isWritable: true },
+        { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+      ], data });
+    }
+
+    const tx = new Transaction().add(ix);
+    tx.feePayer = this.wallet.publicKey;
+    tx.recentBlockhash = (await this.conn.getLatestBlockhash()).blockhash;
+    tx.sign(this.wallet);
+    const sig = await this.conn.sendRawTransaction(tx.serialize());
+    await this.conn.confirmTransaction(sig, 'confirmed');
+    return sig;
+  }
+}
+
+{{TEMPLATE_PRE_SETUP}}
+const baozi = new BaoziClient({
+  rpcUrl: process.env.SOLANA_RPC_URL || 'https://api.mainnet-beta.solana.com',
+  privateKey: process.env.SOLANA_PRIVATE_KEY,
+});
+
+const agent = await createAgent({
+  name: process.env.AGENT_NAME ?? "prediction-market-agent",
+  version: process.env.AGENT_VERSION ?? "0.1.0",
+  description: process.env.AGENT_DESCRIPTION ?? "Prediction market data and trading agent",
+})
+  .use(http())
+  .build();
+
+{{TEMPLATE_POST_SETUP}}
+
+/**
+ * Prediction Market Agent — Baozi on Solana
+ *
+ * Entrypoints:
+ *   getMarkets      — List active prediction markets with current odds
+ *   getMarketOdds   — Probabilities and pool sizes for one market
+ *   getPortfolio    — Active positions for a wallet
+ *   placeBet        — Place a bet (requires SOLANA_PRIVATE_KEY)
+ *   analyzeMarket   — Statistical market summary
+ */
+
+const marketSchema = z.object({
+  id: z.string(),
+  question: z.string(),
+  type: z.enum(['boolean', 'race']),
+  outcomes: z.array(z.object({
+    label: z.string(),
+    probability: z.number(),
+    poolSol: z.number(),
+  })),
+  totalPoolSol: z.number(),
+  status: z.string(),
+  layer: z.string(),
+  closingTime: z.string(),
+  url: z.string(),
+});
+
+addEntrypoint({
+  key: 'getMarkets',
+  description: 'Fetch active prediction markets from Solana with current odds',
+  input: z.object({
+    status: z.enum(['active', 'closed', 'all']).optional().describe('Filter by market status'),
+    query: z.string().optional().describe('Search market titles'),
+    limit: z.number().optional().describe('Max results to return'),
+  }),
+  output: z.object({
+    markets: z.array(marketSchema),
+    count: z.number(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const markets = await baozi.fetchMarkets(ctx.input);
+    return {
+      output: { markets, count: markets.length },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+addEntrypoint({
+  key: 'getMarketOdds',
+  description: 'Get current odds (implied probabilities) and pool sizes for a specific market',
+  input: z.object({
+    marketId: z.string().describe('Market public key (base58)'),
+  }),
+  output: z.object({
+    marketId: z.string(),
+    question: z.string(),
+    outcomes: z.array(z.object({
+      label: z.string(),
+      probability: z.number(),
+      poolSol: z.number(),
+    })),
+    totalPoolSol: z.number(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const market = await baozi.fetchMarket(ctx.input.marketId);
+    if (!market) throw new Error(`Market not found: ${ctx.input.marketId}`);
+    return {
+      output: {
+        marketId: market.id,
+        question: market.question,
+        outcomes: market.outcomes,
+        totalPoolSol: market.totalPoolSol,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+addEntrypoint({
+  key: 'getPortfolio',
+  description: 'View active prediction market positions for a wallet',
+  input: z.object({
+    wallet: z.string().describe('Solana wallet address (base58)'),
+  }),
+  output: z.object({
+    positions: z.array(z.object({
+      pubkey: z.string(),
+      marketId: z.string(),
+      user: z.string(),
+      type: z.enum(['boolean', 'race']),
+      yesAmountSol: z.number().optional(),
+      noAmountSol: z.number().optional(),
+      bets: z.array(z.object({
+        outcome: z.number(),
+        amountSol: z.number(),
+      })).optional(),
+      totalBetSol: z.number(),
+      claimed: z.boolean(),
+    })),
+    count: z.number(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const positions = await baozi.getPositions(ctx.input.wallet);
+    return {
+      output: { positions, count: positions.length },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+addEntrypoint({
+  key: 'placeBet',
+  description: 'Place a bet on a prediction market outcome (requires SOLANA_PRIVATE_KEY)',
+  input: z.object({
+    marketId: z.string().describe('Market public key (base58)'),
+    outcome: z.number().describe('Outcome index (0=Yes/first, 1=No/second, etc.)'),
+    amountSol: z.number().min(0.01).max(100).describe('Bet amount in SOL'),
+  }),
+  output: z.object({
+    signature: z.string(),
+    market: z.string(),
+    outcome: z.number(),
+    amountSol: z.number(),
+    explorerUrl: z.string(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const { marketId, outcome, amountSol } = ctx.input;
+    const signature = await baozi.placeBet({ marketPubkey: marketId, outcome, amountSol });
+    return {
+      output: {
+        signature,
+        market: marketId,
+        outcome,
+        amountSol,
+        explorerUrl: `https://solscan.io/tx/${signature}`,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+addEntrypoint({
+  key: 'analyzeMarket',
+  description: 'Get a statistical summary and analysis of a prediction market',
+  input: z.object({
+    marketId: z.string().describe('Market public key (base58)'),
+  }),
+  output: z.object({
+    marketId: z.string(),
+    question: z.string(),
+    summary: z.string(),
+    odds: z.array(z.object({
+      label: z.string(),
+      probability: z.number(),
+      impliedReturn: z.number(),
+    })),
+    totalPoolSol: z.number(),
+    status: z.string(),
+    closingTime: z.string(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const market = await baozi.fetchMarket(ctx.input.marketId);
+    if (!market) throw new Error(`Market not found: ${ctx.input.marketId}`);
+
+    const odds = market.outcomes.map(o => ({
+      label: o.label,
+      probability: o.probability,
+      impliedReturn: o.probability > 0 ? 1 / o.probability : 0,
+    }));
+
+    const fav = market.outcomes.reduce((a, b) => a.probability > b.probability ? a : b);
+    const summary = [
+      `"${market.question}"`,
+      `Total pool: ${market.totalPoolSol.toFixed(2)} SOL`,
+      `${market.outcomes.length} outcomes — favorite is "${fav.label}" at ${(fav.probability * 100).toFixed(1)}%`,
+      `Status: ${market.status}, closes ${market.closingTime}`,
+      `Market type: ${market.type} (pari-mutuel pricing)`,
+    ].join('. ');
+
+    return {
+      output: {
+        marketId: market.id,
+        question: market.question,
+        summary,
+        odds,
+        totalPoolSol: market.totalPoolSol,
+        status: market.status,
+        closingTime: market.closingTime,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});

--- a/packages/cli/templates/prediction-market-agent/agent.ts.template
+++ b/packages/cli/templates/prediction-market-agent/agent.ts.template
@@ -43,6 +43,10 @@ const RACE_BET_DISC = Buffer.from([195, 181, 151, 159, 105, 100, 234, 244]);
 const CREATE_PROFILE_DISC = Buffer.from([139, 244, 127, 145, 95, 172, 140, 154]);
 const CREATE_LAB_MARKET_DISC = Buffer.from([35, 159, 50, 67, 31, 134, 199, 157]);
 const CREATE_RACE_MARKET_DISC = Buffer.from([94, 237, 40, 47, 63, 233, 25, 67]);
+const CANCEL_MARKET_DISC = Buffer.from([205, 121, 84, 210, 222, 71, 150, 11]);
+const CANCEL_RACE_DISC = Buffer.from([223, 214, 232, 232, 43, 15, 165, 234]);
+const CLAIM_REFUND_DISC = Buffer.from([8, 82, 5, 144, 194, 114, 255, 20]);
+const CLAIM_RACE_REFUND_DISC = Buffer.from([174, 101, 101, 227, 171, 69, 173, 243]);
 
 const STATUS_NAMES: Record<number, string> = {
   0: 'active', 1: 'closed', 2: 'resolved', 3: 'cancelled',
@@ -285,6 +289,20 @@ function raceToMarket(raw: ReturnType<typeof parseRaceMarket>, pk: string): Mark
 }
 
 // -- Parimutuel Rules v6.3 — Market Creation Guardrails --------------------
+//
+// THE GOLDEN RULE: Bettors must NEVER have access to ANY information that
+// could inform the outcome while betting is still open.
+//
+// Two market types with DISTINCT timing rules:
+//
+//   Type A (Event-Based): Sports, awards, announcements, crypto snapshots
+//     → Betting closes 8h+ BEFORE the event (12-24h recommended)
+//     → Best for: CS2/LoL matches, UFC fights, Super Bowl, elections
+//
+//   Type B (Measurement-Period): Charts, weekly metrics, accumulated data
+//     → Betting closes BEFORE measurement period starts
+//     → Best for: Netflix Top 10, Billboard, weekly DeFi metrics
+//     → Prefer SHORT periods (2-7 days) — users hate capital lockup
 
 const BLOCKED_SUBJECTIVE = [
   'ai agent', 'an agent', 'autonomously', 'become popular', 'go viral',
@@ -298,37 +316,106 @@ const BLOCKED_MANIPULATION = [
 const IMPLIED_SOURCES = [
   /\b(btc|eth|sol|bitcoin|ethereum|solana|coingecko|coinmarketcap|binance|coinbase|tradingview)\b/i,
   /\b(ufc|nba|nfl|mlb|nhl|champions league|world cup|super bowl|espn|uefa|fifa|atp|wta)\b/i,
+  /\b(cs2|csgo|counter.strike|league of legends|lol|dota|valorant|overwatch)\b/i,
   /\b(tokyo|london|new york|los angeles|paris|snow|rain|temperature|nws|jma|weather)\b/i,
   /\b(election|president|congress|parliament|vote|ap news|reuters|sec|nasdaq|nyse)\b/i,
+  /\b(netflix|billboard|spotify|grammy|oscar|golden globe|emmy)\b/i,
   /source:/i, /official/i,
 ];
 
-function validateParimutuelRules(question: string): { valid: boolean; errors: string[]; warnings: string[] } {
+interface ParimutuelValidation {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+function validateParimutuelRules(params: {
+  question: string;
+  closingTimeMs: number;
+  marketType: 'event' | 'measurement';
+  eventTime?: string;         // ISO 8601 — when outcome is decided (Type A)
+  measurementStart?: string;  // ISO 8601 — when data collection begins (Type B)
+  measurementEnd?: string;    // ISO 8601 — when data collection ends (Type B)
+}): ParimutuelValidation {
   const errors: string[] = [];
   const warnings: string[] = [];
-  const q = question.toLowerCase();
+  const q = params.question.toLowerCase();
+  const closeMs = params.closingTimeMs;
 
-  // Check subjective/unverifiable outcomes
+  // ---- Content validation ----
+
   const subjective = BLOCKED_SUBJECTIVE.filter(p => q.includes(p));
   if (subjective.length > 0)
-    errors.push(`BLOCKED: Unverifiable/subjective terms detected: "${subjective.join('", "')}". Markets must have outcomes verifiable by third party using public records.`);
+    errors.push(`BLOCKED: Unverifiable/subjective terms: "${subjective.join('", "')}". Outcomes must be objectively verifiable by third party.`);
 
-  // Check manipulation risk
   const manipulation = BLOCKED_MANIPULATION.filter(p => q.includes(p));
   if (manipulation.length > 0)
-    errors.push(`BLOCKED: Manipulation risk — terms: "${manipulation.join('", "')}". Creators cannot make markets about outcomes they can directly influence.`);
+    errors.push(`BLOCKED: Manipulation risk — terms: "${manipulation.join('", "')}". Creators cannot make markets about outcomes they can influence.`);
 
-  // Check for implied/explicit data source
-  const hasSource = IMPLIED_SOURCES.some(r => r.test(question));
+  const hasSource = IMPLIED_SOURCES.some(r => r.test(params.question));
   if (!hasSource)
-    errors.push('BLOCKED: No verifiable data source. Include a source like "(Source: CoinGecko)" or reference a known category (sports league, crypto asset, weather location). Approved: CoinGecko, ESPN, NWS, Reuters, SEC, etc.');
+    errors.push('BLOCKED: No verifiable data source. Reference a known entity (BTC, NBA, CS2, Netflix, etc.) or add "(Source: CoinGecko)". See approved sources list.');
 
-  // Check clear criteria
-  const hasCriteria = /\$[\d,]+/.test(question) || /\d+%/.test(question) ||
-    /above|below|over|under|at least|more than|less than/i.test(question) ||
-    /will .+ (win|lose|defeat|advance|qualify|score|achieve|snow|rain|happen|launch|release|announce)/i.test(question);
+  const hasCriteria = /\$[\d,]+/.test(params.question) || /\d+%/.test(params.question) ||
+    /above|below|over|under|at least|more than|less than/i.test(params.question) ||
+    /will .+ (win|lose|defeat|advance|qualify|score|beat|knock|eliminate)/i.test(params.question) ||
+    /who will/i.test(params.question) || /which .+ will/i.test(params.question);
   if (!hasCriteria)
-    warnings.push('Recommended: Include clear numeric threshold or binary outcome (e.g. "above $X", "will Team A win").');
+    warnings.push('Tip: Include clear criteria — "above $X", "will Team A win", "who will win". Ambiguous questions cause resolution disputes.');
+
+  // ---- Timing validation (THE CORE RULES) ----
+
+  if (params.marketType === 'event') {
+    // TYPE A: Betting must close 24h+ BEFORE event
+    if (!params.eventTime) {
+      errors.push('BLOCKED: Event-based markets MUST specify eventTime — the moment the outcome is decided (e.g. game kickoff, announcement time, snapshot time).');
+    } else {
+      const eventMs = new Date(params.eventTime).getTime();
+      if (isNaN(eventMs)) {
+        errors.push('BLOCKED: Invalid eventTime — must be valid ISO 8601.');
+      } else {
+        const bufferHours = (eventMs - closeMs) / (1000 * 60 * 60);
+        if (bufferHours < 8) {
+          errors.push(`BLOCKED: Betting closes only ${bufferHours.toFixed(1)}h before event. MINIMUM is 8h. Late bets create information advantage.`);
+        } else if (bufferHours < 12) {
+          warnings.push(`Buffer is ${bufferHours.toFixed(1)}h before event. Minimum met, but 12-24h recommended for operational safety.`);
+        }
+        if (closeMs >= eventMs) {
+          errors.push('BLOCKED: Betting closes AFTER the event! Bettors would already know the outcome.');
+        }
+      }
+    }
+  } else {
+    // TYPE B: Betting must close BEFORE measurement period starts
+    if (!params.measurementStart) {
+      errors.push('BLOCKED: Measurement-period markets MUST specify measurementStart — when data collection begins (e.g. Monday for weekly chart, month start for monthly metric).');
+    } else {
+      const startMs = new Date(params.measurementStart).getTime();
+      if (isNaN(startMs)) {
+        errors.push('BLOCKED: Invalid measurementStart — must be valid ISO 8601.');
+      } else {
+        if (closeMs >= startMs) {
+          const overlapHours = (closeMs - startMs) / (1000 * 60 * 60);
+          errors.push(`BLOCKED: Betting closes ${overlapHours.toFixed(1)}h AFTER measurement starts! Bettors can observe data accumulating and bet with foreknowledge. Betting MUST close BEFORE measurement period starts.`);
+        }
+        if (startMs <= Date.now()) {
+          errors.push('BLOCKED: Measurement period has already started. Cannot create a market for an ongoing measurement period — data is already accumulating.');
+        }
+      }
+      // Check measurement period length — prefer SHORT (2-7 days)
+      if (params.measurementEnd) {
+        const endMs = new Date(params.measurementEnd).getTime();
+        if (!isNaN(endMs) && !isNaN(new Date(params.measurementStart).getTime())) {
+          const periodDays = (endMs - new Date(params.measurementStart).getTime()) / (1000 * 60 * 60 * 24);
+          if (periodDays > 14) {
+            errors.push(`BLOCKED: Measurement period is ${Math.round(periodDays)} days. Max is 14 days. Users don't want funds locked that long. Convert to a snapshot (Type A) market or shorten the period to 2-7 days.`);
+          } else if (periodDays > 7) {
+            warnings.push(`${Math.round(periodDays)}-day measurement period. 2-7 days is ideal — shorter lockups = more betting volume.`);
+          }
+        }
+      }
+    }
+  }
 
   return { valid: errors.length === 0, errors, warnings };
 }
@@ -585,6 +672,73 @@ class BaoziClient {
     this.invalidateCache();
     return { signature: sig, marketAddress: rmPda.toString(), marketId: Number(config.marketCount) };
   }
+
+  async cancelMarket(params: { marketPubkey: string; reason: string }): Promise<string> {
+    if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY.');
+    const market = await this.fetchMarket(params.marketPubkey);
+    if (!market) throw new Error(`Market not found: ${params.marketPubkey}`);
+    if (market.status === 'cancelled') throw new Error('Market is already cancelled');
+    if (market.status === 'resolved') throw new Error('Market is already resolved — cannot cancel');
+
+    const mPk = new PublicKey(params.marketPubkey);
+    const w = new BorshWriter();
+    let ix: TransactionInstruction;
+
+    if (market.type === 'boolean') {
+      w.raw(CANCEL_MARKET_DISC);
+      w.string(params.reason);
+      ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+        { pubkey: configPda(), isSigner: false, isWritable: false },
+        { pubkey: mPk, isSigner: false, isWritable: true },
+        { pubkey: this.wallet.publicKey, isSigner: true, isWritable: false },
+      ], data: w.toBuffer() });
+    } else {
+      w.raw(CANCEL_RACE_DISC);
+      w.string(params.reason);
+      ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+        { pubkey: configPda(), isSigner: false, isWritable: false },
+        { pubkey: mPk, isSigner: false, isWritable: true },
+        { pubkey: this.wallet.publicKey, isSigner: true, isWritable: false },
+      ], data: w.toBuffer() });
+    }
+
+    const sig = await this.sendTx(ix);
+    this.invalidateCache();
+    return sig;
+  }
+
+  async claimRefund(params: { marketPubkey: string }): Promise<string> {
+    if (!this.wallet) throw new Error('Wallet not configured. Set SOLANA_PRIVATE_KEY.');
+    const market = await this.fetchMarket(params.marketPubkey);
+    if (!market) throw new Error(`Market not found: ${params.marketPubkey}`);
+    if (market.status !== 'cancelled') throw new Error(`Market status is "${market.status}" — refunds are only available for cancelled markets`);
+
+    const mPk = new PublicKey(params.marketPubkey);
+    const rawId = BigInt(market.rawMarketId);
+    let ix: TransactionInstruction;
+
+    if (market.type === 'boolean') {
+      const pos = positionPda(rawId, this.wallet.publicKey);
+      ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+        { pubkey: mPk, isSigner: false, isWritable: true },
+        { pubkey: pos, isSigner: false, isWritable: true },
+        { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+      ], data: CLAIM_REFUND_DISC });
+    } else {
+      const pos = racePosPda(rawId, this.wallet.publicKey);
+      ix = new TransactionInstruction({ programId: PROGRAM_ID, keys: [
+        { pubkey: mPk, isSigner: false, isWritable: true },
+        { pubkey: pos, isSigner: false, isWritable: true },
+        { pubkey: this.wallet.publicKey, isSigner: true, isWritable: true },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+      ], data: CLAIM_RACE_REFUND_DISC });
+    }
+
+    const sig = await this.sendTx(ix);
+    this.invalidateCache();
+    return sig;
+  }
 }
 
 {{TEMPLATE_PRE_SETUP}}
@@ -621,6 +775,8 @@ const agent = await createAgent({
  *   createCreatorProfile  — Create on-chain creator profile (required for Labs)
  *   createLabMarket       — Create a Yes/No Lab market
  *   createLabRaceMarket   — Create a multi-outcome Lab race market
+ *   cancelLabMarket       — Cancel a Lab market you created (full refund to bettors)
+ *   claimRefund           — Claim refund from a cancelled market
  */
 
 const solPubkey = z.string().refine(s => { try { new PublicKey(s); return true; } catch { return false; } }, 'Invalid Solana public key');
@@ -843,10 +999,22 @@ addEntrypoint({
 
 addEntrypoint({
   key: 'createLabMarket',
-  description: 'Create a boolean (Yes/No) Lab prediction market. Requires a CreatorProfile (call createCreatorProfile first). Lab markets use HostOracle resolution and charge 3% platform fee.',
+  description: `Create a boolean (Yes/No) Lab prediction market. Requires CreatorProfile. Enforces Parimutuel Rules v6.3.
+
+MARKET TYPES (you MUST specify one):
+- "event" (Type A): Sports, fights, awards, crypto snapshots, elections
+  → Provide eventTime (when outcome is decided). Betting closes 8h+ before (12-24h recommended).
+  → BEST FOR: CS2/LoL matches, UFC fights, Super Bowl, price snapshots
+- "measurement" (Type B): Charts, weekly metrics, accumulated data
+  → Provide measurementStart + measurementEnd. Betting closes before start.
+  → Max 14 days. BEST FOR: Netflix Top 10, Billboard, weekly DeFi metrics`,
   input: z.object({
-    question: z.string().min(10).max(200).describe('The prediction question (e.g. "Will BTC hit $200k by March 2026?")'),
-    closingTime: z.string().describe('ISO 8601 closing time (e.g. "2026-03-01T00:00:00Z")'),
+    question: z.string().min(10).max(200).describe('Clear prediction question with verifiable outcome'),
+    closingTime: z.string().describe('ISO 8601 — when betting closes'),
+    marketType: z.enum(['event', 'measurement']).describe('Type A (event) or Type B (measurement-period)'),
+    eventTime: z.string().optional().describe('Type A only: ISO 8601 — when outcome is decided (game start, announcement, snapshot). Must be 8h+ after closingTime.'),
+    measurementStart: z.string().optional().describe('Type B only: ISO 8601 — when data collection begins. Must be after closingTime.'),
+    measurementEnd: z.string().optional().describe('Type B only: ISO 8601 — when data collection ends. Max 14 days from start.'),
   }),
   output: z.object({
     signature: z.string(),
@@ -857,13 +1025,21 @@ addEntrypoint({
   }),
   price: process.env.DEFAULT_PRICE || undefined,
   handler: async (ctx) => {
-    // Parimutuel v6.3 guardrails — validate before on-chain submission
-    const validation = validateParimutuelRules(ctx.input.question);
+    const closeMs = new Date(ctx.input.closingTime).getTime();
+    if (isNaN(closeMs) || closeMs <= Date.now()) throw new Error('closingTime must be a valid future ISO 8601 date');
+
+    const validation = validateParimutuelRules({
+      question: ctx.input.question,
+      closingTimeMs: closeMs,
+      marketType: ctx.input.marketType,
+      eventTime: ctx.input.eventTime,
+      measurementStart: ctx.input.measurementStart,
+      measurementEnd: ctx.input.measurementEnd,
+    });
     if (!validation.valid) throw new Error(`Market creation blocked by Parimutuel Rules v6.3:\n${validation.errors.join('\n')}`);
     if (validation.warnings.length > 0) console.warn(`Parimutuel warnings: ${validation.warnings.join('; ')}`);
 
-    const closingTimestamp = Math.floor(new Date(ctx.input.closingTime).getTime() / 1000);
-    if (closingTimestamp <= Math.floor(Date.now() / 1000)) throw new Error('Closing time must be in the future');
+    const closingTimestamp = Math.floor(closeMs / 1000);
     const result = await baozi.createLabMarket({ question: ctx.input.question, closingTime: closingTimestamp });
     return {
       output: {
@@ -878,11 +1054,21 @@ addEntrypoint({
 
 addEntrypoint({
   key: 'createLabRaceMarket',
-  description: 'Create a multi-outcome Lab race market (2-10 outcomes). Requires a CreatorProfile. Lab markets use HostOracle resolution and charge 3% platform fee.',
+  description: `Create a multi-outcome Lab race market (2-10 outcomes). Requires CreatorProfile. Enforces Parimutuel Rules v6.3.
+
+MARKET TYPES (you MUST specify one):
+- "event" (Type A): Who wins? Which team advances? Best for esports, sports, elections.
+  → Provide eventTime. Betting closes 8h+ before (12-24h recommended).
+- "measurement" (Type B): Which gets most X during period?
+  → Provide measurementStart + measurementEnd. Max 14 days.`,
   input: z.object({
-    question: z.string().min(10).max(200).describe('The prediction question'),
-    closingTime: z.string().describe('ISO 8601 closing time'),
-    outcomes: z.array(z.string().max(32)).min(2).max(10).describe('Outcome labels (e.g. ["Trump", "DeSantis", "Newsom"])'),
+    question: z.string().min(10).max(200).describe('Clear prediction question'),
+    closingTime: z.string().describe('ISO 8601 — when betting closes'),
+    outcomes: z.array(z.string().max(32)).min(2).max(10).describe('Outcome labels (e.g. ["NaVi", "FaZe", "G2", "Vitality"])'),
+    marketType: z.enum(['event', 'measurement']).describe('Type A (event) or Type B (measurement-period)'),
+    eventTime: z.string().optional().describe('Type A: when outcome is decided'),
+    measurementStart: z.string().optional().describe('Type B: when data collection begins'),
+    measurementEnd: z.string().optional().describe('Type B: when data collection ends (max 14 days)'),
   }),
   output: z.object({
     signature: z.string(),
@@ -893,19 +1079,83 @@ addEntrypoint({
   }),
   price: process.env.DEFAULT_PRICE || undefined,
   handler: async (ctx) => {
-    // Parimutuel v6.3 guardrails — validate before on-chain submission
-    const validation = validateParimutuelRules(ctx.input.question);
+    const closeMs = new Date(ctx.input.closingTime).getTime();
+    if (isNaN(closeMs) || closeMs <= Date.now()) throw new Error('closingTime must be a valid future ISO 8601 date');
+
+    const validation = validateParimutuelRules({
+      question: ctx.input.question,
+      closingTimeMs: closeMs,
+      marketType: ctx.input.marketType,
+      eventTime: ctx.input.eventTime,
+      measurementStart: ctx.input.measurementStart,
+      measurementEnd: ctx.input.measurementEnd,
+    });
     if (!validation.valid) throw new Error(`Market creation blocked by Parimutuel Rules v6.3:\n${validation.errors.join('\n')}`);
     if (validation.warnings.length > 0) console.warn(`Parimutuel warnings: ${validation.warnings.join('; ')}`);
 
-    const closingTimestamp = Math.floor(new Date(ctx.input.closingTime).getTime() / 1000);
-    if (closingTimestamp <= Math.floor(Date.now() / 1000)) throw new Error('Closing time must be in the future');
+    const closingTimestamp = Math.floor(closeMs / 1000);
     const result = await baozi.createLabRaceMarket({ question: ctx.input.question, closingTime: closingTimestamp, outcomes: ctx.input.outcomes });
     return {
       output: {
         ...result,
         explorerUrl: `https://solscan.io/tx/${result.signature}`,
         marketUrl: `https://baozi.bet/market/${result.marketAddress}`,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+addEntrypoint({
+  key: 'cancelLabMarket',
+  description: `Cancel a Lab market you created. All bettors receive a full 100% refund (no fees deducted).
+
+CONSTRAINTS (enforced on-chain):
+- Creator can cancel if NO bets have been placed yet, OR if pool < 0.5 SOL
+- Admin/guardian can cancel any market at any time (emergency)
+- Cannot cancel resolved or already-cancelled markets
+- After cancellation, each bettor calls claimRefund to withdraw their SOL`,
+  input: z.object({
+    marketId: solPubkey.describe('Market public key to cancel'),
+    reason: z.string().min(1).max(200).describe('Reason for cancellation (stored on-chain)'),
+  }),
+  output: z.object({
+    signature: z.string(),
+    explorerUrl: z.string(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const sig = await baozi.cancelMarket({ marketPubkey: ctx.input.marketId, reason: ctx.input.reason });
+    return {
+      output: {
+        signature: sig,
+        explorerUrl: `https://solscan.io/tx/${sig}`,
+      },
+      usage: { total_tokens: 0 },
+    };
+  },
+});
+
+addEntrypoint({
+  key: 'claimRefund',
+  description: `Claim a full 100% refund from a cancelled market. No fees are deducted — you get your entire bet back.
+
+Works for both boolean and race markets. Race market refunds return ALL bets across all outcomes.
+Requires the market to be in "cancelled" status. Each wallet can only claim once.`,
+  input: z.object({
+    marketId: solPubkey.describe('Cancelled market public key'),
+  }),
+  output: z.object({
+    signature: z.string(),
+    explorerUrl: z.string(),
+  }),
+  price: process.env.DEFAULT_PRICE || undefined,
+  handler: async (ctx) => {
+    const sig = await baozi.claimRefund({ marketPubkey: ctx.input.marketId });
+    return {
+      output: {
+        signature: sig,
+        explorerUrl: `https://solscan.io/tx/${sig}`,
       },
       usage: { total_tokens: 0 },
     };

--- a/packages/cli/templates/prediction-market-agent/template.json
+++ b/packages/cli/templates/prediction-market-agent/template.json
@@ -1,0 +1,66 @@
+{
+  "id": "prediction-market-agent",
+  "name": "Prediction Market Agent",
+  "description": "Agent that reads and trades on-chain Solana prediction markets (Baozi)",
+  "adapters": ["hono", "express"],
+  "package": {
+    "dependencies": {
+      "@solana/web3.js": "^1.98.0",
+      "bs58": "^6.0.0"
+    }
+  },
+  "wizard": {
+    "prompts": [
+      {
+        "key": "AGENT_DESCRIPTION",
+        "type": "input",
+        "message": "How would you describe your prediction market agent?",
+        "defaultValue": "Prediction market data and trading agent"
+      },
+      {
+        "key": "AGENT_VERSION",
+        "type": "input",
+        "message": "What version should the agent start at?",
+        "defaultValue": "0.1.0"
+      },
+      {
+        "key": "SOLANA_RPC_URL",
+        "type": "input",
+        "message": "Solana RPC URL?",
+        "defaultValue": "https://api.mainnet-beta.solana.com"
+      },
+      {
+        "key": "ENABLE_TRADING",
+        "type": "confirm",
+        "message": "Enable betting/trading? (requires wallet private key)",
+        "defaultValue": false
+      },
+      {
+        "key": "SOLANA_PRIVATE_KEY",
+        "type": "input",
+        "message": "Solana wallet private key (base58)?",
+        "defaultValue": "",
+        "when": {
+          "key": "ENABLE_TRADING",
+          "equals": true
+        }
+      },
+      {
+        "key": "ENABLE_PAYMENTS",
+        "type": "confirm",
+        "message": "Enable x402 payments for entrypoints?",
+        "defaultValue": false
+      },
+      {
+        "key": "DEFAULT_PRICE",
+        "type": "input",
+        "message": "Default price per call (in base units)?",
+        "defaultValue": "1000",
+        "when": {
+          "key": "ENABLE_PAYMENTS",
+          "equals": true
+        }
+      }
+    ]
+  }
+}

--- a/packages/cli/templates/prediction-market-agent/template.schema.json
+++ b/packages/cli/templates/prediction-market-agent/template.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Prediction Market Agent Template Arguments",
+  "type": "object",
+  "properties": {
+    "AGENT_DESCRIPTION": {
+      "type": "string",
+      "description": "Description of the prediction market agent"
+    },
+    "AGENT_VERSION": {
+      "type": "string",
+      "description": "Version number for the agent",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "SOLANA_RPC_URL": {
+      "type": "string",
+      "format": "uri",
+      "description": "Solana RPC endpoint URL",
+      "default": "https://api.mainnet-beta.solana.com"
+    },
+    "ENABLE_TRADING": {
+      "type": "boolean",
+      "description": "Enable betting/trading functionality (requires wallet key)",
+      "default": false
+    },
+    "SOLANA_PRIVATE_KEY": {
+      "type": "string",
+      "description": "Base58-encoded Solana wallet private key for trading"
+    },
+    "ENABLE_PAYMENTS": {
+      "type": "boolean",
+      "description": "Enable x402 payments for entrypoints",
+      "default": false
+    },
+    "DEFAULT_PRICE": {
+      "type": "string",
+      "description": "Default price per entrypoint call in base units",
+      "default": "1000"
+    }
+  },
+  "required": ["AGENT_DESCRIPTION", "AGENT_VERSION"]
+}


### PR DESCRIPTION
## Summary

- New CLI template `prediction-market-agent` for building AI agents that read and trade on-chain Solana prediction markets via the [Baozi](https://baozi.bet) protocol
- 5 typed entrypoints: `getMarkets`, `getMarketOdds`, `getPortfolio`, `placeBet`, `analyzeMarket`
- Self-contained Borsh deserialization — reads market data directly from Solana blockchain, zero backend/API dependency
- Supports both boolean (YES/NO) and race (multi-outcome, 2-10) pari-mutuel markets
- Optional wallet-based trading, x402 payment gating, and AI analysis features via wizard prompts
- Modeled after `trading-data-agent` / `trading-recommendation-agent` templates

## What's included

```
packages/cli/templates/prediction-market-agent/
├── agent.ts.template      # Agent + on-chain client with 5 entrypoints
├── template.json          # CLI wizard (RPC URL, trading toggle, payments)
├── template.schema.json   # JSON Schema for template arguments
├── README.md              # Quick start + testing guide
└── AGENTS.md              # AI implementation guide
```

**On-chain client features:**
- `BorshReader` class for cursor-based binary parsing
- Account discriminator filtering via `getProgramAccounts`
- PDA derivation for config, positions, points
- Pari-mutuel implied probability calculation
- 30-second TTL cache for market list queries
- Raw transaction construction for `place_bet_sol` / `bet_on_race_outcome_sol`

**Dependencies added to scaffolded projects:** `@solana/web3.js`, `bs58`

## Test plan

- [ ] `bun install` resolves
- [ ] `bun run build` compiles (verified locally — all packages pass)
- [ ] Template is auto-discovered by CLI (`loadTemplates` scans directories)
- [ ] Scaffold with hono adapter produces valid TypeScript
- [ ] `getMarkets` returns live on-chain markets against mainnet RPC
- [ ] `getMarketOdds` returns probabilities for a specific market
- [ ] `placeBet` constructs and sends valid Solana transaction (with wallet key)

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new CLI template for a Solana prediction-market agent with interactive prompts and JSON schema; includes a user-facing client to discover markets, view odds, manage positions, place bets, create/cancel markets, and claim refunds.

* **Documentation**
  * Added comprehensive README and implementation guide covering architecture, market types, trading/resolution flows, pari-mutuel pricing rules, entrypoints, examples, troubleshooting, and customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->