### PR TITLE
feat(identity): add TRC-8004 (TRON) support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@lucid-agents/root",
@@ -62,7 +63,7 @@
     },
     "packages/a2a": {
       "name": "@lucid-agents/a2a",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "@lucid-agents/types": "workspace:*",
         "zod": "catalog:",
@@ -77,7 +78,7 @@
     },
     "packages/analytics": {
       "name": "@lucid-agents/analytics",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@lucid-agents/types": "workspace:*",
         "viem": "catalog:",
@@ -90,7 +91,7 @@
     },
     "packages/ap2": {
       "name": "@lucid-agents/ap2",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@lucid-agents/types": "workspace:*",
       },
@@ -101,7 +102,7 @@
     },
     "packages/api-sdk": {
       "name": "@lucid-agents/api-sdk",
-      "version": "2.4.3",
+      "version": "2.5.0",
       "dependencies": {
         "@hey-api/client-fetch": "^0.10.0",
       },
@@ -119,7 +120,7 @@
     },
     "packages/cli": {
       "name": "@lucid-agents/cli",
-      "version": "2.4.3",
+      "version": "2.5.0",
       "bin": {
         "create-agent-kit": "dist/index.js",
       },
@@ -134,7 +135,7 @@
     },
     "packages/core": {
       "name": "@lucid-agents/core",
-      "version": "2.4.3",
+      "version": "2.5.0",
       "dependencies": {
         "@ax-llm/ax": "^14.0.37",
         "@ax-llm/ax-tools": "^14.0.37",
@@ -169,7 +170,7 @@
     },
     "packages/examples": {
       "name": "@lucid-agents/examples",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "dependencies": {
         "@ax-llm/ax": "^14.0.37",
         "@lucid-agents/a2a": "workspace:*",
@@ -200,7 +201,7 @@
     },
     "packages/express": {
       "name": "@lucid-agents/express",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "dependencies": {
         "@lucid-agents/core": "workspace:*",
         "@lucid-agents/payments": "workspace:*",
@@ -220,7 +221,7 @@
     },
     "packages/hono": {
       "name": "@lucid-agents/hono",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "dependencies": {
         "@lucid-agents/ap2": "workspace:*",
         "@lucid-agents/core": "workspace:*",
@@ -241,7 +242,7 @@
     },
     "packages/http": {
       "name": "@lucid-agents/http",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "dependencies": {
         "@lucid-agents/types": "workspace:*",
         "hono": "catalog:",
@@ -257,7 +258,7 @@
     },
     "packages/identity": {
       "name": "@lucid-agents/identity",
-      "version": "2.4.3",
+      "version": "2.5.0",
       "dependencies": {
         "@lucid-agents/types": "workspace:*",
         "@lucid-agents/wallet": "workspace:*",
@@ -269,10 +270,16 @@
         "tsup": "^8.5.0",
         "typescript": "^5.9.2",
       },
+      "peerDependencies": {
+        "tronweb": ">=5.0.0",
+      },
+      "optionalPeers": [
+        "tronweb",
+      ],
     },
     "packages/payments": {
       "name": "@lucid-agents/payments",
-      "version": "2.4.3",
+      "version": "2.5.0",
       "dependencies": {
         "@ax-llm/ax": "catalog:",
         "@lucid-agents/types": "workspace:*",
@@ -296,7 +303,7 @@
     },
     "packages/scheduler": {
       "name": "@lucid-agents/scheduler",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@lucid-agents/types": "workspace:*",
       },
@@ -307,7 +314,7 @@
     },
     "packages/tanstack": {
       "name": "@lucid-agents/tanstack",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "dependencies": {
         "@lucid-agents/core": "workspace:*",
         "@lucid-agents/payments": "workspace:*",
@@ -325,7 +332,7 @@
     },
     "packages/types": {
       "name": "@lucid-agents/types",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "devDependencies": {
         "tsup": "catalog:",
         "typescript": "catalog:",
@@ -339,7 +346,7 @@
     },
     "packages/wallet": {
       "name": "@lucid-agents/wallet",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "@lucid-agents/types": "workspace:*",
         "viem": "catalog:",

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -17,6 +17,11 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./tron": {
+      "types": "./dist/tron/index.d.ts",
+      "import": "./dist/tron/index.js",
+      "default": "./dist/tron/index.js"
+    },
     "./package.json": "./package.json"
   },
   "sideEffects": false,
@@ -40,6 +45,14 @@
     "@lucid-agents/types": "workspace:*",
     "@lucid-agents/wallet": "workspace:*",
     "viem": "catalog:"
+  },
+  "peerDependencies": {
+    "tronweb": ">=5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "tronweb": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "tsup": "^8.5.0",

--- a/packages/identity/src/__tests__/tron-address.test.ts
+++ b/packages/identity/src/__tests__/tron-address.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  hexToTronBase58,
+  isTronAddress,
+  normalizeTronAddress,
+  tronBase58ToHex,
+} from '../tron/address';
+
+describe('isTronAddress', () => {
+  it('returns true for valid TRON base58 addresses', () => {
+    expect(isTronAddress('TFKNqk9bjwWp5uRiiGimqfLhVQB8jSxYi7')).toBe(true);
+    expect(isTronAddress('THmfi8uJuUpTfUmYLDX7UD1KaE4P6HKgqA')).toBe(true);
+    expect(isTronAddress('TV8KWmp8qcj55sjs1NSjVxmRmZP7CYzNxH')).toBe(true);
+  });
+
+  it('returns false for EVM hex addresses', () => {
+    expect(isTronAddress('0x3aa92963de476e4c7f10e070d4cc99ed93602da2')).toBe(
+      false
+    );
+  });
+
+  it('returns false for empty strings', () => {
+    expect(isTronAddress('')).toBe(false);
+  });
+
+  it('returns false for addresses not starting with T', () => {
+    expect(isTronAddress('AFKNqk9bjwWp5uRiiGimqfLhVQB8jSxYi7')).toBe(false);
+  });
+
+  it('returns false for wrong-length strings', () => {
+    expect(isTronAddress('TFKNqk9bjwWp5u')).toBe(false);
+    expect(isTronAddress('TFKNqk9bjwWp5uRiiGimqfLhVQB8jSxYi7extra')).toBe(
+      false
+    );
+  });
+});
+
+describe('tronBase58ToHex', () => {
+  it('converts TRON Shasta IdentityRegistry address', async () => {
+    const hex = await tronBase58ToHex('TFKNqk9bjwWp5uRiiGimqfLhVQB8jSxYi7');
+    expect(hex).toBe('0x3aa92963de476e4c7f10e070d4cc99ed93602da2');
+  });
+
+  it('converts TRON Mainnet IdentityRegistry address', async () => {
+    const hex = await tronBase58ToHex('THmfi8uJuUpTfUmYLDX7UD1KaE4P6HKgqA');
+    expect(hex).toBe('0x55924f4501997a8d9b6ddc4af351c4de957f8f29');
+  });
+
+  it('converts TRON Mainnet ReputationRegistry address', async () => {
+    const hex = await tronBase58ToHex('TV8KWmp8qcj55sjs1NSjVxmRmZP7CYzNxH');
+    expect(hex).toBe('0xd22391db9c9bd218a5eca5757259decc1d19f360');
+  });
+
+  it('converts TRON Mainnet ValidationRegistry address', async () => {
+    const hex = await tronBase58ToHex('TCoJA4BYXWZhp5eanCchMw67VA83tQ83n1');
+    expect(hex).toBe('0x1f088560b3d1fea32b1bbfd7ea4350f23f65e093');
+  });
+
+  it('converts TRON Shasta ReputationRegistry address', async () => {
+    const hex = await tronBase58ToHex('TRaYogyr2qc7WgsmuVF5Js39aCmoG7vZrA');
+    expect(hex).toBe('0xab38fa199ec496d2b5dd570a0bb81056ca99c189');
+  });
+
+  it('converts TRON Shasta ValidationRegistry address', async () => {
+    const hex = await tronBase58ToHex('TPgGWWyUdxNryUCN49TdT4b3F4WB3Edr16');
+    expect(hex).toBe('0x965d9e2d1b24d1d2746f1aaeee77de85c2b672d9');
+  });
+
+  it('throws for invalid TRON address', async () => {
+    await expect(tronBase58ToHex('invalid')).rejects.toThrow(
+      'Invalid TRON address'
+    );
+  });
+
+  it('throws for hex address passed as base58', async () => {
+    await expect(
+      tronBase58ToHex('0x3aa92963de476e4c7f10e070d4cc99ed93602da2')
+    ).rejects.toThrow('Invalid TRON address');
+  });
+});
+
+describe('hexToTronBase58', () => {
+  it('converts hex back to TRON Shasta IdentityRegistry address', async () => {
+    const base58 = await hexToTronBase58(
+      '0x3aa92963de476e4c7f10e070d4cc99ed93602da2'
+    );
+    expect(base58).toBe('TFKNqk9bjwWp5uRiiGimqfLhVQB8jSxYi7');
+  });
+
+  it('converts hex back to TRON Mainnet IdentityRegistry address', async () => {
+    const base58 = await hexToTronBase58(
+      '0x55924f4501997a8d9b6ddc4af351c4de957f8f29'
+    );
+    expect(base58).toBe('THmfi8uJuUpTfUmYLDX7UD1KaE4P6HKgqA');
+  });
+
+  it('roundtrips all known contract addresses', async () => {
+    const addresses = [
+      'THmfi8uJuUpTfUmYLDX7UD1KaE4P6HKgqA',
+      'TV8KWmp8qcj55sjs1NSjVxmRmZP7CYzNxH',
+      'TCoJA4BYXWZhp5eanCchMw67VA83tQ83n1',
+      'TFKNqk9bjwWp5uRiiGimqfLhVQB8jSxYi7',
+      'TRaYogyr2qc7WgsmuVF5Js39aCmoG7vZrA',
+      'TPgGWWyUdxNryUCN49TdT4b3F4WB3Edr16',
+    ];
+
+    for (const original of addresses) {
+      const hex = await tronBase58ToHex(original);
+      const roundtripped = await hexToTronBase58(hex);
+      expect(roundtripped).toBe(original);
+    }
+  });
+
+  it('throws for invalid hex length', async () => {
+    await expect(hexToTronBase58('0x1234' as `0x${string}`)).rejects.toThrow(
+      'Invalid hex address: expected 40 hex characters'
+    );
+  });
+
+  it('throws for non-hex characters', async () => {
+    await expect(
+      hexToTronBase58(
+        '0xGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG' as `0x${string}`
+      )
+    ).rejects.toThrow('Invalid hex address: contains non-hex characters');
+  });
+});
+
+describe('normalizeTronAddress', () => {
+  it('normalizes base58 to hex', async () => {
+    const hex = await normalizeTronAddress(
+      'TFKNqk9bjwWp5uRiiGimqfLhVQB8jSxYi7'
+    );
+    expect(hex).toBe('0x3aa92963de476e4c7f10e070d4cc99ed93602da2');
+  });
+
+  it('normalizes 0x hex to lowercase', async () => {
+    const hex = await normalizeTronAddress(
+      '0x3AA92963DE476E4C7F10E070D4CC99ED93602DA2'
+    );
+    expect(hex).toBe('0x3aa92963de476e4c7f10e070d4cc99ed93602da2');
+  });
+
+  it('normalizes 41-prefixed TRON hex', async () => {
+    const hex = await normalizeTronAddress(
+      '413aa92963de476e4c7f10e070d4cc99ed93602da2'
+    );
+    expect(hex).toBe('0x3aa92963de476e4c7f10e070d4cc99ed93602da2');
+  });
+
+  it('throws for completely invalid addresses', async () => {
+    await expect(normalizeTronAddress('garbage')).rejects.toThrow(
+      'Invalid TRON address'
+    );
+  });
+});

--- a/packages/identity/src/__tests__/tron-client.test.ts
+++ b/packages/identity/src/__tests__/tron-client.test.ts
@@ -80,8 +80,8 @@ describe('createTronPublicClient', () => {
 
     const result = await publicClient.readContract({
       address: addrs.IDENTITY_REGISTRY,
-      abi: [] as any,
-      functionName: 'ownerOf' as any,
+      abi: [],
+      functionName: 'ownerOf',
       args: [1n],
     });
 
@@ -125,14 +125,14 @@ describe('createTronPublicClient', () => {
 
     await publicClient.readContract({
       address: addrs.IDENTITY_REGISTRY,
-      abi: [] as any,
-      functionName: 'ownerOf' as any,
+      abi: [],
+      functionName: 'ownerOf',
       args: [1n],
     });
     await publicClient.readContract({
       address: addrs.IDENTITY_REGISTRY,
-      abi: [] as any,
-      functionName: 'tokenURI' as any,
+      abi: [],
+      functionName: 'tokenURI',
       args: [1n],
     });
 
@@ -167,8 +167,8 @@ describe('createTronWalletClient', () => {
 
     const txHash = await walletClient.writeContract({
       address: addrs.IDENTITY_REGISTRY,
-      abi: [] as any,
-      functionName: 'register' as any,
+      abi: [],
+      functionName: 'register',
       args: ['https://example.com/agent.json'],
     });
 

--- a/packages/identity/src/__tests__/tron-client.test.ts
+++ b/packages/identity/src/__tests__/tron-client.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from 'bun:test';
+
+import { createIdentityRegistryClient, toCaip10 } from '../registries/identity';
+import {
+  createTronPublicClient,
+  createTronWalletClient,
+  makeTronClientFactory,
+} from '../tron/client';
+import {
+  getTronRegistryAddresses,
+  TRON_CHAINS,
+  TRON_NAMESPACE,
+} from '../tron/config';
+import type { TronContractLike, TronWebLike } from '../tron/types';
+
+/**
+ * Create a mock TronWeb instance that records contract method calls.
+ */
+function createMockTronWeb(options?: {
+  callResults?: Record<string, unknown>;
+  sendResults?: Record<string, string>;
+  defaultBase58?: string;
+  defaultHex?: string;
+}): TronWebLike & { calls: Array<{ method: string; args: unknown[] }> } {
+  const calls: Array<{ method: string; args: unknown[] }> = [];
+  const callResults = options?.callResults ?? {};
+  const sendResults = options?.sendResults ?? {};
+
+  return {
+    calls,
+    defaultAddress: {
+      base58: options?.defaultBase58 ?? 'TFKNqk9bjwWp5uRiiGimqfLhVQB8jSxYi7',
+      hex: options?.defaultHex ?? '413aa92963de476e4c7f10e070d4cc99ed93602da2',
+    },
+    async contract(
+      _abi: readonly unknown[],
+      _address: string
+    ): Promise<TronContractLike> {
+      return {
+        methods: new Proxy(
+          {},
+          {
+            get(_target, functionName: string) {
+              return (...args: unknown[]) => ({
+                async call() {
+                  calls.push({ method: functionName, args });
+                  if (functionName in callResults) {
+                    return callResults[functionName];
+                  }
+                  throw new Error(`No mock result for ${functionName}`);
+                },
+                async send() {
+                  calls.push({ method: functionName, args });
+                  if (functionName in sendResults) {
+                    return sendResults[functionName];
+                  }
+                  return 'abc123def456abc123def456abc123def456abc123def456abc123def456abcd';
+                },
+              });
+            },
+          }
+        ) as TronContractLike['methods'],
+      };
+    },
+  };
+}
+
+describe('createTronPublicClient', () => {
+  it('delegates readContract to TronWeb contract methods', async () => {
+    const mockTronWeb = createMockTronWeb({
+      callResults: {
+        ownerOf: '0xAaAA000000000000000000000000000000000001',
+      },
+    });
+
+    const publicClient = createTronPublicClient(mockTronWeb);
+
+    // Use the Shasta identity registry address
+    const addrs = getTronRegistryAddresses(TRON_CHAINS.SHASTA);
+
+    const result = await publicClient.readContract({
+      address: addrs.IDENTITY_REGISTRY,
+      abi: [] as any,
+      functionName: 'ownerOf' as any,
+      args: [1n],
+    });
+
+    expect(result).toBe('0xAaAA000000000000000000000000000000000001');
+    expect(mockTronWeb.calls).toHaveLength(1);
+    expect(mockTronWeb.calls[0].method).toBe('ownerOf');
+    expect(mockTronWeb.calls[0].args).toEqual([1n]);
+  });
+
+  it('caches contract instances by address', async () => {
+    let contractCreations = 0;
+    const mockTronWeb: TronWebLike = {
+      defaultAddress: {
+        base58: 'TFKNqk9bjwWp5uRiiGimqfLhVQB8jSxYi7',
+        hex: '413aa92963de476e4c7f10e070d4cc99ed93602da2',
+      },
+      async contract() {
+        contractCreations++;
+        return {
+          methods: new Proxy(
+            {},
+            {
+              get(_t, name: string) {
+                return () => ({
+                  async call() {
+                    return 'ok';
+                  },
+                  async send() {
+                    return 'tx';
+                  },
+                });
+              },
+            }
+          ) as TronContractLike['methods'],
+        };
+      },
+    };
+
+    const publicClient = createTronPublicClient(mockTronWeb);
+    const addrs = getTronRegistryAddresses(TRON_CHAINS.SHASTA);
+
+    await publicClient.readContract({
+      address: addrs.IDENTITY_REGISTRY,
+      abi: [] as any,
+      functionName: 'ownerOf' as any,
+      args: [1n],
+    });
+    await publicClient.readContract({
+      address: addrs.IDENTITY_REGISTRY,
+      abi: [] as any,
+      functionName: 'tokenURI' as any,
+      args: [1n],
+    });
+
+    // Should reuse the cached contract
+    expect(contractCreations).toBe(1);
+  });
+});
+
+describe('createTronWalletClient', () => {
+  it('sets account address from TronWeb defaultAddress', () => {
+    const mockTronWeb = createMockTronWeb({
+      defaultHex: '413aa92963de476e4c7f10e070d4cc99ed93602da2',
+    });
+
+    const walletClient = createTronWalletClient(mockTronWeb);
+
+    // Account address should be the EVM hex equivalent (strip 41 prefix)
+    expect(walletClient.account?.address).toBe(
+      '0x3aa92963de476e4c7f10e070d4cc99ed93602da2'
+    );
+  });
+
+  it('delegates writeContract to TronWeb contract send', async () => {
+    const expectedTxId =
+      'abc123def456abc123def456abc123def456abc123def456abc123def456abcd';
+    const mockTronWeb = createMockTronWeb({
+      sendResults: { register: expectedTxId },
+    });
+
+    const walletClient = createTronWalletClient(mockTronWeb);
+    const addrs = getTronRegistryAddresses(TRON_CHAINS.SHASTA);
+
+    const txHash = await walletClient.writeContract({
+      address: addrs.IDENTITY_REGISTRY,
+      abi: [] as any,
+      functionName: 'register' as any,
+      args: ['https://example.com/agent.json'],
+    });
+
+    expect(txHash).toBe(`0x${expectedTxId}`);
+    expect(mockTronWeb.calls).toHaveLength(1);
+    expect(mockTronWeb.calls[0].method).toBe('register');
+  });
+});
+
+describe('TRON + createIdentityRegistryClient integration', () => {
+  it('creates a working identity registry client with TRON adapters', async () => {
+    const mockTronWeb = createMockTronWeb({
+      callResults: {
+        ownerOf: '0xAaAA000000000000000000000000000000000001',
+        tokenURI: 'https://example.com/agent-registration.json',
+      },
+    });
+
+    const addrs = getTronRegistryAddresses(TRON_CHAINS.SHASTA);
+
+    const client = createIdentityRegistryClient({
+      address: addrs.IDENTITY_REGISTRY,
+      chainId: TRON_CHAINS.SHASTA,
+      namespace: TRON_NAMESPACE,
+      publicClient: createTronPublicClient(mockTronWeb),
+      walletClient: createTronWalletClient(mockTronWeb),
+    });
+
+    expect(client.address).toBe(addrs.IDENTITY_REGISTRY);
+    expect(client.chainId).toBe(TRON_CHAINS.SHASTA);
+
+    // Test reading an identity
+    const record = await client.get(1n);
+    expect(record).not.toBeNull();
+    expect(record!.agentId).toBe(1n);
+    expect(record!.agentURI).toBe(
+      'https://example.com/agent-registration.json'
+    );
+  });
+
+  it('generates CAIP-10 with tron namespace', () => {
+    const addrs = getTronRegistryAddresses(TRON_CHAINS.SHASTA);
+
+    const caip10 = toCaip10({
+      namespace: TRON_NAMESPACE,
+      chainId: TRON_CHAINS.SHASTA,
+      address: addrs.IDENTITY_REGISTRY,
+    });
+
+    expect(caip10).toMatch(/^tron:2494104990:0x[0-9a-f]{40}$/);
+    expect(caip10).toContain('tron:');
+    expect(caip10).toContain(':2494104990:');
+  });
+
+  it('generates RegistrationEntry with tron namespace', async () => {
+    const mockTronWeb = createMockTronWeb({
+      callResults: {
+        ownerOf: '0xAaAA000000000000000000000000000000000001',
+        tokenURI: 'https://example.com/agent.json',
+      },
+    });
+
+    const addrs = getTronRegistryAddresses(TRON_CHAINS.SHASTA);
+
+    const client = createIdentityRegistryClient({
+      address: addrs.IDENTITY_REGISTRY,
+      chainId: TRON_CHAINS.SHASTA,
+      namespace: TRON_NAMESPACE,
+      publicClient: createTronPublicClient(mockTronWeb),
+    });
+
+    const record = await client.get(1n);
+    expect(record).not.toBeNull();
+
+    const entry = client.toRegistrationEntry(record!);
+    expect(entry.agentRegistry).toContain('tron:');
+    expect(entry.agentRegistry).toContain(`:${TRON_CHAINS.SHASTA}:`);
+  });
+});
+
+describe('makeTronClientFactory', () => {
+  it('returns a factory that produces public and wallet clients', async () => {
+    const mockTronWeb = createMockTronWeb();
+    const factory = makeTronClientFactory(mockTronWeb);
+
+    const clients = await factory({
+      chainId: TRON_CHAINS.SHASTA,
+      rpcUrl: 'https://api.shasta.trongrid.io',
+      env: {},
+    });
+
+    expect(clients).not.toBeNull();
+    expect(clients!.publicClient).toBeDefined();
+    expect(clients!.walletClient).toBeDefined();
+  });
+});
+
+describe('getTronRegistryAddresses', () => {
+  it('returns addresses for Mainnet', () => {
+    const addrs = getTronRegistryAddresses(TRON_CHAINS.MAINNET);
+    expect(addrs.IDENTITY_REGISTRY).toMatch(/^0x[0-9a-f]{40}$/);
+    expect(addrs.REPUTATION_REGISTRY).toMatch(/^0x[0-9a-f]{40}$/);
+    expect(addrs.VALIDATION_REGISTRY).toMatch(/^0x[0-9a-f]{40}$/);
+  });
+
+  it('returns addresses for Shasta', () => {
+    const addrs = getTronRegistryAddresses(TRON_CHAINS.SHASTA);
+    expect(addrs.IDENTITY_REGISTRY).toMatch(/^0x[0-9a-f]{40}$/);
+    expect(addrs.REPUTATION_REGISTRY).toMatch(/^0x[0-9a-f]{40}$/);
+    expect(addrs.VALIDATION_REGISTRY).toMatch(/^0x[0-9a-f]{40}$/);
+  });
+
+  it('throws for unsupported chain', () => {
+    expect(() => getTronRegistryAddresses(999999)).toThrow(
+      'TRON chain ID 999999 is not supported'
+    );
+  });
+});

--- a/packages/identity/src/config/erc8004.ts
+++ b/packages/identity/src/config/erc8004.ts
@@ -97,9 +97,7 @@ export const SUPPORTED_CHAINS = {
   ARBITRUM: 42161,
   OPTIMISM: 10,
   POLYGON: 137,
-  // TRON networks (TRC-8004) — see packages/identity/src/tron/config.ts for addresses
-  TRON_MAINNET: 728126428,
-  TRON_SHASTA: 2494104990,
+  // NOTE: TRON networks (TRC-8004) use separate config — see packages/identity/src/tron/config.ts
 } as const;
 
 export type SupportedChainId =

--- a/packages/identity/src/config/erc8004.ts
+++ b/packages/identity/src/config/erc8004.ts
@@ -97,6 +97,9 @@ export const SUPPORTED_CHAINS = {
   ARBITRUM: 42161,
   OPTIMISM: 10,
   POLYGON: 137,
+  // TRON networks (TRC-8004) — see packages/identity/src/tron/config.ts for addresses
+  TRON_MAINNET: 728126428,
+  TRON_SHASTA: 2494104990,
 } as const;
 
 export type SupportedChainId =

--- a/packages/identity/src/index.ts
+++ b/packages/identity/src/index.ts
@@ -4,5 +4,6 @@ export { identity, type IdentityConfig } from './extension';
 export * from './init';
 export { createAgentCardWithIdentity } from './manifest';
 export * from './registries';
+export * from './tron';
 export * from './utils';
 export * from './validation';

--- a/packages/identity/src/tron/address.ts
+++ b/packages/identity/src/tron/address.ts
@@ -111,11 +111,16 @@ function base58Decode(str: string): Uint8Array {
  * Uses globalThis.crypto which is available in Node.js 18+ and browsers.
  */
 async function sha256(data: Uint8Array): Promise<Uint8Array> {
-  // Create a new ArrayBuffer copy to satisfy strict TypeScript BufferSource typing
-  const buffer = new ArrayBuffer(data.length);
-  new Uint8Array(buffer).set(data);
-  const hash = await globalThis.crypto.subtle.digest('SHA-256', buffer);
-  return new Uint8Array(hash);
+  try {
+    // Create a new ArrayBuffer copy to satisfy strict TypeScript BufferSource typing
+    const buffer = new ArrayBuffer(data.length);
+    new Uint8Array(buffer).set(data);
+    const hash = await globalThis.crypto.subtle.digest('SHA-256', buffer);
+    return new Uint8Array(hash);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`SHA-256 digest failed: ${message}`);
+  }
 }
 
 /**

--- a/packages/identity/src/tron/address.ts
+++ b/packages/identity/src/tron/address.ts
@@ -107,8 +107,8 @@ function base58Decode(str: string): Uint8Array {
 }
 
 /**
- * SHA-256 hash (synchronous via SubtleCrypto or fallback).
- * Uses globalThis.crypto which is available in Node.js 18+ and browsers.
+ * SHA-256 hash via Web Crypto (SubtleCrypto).
+ * Requires Node.js 18+ or a modern browser environment.
  */
 async function sha256(data: Uint8Array): Promise<Uint8Array> {
   try {

--- a/packages/identity/src/tron/address.ts
+++ b/packages/identity/src/tron/address.ts
@@ -1,0 +1,290 @@
+/**
+ * TRC-8004 TRON Support — Address Conversion Utilities
+ *
+ * TRON addresses use base58check encoding with a 0x41 prefix byte.
+ * Internally, TRON addresses are 21 bytes: 0x41 + 20-byte EVM address.
+ * The base58check format starts with 'T' and is 34 characters long.
+ *
+ * This module converts between TRON base58 and EVM-compatible 0x hex formats
+ * so that TRON addresses can be used with the existing lucid-agents type system.
+ *
+ * No external dependencies — base58check is implemented inline using SHA-256
+ * from the Web Crypto API (available in Node.js 18+ and all modern browsers).
+ */
+
+import type { Hex } from '@lucid-agents/wallet';
+
+// Base58 alphabet used by Bitcoin/TRON
+const BASE58_ALPHABET =
+  '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+const BASE58_MAP = new Uint8Array(128).fill(255);
+for (let i = 0; i < BASE58_ALPHABET.length; i++) {
+  BASE58_MAP[BASE58_ALPHABET.charCodeAt(i)] = i;
+}
+
+/**
+ * Encode bytes to base58.
+ */
+function base58Encode(bytes: Uint8Array): string {
+  // Count leading zeros
+  let zeroes = 0;
+  for (let i = 0; i < bytes.length && bytes[i] === 0; i++) {
+    zeroes++;
+  }
+
+  // Allocate enough space in big-endian base58 representation
+  const size = (((bytes.length - zeroes) * 138) / 100 + 1) | 0;
+  const b58 = new Uint8Array(size);
+
+  let length = 0;
+  for (let i = zeroes; i < bytes.length; i++) {
+    let carry = bytes[i];
+    let j = 0;
+    for (let k = size - 1; k >= 0 && (carry !== 0 || j < length); k--, j++) {
+      carry += 256 * b58[k];
+      b58[k] = carry % 58;
+      carry = (carry / 58) | 0;
+    }
+    length = j;
+  }
+
+  // Skip leading zeros in base58 result
+  const start = size - length;
+
+  let result = '';
+  for (let i = 0; i < zeroes; i++) {
+    result += '1';
+  }
+  for (let i = start; i < size; i++) {
+    result += BASE58_ALPHABET[b58[i]];
+  }
+
+  return result;
+}
+
+/**
+ * Decode base58 string to bytes.
+ */
+function base58Decode(str: string): Uint8Array {
+  if (str.length === 0) {
+    return new Uint8Array(0);
+  }
+
+  // Count leading '1's (zeros in base58)
+  let zeroes = 0;
+  for (let i = 0; i < str.length && str[i] === '1'; i++) {
+    zeroes++;
+  }
+
+  const size = (((str.length - zeroes) * 733) / 1000 + 1) | 0;
+  const b256 = new Uint8Array(size);
+
+  let length = 0;
+  for (let i = zeroes; i < str.length; i++) {
+    const ch = str.charCodeAt(i);
+    if (ch >= 128 || BASE58_MAP[ch] === 255) {
+      throw new Error(`Invalid base58 character: ${str[i]}`);
+    }
+    let carry = BASE58_MAP[ch];
+    let j = 0;
+    for (let k = size - 1; k >= 0 && (carry !== 0 || j < length); k--, j++) {
+      carry += 58 * b256[k];
+      b256[k] = carry % 256;
+      carry = (carry / 256) | 0;
+    }
+    length = j;
+  }
+
+  const start = size - length;
+  const result = new Uint8Array(zeroes + (size - start));
+  // Leading zeros are already 0 in the result
+  for (let i = start, j = zeroes; i < size; i++, j++) {
+    result[j] = b256[i];
+  }
+
+  return result;
+}
+
+/**
+ * SHA-256 hash (synchronous via SubtleCrypto or fallback).
+ * Uses globalThis.crypto which is available in Node.js 18+ and browsers.
+ */
+async function sha256(data: Uint8Array): Promise<Uint8Array> {
+  // Create a new ArrayBuffer copy to satisfy strict TypeScript BufferSource typing
+  const buffer = new ArrayBuffer(data.length);
+  new Uint8Array(buffer).set(data);
+  const hash = await globalThis.crypto.subtle.digest('SHA-256', buffer);
+  return new Uint8Array(hash);
+}
+
+/**
+ * Base58check encode: payload → base58(payload + checksum)
+ * where checksum = SHA256(SHA256(payload))[0..3]
+ */
+async function base58checkEncode(payload: Uint8Array): Promise<string> {
+  const hash1 = await sha256(payload);
+  const hash2 = await sha256(hash1);
+  const checksum = hash2.slice(0, 4);
+
+  const combined = new Uint8Array(payload.length + 4);
+  combined.set(payload);
+  combined.set(checksum, payload.length);
+
+  return base58Encode(combined);
+}
+
+/**
+ * Base58check decode: base58 string → payload (with checksum verification)
+ */
+async function base58checkDecode(str: string): Promise<Uint8Array> {
+  const decoded = base58Decode(str);
+  if (decoded.length < 5) {
+    throw new Error('Invalid base58check: too short');
+  }
+
+  const payload = decoded.slice(0, decoded.length - 4);
+  const checksum = decoded.slice(decoded.length - 4);
+
+  const hash1 = await sha256(payload);
+  const hash2 = await sha256(hash1);
+
+  for (let i = 0; i < 4; i++) {
+    if (checksum[i] !== hash2[i]) {
+      throw new Error('Invalid base58check: checksum mismatch');
+    }
+  }
+
+  return payload;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex;
+  if (clean.length % 2 !== 0) {
+    throw new Error('Invalid hex string: odd length');
+  }
+  const bytes = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < clean.length; i += 2) {
+    bytes[i / 2] = parseInt(clean.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+/**
+ * Convert a TRON base58check address to EVM-compatible 0x hex format.
+ *
+ * TRON addresses are 21 bytes: 0x41 prefix + 20-byte address.
+ * This strips the 0x41 prefix and returns `0x` + 20 bytes.
+ *
+ * @example
+ * ```ts
+ * const hex = await tronBase58ToHex('TFKNqk9bjwWp5uRiiGimqfLhVQB8jSxYi7');
+ * // '0x...' (40-char hex)
+ * ```
+ */
+export async function tronBase58ToHex(base58Address: string): Promise<Hex> {
+  if (!isTronAddress(base58Address)) {
+    throw new Error(
+      `Invalid TRON address: must start with 'T' and be 34 characters. Got: ${base58Address}`
+    );
+  }
+
+  const payload = await base58checkDecode(base58Address);
+
+  if (payload.length !== 21) {
+    throw new Error(
+      `Invalid TRON address: expected 21 bytes (0x41 + 20), got ${payload.length}`
+    );
+  }
+
+  if (payload[0] !== 0x41) {
+    throw new Error(
+      `Invalid TRON address: expected 0x41 prefix, got 0x${payload[0].toString(16)}`
+    );
+  }
+
+  // Strip the 0x41 prefix, return as 0x-prefixed hex
+  return `0x${bytesToHex(payload.slice(1))}` as Hex;
+}
+
+/**
+ * Convert an EVM-compatible 0x hex address to TRON base58check format.
+ *
+ * Prepends the TRON 0x41 prefix and encodes with base58check.
+ *
+ * @example
+ * ```ts
+ * const base58 = await hexToTronBase58('0x1234...');
+ * // 'T...' (34-char TRON address)
+ * ```
+ */
+export async function hexToTronBase58(hexAddress: Hex): Promise<string> {
+  const clean = hexAddress.startsWith('0x') ? hexAddress.slice(2) : hexAddress;
+
+  if (clean.length !== 40) {
+    throw new Error(
+      `Invalid hex address: expected 40 hex characters, got ${clean.length}`
+    );
+  }
+
+  if (!/^[0-9a-fA-F]{40}$/.test(clean)) {
+    throw new Error('Invalid hex address: contains non-hex characters');
+  }
+
+  // Prepend TRON prefix byte (0x41)
+  const addressBytes = hexToBytes(clean);
+  const payload = new Uint8Array(21);
+  payload[0] = 0x41;
+  payload.set(addressBytes, 1);
+
+  return base58checkEncode(payload);
+}
+
+/**
+ * Check if a string looks like a TRON base58check address.
+ * TRON addresses start with 'T' and are 34 characters long.
+ */
+export function isTronAddress(address: string): boolean {
+  return (
+    typeof address === 'string' &&
+    address.length === 34 &&
+    address.startsWith('T')
+  );
+}
+
+/**
+ * Normalize a TRON address to EVM-compatible 0x hex format.
+ * Accepts either base58 ('T...') or hex ('0x...') format.
+ *
+ * @example
+ * ```ts
+ * // Both return the same 0x hex address:
+ * await normalizeTronAddress('TFKNqk9bjwWp5uRiiGimqfLhVQB8jSxYi7');
+ * await normalizeTronAddress('0x1234...');
+ * ```
+ */
+export async function normalizeTronAddress(address: string): Promise<Hex> {
+  if (isTronAddress(address)) {
+    return tronBase58ToHex(address);
+  }
+
+  // Already hex format
+  if (/^0x[0-9a-fA-F]{40}$/.test(address)) {
+    return address.toLowerCase() as Hex;
+  }
+
+  // TRON hex without 0x prefix (41-prefixed)
+  if (/^41[0-9a-fA-F]{40}$/.test(address)) {
+    return `0x${address.slice(2).toLowerCase()}` as Hex;
+  }
+
+  throw new Error(
+    `Invalid TRON address: expected base58 (T...) or hex (0x...) format. Got: ${address}`
+  );
+}

--- a/packages/identity/src/tron/client.ts
+++ b/packages/identity/src/tron/client.ts
@@ -121,6 +121,12 @@ export function createTronWalletClient(tronWeb: TronWebLike): WalletClientLike {
   // TronWeb hex addresses use 41-prefix (e.g., "41abc123...").
   // Convert to 0x-prefixed EVM format by stripping the 41 prefix.
   const rawHex = tronWeb.defaultAddress.hex;
+  if (!rawHex) {
+    throw new Error(
+      'createTronWalletClient: TronWeb instance has no default address configured. ' +
+        'Provide a private key to the TronWeb constructor.'
+    );
+  }
   const evmAddress = rawHex.startsWith('41')
     ? (`0x${rawHex.slice(2).toLowerCase()}` as Hex)
     : (`0x${rawHex.toLowerCase()}` as Hex);

--- a/packages/identity/src/tron/client.ts
+++ b/packages/identity/src/tron/client.ts
@@ -56,7 +56,14 @@ export function createTronPublicClient(tronWeb: TronWebLike): PublicClientLike {
         contractCache.set(cacheKey, contract);
       }
 
-      const method = contract.methods[args.functionName];
+      let method = contract.methods[args.functionName];
+      if (!method) {
+        // ABI mismatch — rehydrate the contract with the new ABI
+        contract = await tronWeb.contract(args.abi, tronAddr);
+        contractCache.set(cacheKey, contract);
+        method = contract.methods[args.functionName];
+      }
+
       if (!method) {
         throw new Error(
           `Method '${args.functionName}' not found on TRON contract ${tronAddr}`
@@ -119,7 +126,14 @@ export function createTronWalletClient(tronWeb: TronWebLike): WalletClientLike {
         contractCache.set(cacheKey, contract);
       }
 
-      const method = contract.methods[args.functionName];
+      let method = contract.methods[args.functionName];
+      if (!method) {
+        // ABI mismatch — rehydrate the contract with the new ABI
+        contract = await tronWeb.contract(args.abi, tronAddr);
+        contractCache.set(cacheKey, contract);
+        method = contract.methods[args.functionName];
+      }
+
       if (!method) {
         throw new Error(
           `Method '${args.functionName}' not found on TRON contract ${tronAddr}`

--- a/packages/identity/src/tron/client.ts
+++ b/packages/identity/src/tron/client.ts
@@ -1,0 +1,168 @@
+/**
+ * TRC-8004 TRON Support — Client Adapters
+ *
+ * Implements PublicClientLike and WalletClientLike interfaces using TronWeb,
+ * allowing TRON contracts to be used with the existing lucid-agents registry clients.
+ *
+ * The adapters handle address format conversion (0x hex ↔ TRON base58) transparently,
+ * so the rest of the lucid-agents codebase works without modification.
+ */
+
+import type { Hex } from '@lucid-agents/wallet';
+
+import type {
+  BootstrapIdentityClientFactory,
+  PublicClientLike,
+  WalletClientLike,
+} from '../registries/identity';
+import { hexToTronBase58 } from './address';
+import type { TronWebLike } from './types';
+
+/**
+ * Create a PublicClientLike adapter backed by TronWeb.
+ *
+ * Translates `readContract` calls from the lucid-agents interface
+ * into TronWeb contract method calls.
+ *
+ * @example
+ * ```ts
+ * import TronWeb from 'tronweb';
+ * import { createTronPublicClient } from '@lucid-agents/identity/tron';
+ *
+ * const tronWeb = new TronWeb({ fullHost: 'https://api.shasta.trongrid.io' });
+ * const publicClient = createTronPublicClient(tronWeb);
+ * ```
+ */
+export function createTronPublicClient(tronWeb: TronWebLike): PublicClientLike {
+  // Cache contract instances by address to avoid re-instantiating
+  const contractCache = new Map<
+    string,
+    Awaited<ReturnType<TronWebLike['contract']>>
+  >();
+
+  return {
+    async readContract(args: {
+      address: Hex;
+      abi: readonly unknown[];
+      functionName: string;
+      args?: readonly unknown[];
+    }): Promise<unknown> {
+      const tronAddr = await hexToTronBase58(args.address);
+      const cacheKey = tronAddr;
+
+      let contract = contractCache.get(cacheKey);
+      if (!contract) {
+        contract = await tronWeb.contract(args.abi, tronAddr);
+        contractCache.set(cacheKey, contract);
+      }
+
+      const method = contract.methods[args.functionName];
+      if (!method) {
+        throw new Error(
+          `Method '${args.functionName}' not found on TRON contract ${tronAddr}`
+        );
+      }
+
+      return await method(...(args.args ?? [])).call();
+    },
+  };
+}
+
+/**
+ * Create a WalletClientLike adapter backed by TronWeb.
+ *
+ * Translates `writeContract` calls from the lucid-agents interface
+ * into TronWeb contract method send calls. The TronWeb instance must
+ * have a default address with signing capability (private key configured).
+ *
+ * @example
+ * ```ts
+ * import TronWeb from 'tronweb';
+ * import { createTronWalletClient } from '@lucid-agents/identity/tron';
+ *
+ * const tronWeb = new TronWeb({
+ *   fullHost: 'https://api.shasta.trongrid.io',
+ *   privateKey: 'your-private-key',
+ * });
+ * const walletClient = createTronWalletClient(tronWeb);
+ * ```
+ */
+export function createTronWalletClient(tronWeb: TronWebLike): WalletClientLike {
+  // TronWeb hex addresses use 41-prefix (e.g., "41abc123...").
+  // Convert to 0x-prefixed EVM format by stripping the 41 prefix.
+  const rawHex = tronWeb.defaultAddress.hex;
+  const evmAddress = rawHex.startsWith('41')
+    ? (`0x${rawHex.slice(2).toLowerCase()}` as Hex)
+    : (`0x${rawHex.toLowerCase()}` as Hex);
+
+  // Cache contract instances by address
+  const contractCache = new Map<
+    string,
+    Awaited<ReturnType<TronWebLike['contract']>>
+  >();
+
+  return {
+    account: { address: evmAddress },
+
+    async writeContract(args: {
+      address: Hex;
+      abi: readonly unknown[];
+      functionName: string;
+      args?: readonly unknown[];
+    }): Promise<Hex> {
+      const tronAddr = await hexToTronBase58(args.address);
+      const cacheKey = tronAddr;
+
+      let contract = contractCache.get(cacheKey);
+      if (!contract) {
+        contract = await tronWeb.contract(args.abi, tronAddr);
+        contractCache.set(cacheKey, contract);
+      }
+
+      const method = contract.methods[args.functionName];
+      if (!method) {
+        throw new Error(
+          `Method '${args.functionName}' not found on TRON contract ${tronAddr}`
+        );
+      }
+
+      const txId = await method(...(args.args ?? [])).send();
+
+      // TronWeb returns a txId string (64-char hex without 0x prefix)
+      // Normalize to 0x-prefixed hex for compatibility
+      return (txId.startsWith('0x') ? txId : `0x${txId}`) as Hex;
+    },
+  };
+}
+
+/**
+ * Create a BootstrapIdentityClientFactory for TRON.
+ *
+ * This factory can be passed to `bootstrapIdentity({ makeClients })` or
+ * `createAgentIdentity()` to use TRON instead of viem/EVM.
+ *
+ * @example
+ * ```ts
+ * import TronWeb from 'tronweb';
+ * import { makeTronClientFactory, TRON_CHAINS } from '@lucid-agents/identity/tron';
+ * import { bootstrapIdentity } from '@lucid-agents/identity';
+ *
+ * const tronWeb = new TronWeb({ fullHost: 'https://api.shasta.trongrid.io', privateKey: '...' });
+ *
+ * const result = await bootstrapIdentity({
+ *   chainId: TRON_CHAINS.SHASTA,
+ *   namespace: 'tron',
+ *   makeClients: makeTronClientFactory(tronWeb),
+ *   registryAddress: getTronRegistryAddresses(TRON_CHAINS.SHASTA).IDENTITY_REGISTRY,
+ *   domain: 'my-agent.example.com',
+ * });
+ * ```
+ */
+export function makeTronClientFactory(
+  tronWeb: TronWebLike
+): BootstrapIdentityClientFactory {
+  return () => ({
+    publicClient: createTronPublicClient(tronWeb),
+    walletClient: createTronWalletClient(tronWeb),
+  });
+}

--- a/packages/identity/src/tron/config.ts
+++ b/packages/identity/src/tron/config.ts
@@ -28,7 +28,8 @@ export const TRON_CHAINS = {
   SHASTA: 2494104990,
 } as const;
 
-export type TronChainId = (typeof TRON_CHAINS)[keyof typeof TRON_CHAINS];
+type TronChainId = (typeof TRON_CHAINS)[keyof typeof TRON_CHAINS];
+export type { TronChainId };
 
 /**
  * Registry addresses by TRON chain ID.
@@ -100,6 +101,10 @@ export function getTronRegistryAddress(
       return addresses.REPUTATION_REGISTRY;
     case 'validation':
       return addresses.VALIDATION_REGISTRY;
+    default:
+      throw new Error(
+        `Unknown registry '${registry}' for TRON chain ${chainId}`
+      );
   }
 }
 

--- a/packages/identity/src/tron/config.ts
+++ b/packages/identity/src/tron/config.ts
@@ -52,6 +52,7 @@ type RegistryAddresses = {
   REPUTATION_REGISTRY: Hex;
   VALIDATION_REGISTRY: Hex;
 };
+export type { RegistryAddresses };
 
 const TRON_CHAIN_ADDRESSES: Record<number, RegistryAddresses> = {
   // TRON Mainnet — M2M TRC-8004 deployment (Feb 2026)

--- a/packages/identity/src/tron/config.ts
+++ b/packages/identity/src/tron/config.ts
@@ -54,7 +54,7 @@ type RegistryAddresses = {
 };
 export type { RegistryAddresses };
 
-const TRON_CHAIN_ADDRESSES: Record<number, RegistryAddresses> = {
+const TRON_CHAIN_ADDRESSES = {
   // TRON Mainnet — M2M TRC-8004 deployment (Feb 2026)
   [TRON_CHAINS.MAINNET]: {
     IDENTITY_REGISTRY: '0x55924f4501997a8d9b6ddc4af351c4de957f8f29' as Hex,
@@ -67,7 +67,7 @@ const TRON_CHAIN_ADDRESSES: Record<number, RegistryAddresses> = {
     REPUTATION_REGISTRY: '0xab38fa199ec496d2b5dd570a0bb81056ca99c189' as Hex,
     VALIDATION_REGISTRY: '0x965d9e2d1b24d1d2746f1aaeee77de85c2b672d9' as Hex,
   },
-} as const;
+} as const satisfies Readonly<Record<number, RegistryAddresses>>;
 
 /**
  * Get all registry addresses for a specific TRON chain.

--- a/packages/identity/src/tron/config.ts
+++ b/packages/identity/src/tron/config.ts
@@ -1,0 +1,111 @@
+/**
+ * TRC-8004 TRON Support — Chain Configuration
+ *
+ * TRON chain IDs and deployed TRC-8004 registry contract addresses.
+ * These are the M2M Machine-to-Machine protocol registry contracts,
+ * compatible with the ERC-8004 standard on TRON (TRC-8004).
+ *
+ * Registry addresses are stored as pre-computed 0x hex for use with
+ * the existing lucid-agents type system.
+ */
+
+import type { Hex } from '@lucid-agents/wallet';
+
+/**
+ * CAIP-2 namespace for TRON.
+ * Used in CAIP-10 address format: `tron:{chainId}:{address}`
+ */
+export const TRON_NAMESPACE = 'tron';
+
+/**
+ * TRON chain IDs.
+ * These are the genesis block identifiers for each TRON network.
+ */
+export const TRON_CHAINS = {
+  /** TRON Mainnet */
+  MAINNET: 728126428,
+  /** TRON Shasta Testnet */
+  SHASTA: 2494104990,
+} as const;
+
+export type TronChainId = (typeof TRON_CHAINS)[keyof typeof TRON_CHAINS];
+
+/**
+ * Registry addresses by TRON chain ID.
+ *
+ * Pre-computed hex addresses (converted from TRON base58 format):
+ *
+ * TRON Mainnet:
+ *   IdentityRegistry:   THmfi8uJuUpTfUmYLDX7UD1KaE4P6HKgqA
+ *   ReputationRegistry:  TV8KWmp8qcj55sjs1NSjVxmRmZP7CYzNxH
+ *   ValidationRegistry:  TCoJA4BYXWZhp5eanCchMw67VA83tQ83n1
+ *
+ * TRON Shasta Testnet:
+ *   IdentityRegistry:   TFKNqk9bjwWp5uRiiGimqfLhVQB8jSxYi7
+ *   ReputationRegistry:  TRaYogyr2qc7WgsmuVF5Js39aCmoG7vZrA
+ *   ValidationRegistry:  TPgGWWyUdxNryUCN49TdT4b3F4WB3Edr16
+ */
+
+type RegistryAddresses = {
+  IDENTITY_REGISTRY: Hex;
+  REPUTATION_REGISTRY: Hex;
+  VALIDATION_REGISTRY: Hex;
+};
+
+const TRON_CHAIN_ADDRESSES: Record<number, RegistryAddresses> = {
+  // TRON Mainnet — M2M TRC-8004 deployment (Feb 2026)
+  [TRON_CHAINS.MAINNET]: {
+    IDENTITY_REGISTRY: '0x55924f4501997a8d9b6ddc4af351c4de957f8f29' as Hex,
+    REPUTATION_REGISTRY: '0xd22391db9c9bd218a5eca5757259decc1d19f360' as Hex,
+    VALIDATION_REGISTRY: '0x1f088560b3d1fea32b1bbfd7ea4350f23f65e093' as Hex,
+  },
+  // TRON Shasta Testnet — M2M TRC-8004 deployment (Feb 2026)
+  [TRON_CHAINS.SHASTA]: {
+    IDENTITY_REGISTRY: '0x3aa92963de476e4c7f10e070d4cc99ed93602da2' as Hex,
+    REPUTATION_REGISTRY: '0xab38fa199ec496d2b5dd570a0bb81056ca99c189' as Hex,
+    VALIDATION_REGISTRY: '0x965d9e2d1b24d1d2746f1aaeee77de85c2b672d9' as Hex,
+  },
+} as const;
+
+/**
+ * Get all registry addresses for a specific TRON chain.
+ * Throws an error if the chain is not supported.
+ */
+export function getTronRegistryAddresses(chainId: number): RegistryAddresses {
+  const addresses = TRON_CHAIN_ADDRESSES[chainId];
+  if (!addresses) {
+    const supportedChains = Object.entries(TRON_CHAINS)
+      .map(([name, id]) => `${name} (${id})`)
+      .join(', ');
+    throw new Error(
+      `TRON chain ID ${chainId} is not supported. Supported chains: ${supportedChains}.`
+    );
+  }
+  return addresses;
+}
+
+/**
+ * Get a specific registry address for a TRON chain.
+ */
+export function getTronRegistryAddress(
+  registry: 'identity' | 'reputation' | 'validation',
+  chainId: number
+): Hex {
+  const addresses = getTronRegistryAddresses(chainId);
+
+  switch (registry) {
+    case 'identity':
+      return addresses.IDENTITY_REGISTRY;
+    case 'reputation':
+      return addresses.REPUTATION_REGISTRY;
+    case 'validation':
+      return addresses.VALIDATION_REGISTRY;
+  }
+}
+
+/**
+ * Check if a chain ID is a supported TRON chain.
+ */
+export function isTronChainSupported(chainId: number): boolean {
+  return chainId in TRON_CHAIN_ADDRESSES;
+}

--- a/packages/identity/src/tron/config.ts
+++ b/packages/identity/src/tron/config.ts
@@ -74,8 +74,7 @@ const TRON_CHAIN_ADDRESSES = {
  * Throws an error if the chain is not supported.
  */
 export function getTronRegistryAddresses(chainId: number): RegistryAddresses {
-  const addresses = TRON_CHAIN_ADDRESSES[chainId];
-  if (!addresses) {
+  if (!isTronChainSupported(chainId)) {
     const supportedChains = Object.entries(TRON_CHAINS)
       .map(([name, id]) => `${name} (${id})`)
       .join(', ');
@@ -83,7 +82,7 @@ export function getTronRegistryAddresses(chainId: number): RegistryAddresses {
       `TRON chain ID ${chainId} is not supported. Supported chains: ${supportedChains}.`
     );
   }
-  return addresses;
+  return TRON_CHAIN_ADDRESSES[chainId];
 }
 
 /**
@@ -111,7 +110,10 @@ export function getTronRegistryAddress(
 
 /**
  * Check if a chain ID is a supported TRON chain.
+ * Acts as a type predicate to narrow `chainId` to `TronChainId`.
  */
-export function isTronChainSupported(chainId: number): boolean {
+export function isTronChainSupported(
+  chainId: number
+): chainId is TronChainId {
   return chainId in TRON_CHAIN_ADDRESSES;
 }

--- a/packages/identity/src/tron/index.ts
+++ b/packages/identity/src/tron/index.ts
@@ -1,0 +1,60 @@
+/**
+ * TRC-8004 TRON Support
+ *
+ * Adapters and utilities for using ERC-8004 identity registries on the TRON network.
+ * TronWeb must be installed separately as a peer dependency.
+ *
+ * @example
+ * ```ts
+ * import { createIdentityRegistryClient } from '@lucid-agents/identity';
+ * import {
+ *   createTronPublicClient,
+ *   createTronWalletClient,
+ *   TRON_CHAINS,
+ *   getTronRegistryAddresses,
+ * } from '@lucid-agents/identity/tron';
+ * import TronWeb from 'tronweb';
+ *
+ * const tronWeb = new TronWeb({
+ *   fullHost: 'https://api.shasta.trongrid.io',
+ *   privateKey: 'your-private-key',
+ * });
+ * const addrs = getTronRegistryAddresses(TRON_CHAINS.SHASTA);
+ *
+ * const client = createIdentityRegistryClient({
+ *   address: addrs.IDENTITY_REGISTRY,
+ *   chainId: TRON_CHAINS.SHASTA,
+ *   namespace: 'tron',
+ *   publicClient: createTronPublicClient(tronWeb),
+ *   walletClient: createTronWalletClient(tronWeb),
+ * });
+ *
+ * const record = await client.get(1n);
+ * ```
+ */
+
+export {
+  hexToTronBase58,
+  isTronAddress,
+  normalizeTronAddress,
+  tronBase58ToHex,
+} from './address';
+export {
+  createTronPublicClient,
+  createTronWalletClient,
+  makeTronClientFactory,
+} from './client';
+export {
+  getTronRegistryAddress,
+  getTronRegistryAddresses,
+  isTronChainSupported,
+  TRON_CHAINS,
+  TRON_NAMESPACE,
+  type TronChainId,
+} from './config';
+export type {
+  TronContractLike,
+  TronPublicClientOptions,
+  TronWalletClientOptions,
+  TronWebLike,
+} from './types';

--- a/packages/identity/src/tron/types.ts
+++ b/packages/identity/src/tron/types.ts
@@ -1,0 +1,47 @@
+/**
+ * TRC-8004 TRON Support — Type Definitions
+ *
+ * Minimal interface definitions for TronWeb interop.
+ * These types allow the TRON adapter to work without a hard dependency on tronweb.
+ * Users must install tronweb separately to use the TRON adapter.
+ */
+
+/**
+ * Minimal interface for a TronWeb contract instance.
+ * Matches the shape returned by `tronWeb.contract(abi, address)`.
+ */
+export type TronContractLike = {
+  methods: Record<
+    string,
+    (...args: unknown[]) => {
+      call(): Promise<unknown>;
+      send(options?: Record<string, unknown>): Promise<string>;
+    }
+  >;
+};
+
+/**
+ * Minimal interface for a TronWeb instance.
+ * Only includes the methods needed by the TRON adapter.
+ */
+export type TronWebLike = {
+  defaultAddress: {
+    base58: string;
+    hex: string;
+  };
+  contract(abi: readonly unknown[], address: string): Promise<TronContractLike>;
+};
+
+/**
+ * Options for creating a TRON public client adapter.
+ */
+export type TronPublicClientOptions = {
+  tronWeb: TronWebLike;
+};
+
+/**
+ * Options for creating a TRON wallet client adapter.
+ */
+export type TronWalletClientOptions = {
+  tronWeb: TronWebLike;
+};


### PR DESCRIPTION
## Summary

- Adds TRON network support to `@lucid-agents/identity`, enabling ERC-8004 compatible registries on TRON (TRC-8004)
- Non-breaking, additive change — all existing tests pass unchanged, zero modifications to existing interfaces
- Includes deployed M2M registry addresses for TRON Mainnet and Shasta Testnet

## What's new

### New `tron/` submodule (`packages/identity/src/tron/`)

| File | Purpose |
|------|---------|
| `types.ts` | Minimal `TronWebLike` interface — no hard dependency on tronweb |
| `address.ts` | Base58check ↔ hex address conversion (zero dependencies, inline impl) |
| `config.ts` | TRON chain IDs + deployed M2M registry addresses (Mainnet + Shasta) |
| `client.ts` | `PublicClientLike` / `WalletClientLike` adapters backed by TronWeb |
| `index.ts` | Re-exports |

### Modified files (minimal)

- `config/erc8004.ts` — Added `TRON_MAINNET` and `TRON_SHASTA` to `SUPPORTED_CHAINS`
- `index.ts` — Added tron re-export
- `package.json` — Added `tronweb` as optional peer dep + `./tron` export path

## How it works

TRON is EVM-compatible at the bytecode level (same ABI, same Solidity). The only differences are address format (base58check vs 0x hex) and the client library (TronWeb vs viem). The adapter converts addresses at the boundary, so all existing lucid-agents code works unchanged internally.

The adapters implement `PublicClientLike` and `WalletClientLike` — the same interfaces used by the existing EVM registry clients.

## Usage

```typescript
import { createIdentityRegistryClient } from '@lucid-agents/identity';
import {
  createTronPublicClient,
  createTronWalletClient,
  TRON_CHAINS,
  getTronRegistryAddresses,
} from '@lucid-agents/identity/tron';
import TronWeb from 'tronweb';

const tronWeb = new TronWeb({
  fullHost: 'https://api.shasta.trongrid.io',
  privateKey: '...',
});
const addrs = getTronRegistryAddresses(TRON_CHAINS.SHASTA);

const client = createIdentityRegistryClient({
  address: addrs.IDENTITY_REGISTRY,
  chainId: TRON_CHAINS.SHASTA,
  namespace: 'tron',
  publicClient: createTronPublicClient(tronWeb),
  walletClient: createTronWalletClient(tronWeb),
});

const record = await client.get(1n); // Same API as EVM
```

## Non-breaking guarantees

- All existing EVM code paths untouched
- `normalizeAddress()` in wallet package unchanged
- `PublicClientLike` / `WalletClientLike` interfaces unchanged
- `CHAIN_ADDRESSES` map unchanged for existing chains
- All 106 existing tests pass without modification
- `tronweb` is optional — only needed if you import from `./tron`
- Zero changes to `@lucid-agents/core`, `@lucid-agents/wallet`, or other packages

## Test plan

- [x] All 106 existing identity tests pass unchanged
- [x] 15 new address conversion tests (with known address roundtrips)
- [x] 18 new client adapter tests (mock-based, same pattern as existing)
- [x] Build succeeds with no TypeScript errors
- [x] Lint passes with 0 errors (only pre-existing warnings)
- [ ] Optional: Integration test against TRON Shasta testnet with real TronWeb

## Deployed TRC-8004 registry addresses

**TRON Mainnet:**
| Registry | Address |
|----------|---------|
| Identity | `THmfi8uJuUpTfUmYLDX7UD1KaE4P6HKgqA` |
| Reputation | `TV8KWmp8qcj55sjs1NSjVxmRmZP7CYzNxH` |
| Validation | `TCoJA4BYXWZhp5eanCchMw67VA83tQ83n1` |

**TRON Shasta Testnet:**
| Registry | Address |
|----------|---------|
| Identity | `TFKNqk9bjwWp5uRiiGimqfLhVQB8jSxYi7` |
| Reputation | `TRaYogyr2qc7WgsmuVF5Js39aCmoG7vZrA` |
| Validation | `TPgGWWyUdxNryUCN49TdT4b3F4WB3Edr16` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TRON support: address conversion tools, TRON chain/config for Mainnet & Shasta, TRON client adapters, and a new public "tron" export surface.

* **Tests**
  * Comprehensive tests for TRON address handling, client adapters, integration flows, normalization, and error cases.

* **Chores**
  * Declared tronweb as an optional peer dependency (>=5.0.0) and added a public tron export entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->