### PR TITLE
feat: add XMPT messaging extension with runtime and types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ This is a TypeScript/Bun monorepo for building, monetizing, and verifying AI age
 - **@lucid-agents/payments** - x402 payment utilities
 - **@lucid-agents/wallet** - Wallet SDK for agent and developer wallets
 - **@lucid-agents/a2a** - A2A Protocol client for agent-to-agent communication
+- **@lucid-agents/xmpt** - XMPT messaging extension for inbox and thread-aware messaging
 - **@lucid-agents/ap2** - AP2 (Agent Payments Protocol) extension
 - **@lucid-agents/hono** - Hono HTTP server adapter
 - **@lucid-agents/express** - Express HTTP server adapter
@@ -37,7 +38,7 @@ hono OR express OR tanstack (adapters)
     ↓ both use
 core (protocol-agnostic runtime)
     ↓ uses extensions
-http, identity, payments, wallet, a2a, ap2 (extensions)
+http, identity, payments, wallet, a2a, xmpt, ap2 (extensions)
 ```
 
 ### Extension System
@@ -49,6 +50,7 @@ The framework uses an extension-based architecture where features are added via 
 - **payments** (`@lucid-agents/payments`) - x402 payment verification and pricing
 - **identity** (`@lucid-agents/identity`) - ERC-8004 on-chain identity and trust
 - **a2a** (`@lucid-agents/a2a`) - Agent-to-agent communication protocol
+- **xmpt** (`@lucid-agents/xmpt`) - Message inbox + send/receive abstraction over A2A tasks
 - **ap2** (`@lucid-agents/ap2`) - Agent Payments Protocol extension
 
 ### Adapter System
@@ -339,6 +341,10 @@ type PaymentsRuntime = {
 │   │   │   ├── extension.ts     # A2A extension
 │   │   │   └── client.ts        # A2A client
 │   │   └── examples/
+│   │
+│   ├── xmpt/               # XMPT messaging extension
+│   │   └── src/
+│   │       └── extension.ts     # XMPT extension
 │   │
 │   ├── ap2/                # AP2 extension
 │   │   └── src/
@@ -885,6 +891,7 @@ When developing changes to packages and testing them in external projects (e.g.,
 **Workflow:**
 
 1. **Register packages globally** - In the lucid-agents monorepo, register the packages you want to link:
+
    ```bash
    cd lucid-agents/packages/types
    bun link
@@ -897,6 +904,7 @@ When developing changes to packages and testing them in external projects (e.g.,
    ```
 
 2. **Update your test project's `package.json`** to use the `link:` protocol:
+
    ```json
    {
      "dependencies": {
@@ -908,12 +916,14 @@ When developing changes to packages and testing them in external projects (e.g.,
    ```
 
 3. **Install dependencies** in your test project:
+
    ```bash
    cd my-test-agent
    bun install
    ```
 
 4. **Make changes** in the linked package:
+
    ```bash
    cd lucid-agents/packages/identity
    # Make your changes to source code
@@ -934,6 +944,7 @@ When developing changes to packages and testing them in external projects (e.g.,
    ```
 
 **How it works:**
+
 - `bun link` registers a package globally by name
 - The `link:@package-name` protocol in package.json references the globally registered package
 - Any changes you make and build in the linked package are immediately available

--- a/README.md
+++ b/README.md
@@ -355,6 +355,45 @@ const result = await agent.a2a.client.invoke(
 );
 ```
 
+#### [`@lucid-agents/xmpt`](packages/xmpt/README.md)
+
+XMPT messaging extension for inbox semantics, thread-aware messaging, and local message observability.
+
+```typescript
+import { createAgent } from '@lucid-agents/core';
+import { a2a } from '@lucid-agents/a2a';
+import { http } from '@lucid-agents/http';
+import { xmpt } from '@lucid-agents/xmpt';
+
+const agent = await createAgent({
+  name: 'my-agent',
+  version: '1.0.0',
+})
+  .use(http())
+  .use(a2a())
+  .use(
+    xmpt({
+      inbox: {
+        handler: async ({ message }) => ({
+          content: { text: `ack:${message.content.text ?? ''}` },
+        }),
+      },
+    })
+  )
+  .build();
+
+const result = await agent.xmpt!.sendAndWait(
+  { url: 'https://other-agent.com' },
+  {
+    threadId: 'thread-123',
+    content: { text: 'hello from xmpt' },
+  }
+);
+
+const messages = await agent.xmpt!.listMessages({ threadId: 'thread-123' });
+console.log(result.task.status, messages.length);
+```
+
 #### [`@lucid-agents/analytics`](packages/analytics/README.md)
 
 Payment analytics and reporting with CSV/JSON export for accounting systems.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ curl -X POST http://localhost:3000/entrypoints/echo/invoke \
 Lucid Agents is a TypeScript monorepo built for protocol-agnostic, multi-runtime agent deployment with a compositional extension architecture:
 
 - **Layer 1: Core** - Protocol-agnostic agent runtime with extension system (`@lucid-agents/core`) - no protocol-specific code
-- **Layer 2: Extensions** - Optional capabilities added via composition: `http()` (HTTP protocol), `payments()` (x402), `wallets()` (wallet management), `identity()` (ERC-8004), `a2a()` (agent-to-agent), `ap2()` (Agent Payments Protocol)
+- **Layer 2: Extensions** - Optional capabilities added via composition: `http()` (HTTP protocol), `payments()` (x402), `wallets()` (wallet management), `identity()` (ERC-8004), `a2a()` (agent-to-agent), `xmpt()` (message inbox + threading), `ap2()` (Agent Payments Protocol)
 - **Layer 3: Adapters** - Framework integrations (hono, tanstack, express, next) that use the HTTP extension
 
 The core runtime is completely protocol-agnostic. Protocols like HTTP are provided as extensions that get merged into the runtime. Future protocols (gRPC, WebSocket, etc.) can be added as additional extensions.
@@ -124,6 +124,7 @@ The core runtime is completely protocol-agnostic. Protocols like HTTP are provid
 - **`@lucid-agents/analytics`** - Payment analytics and reporting with CSV/JSON export for accounting system integration
 - **`@lucid-agents/identity`** - ERC-8004 identity toolkit for onchain agent identity
 - **`@lucid-agents/a2a`** - A2A Protocol client for agent-to-agent communication
+- **`@lucid-agents/xmpt`** - XMPT messaging extension for inbox semantics, send/receive APIs, and thread-aware messaging
 - **`@lucid-agents/ap2`** - AP2 (Agent Payments Protocol) extension for Agent Cards
 - **`@lucid-agents/hono`** - Hono HTTP server adapter
 - **`@lucid-agents/express`** - Express HTTP server adapter

--- a/bun.lock
+++ b/bun.lock
@@ -62,7 +62,7 @@
     },
     "packages/a2a": {
       "name": "@lucid-agents/a2a",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "@lucid-agents/types": "workspace:*",
         "zod": "catalog:",
@@ -77,7 +77,7 @@
     },
     "packages/analytics": {
       "name": "@lucid-agents/analytics",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@lucid-agents/types": "workspace:*",
         "viem": "catalog:",
@@ -90,7 +90,7 @@
     },
     "packages/ap2": {
       "name": "@lucid-agents/ap2",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@lucid-agents/types": "workspace:*",
       },
@@ -101,7 +101,7 @@
     },
     "packages/api-sdk": {
       "name": "@lucid-agents/api-sdk",
-      "version": "2.4.3",
+      "version": "2.5.0",
       "dependencies": {
         "@hey-api/client-fetch": "^0.10.0",
       },
@@ -119,7 +119,7 @@
     },
     "packages/cli": {
       "name": "@lucid-agents/cli",
-      "version": "2.4.3",
+      "version": "2.5.0",
       "bin": {
         "create-agent-kit": "dist/index.js",
       },
@@ -134,7 +134,7 @@
     },
     "packages/core": {
       "name": "@lucid-agents/core",
-      "version": "2.4.3",
+      "version": "2.5.0",
       "dependencies": {
         "@ax-llm/ax": "^14.0.37",
         "@ax-llm/ax-tools": "^14.0.37",
@@ -159,6 +159,7 @@
         "@lucid-agents/prettier-config": "workspace:*",
         "@lucid-agents/scheduler": "workspace:*",
         "@lucid-agents/wallet": "workspace:*",
+        "@lucid-agents/xmpt": "workspace:*",
         "tsup": "catalog:",
         "typescript": "catalog:",
       },
@@ -169,7 +170,7 @@
     },
     "packages/examples": {
       "name": "@lucid-agents/examples",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "dependencies": {
         "@ax-llm/ax": "^14.0.37",
         "@lucid-agents/a2a": "workspace:*",
@@ -182,6 +183,7 @@
         "@lucid-agents/scheduler": "workspace:*",
         "@lucid-agents/types": "workspace:*",
         "@lucid-agents/wallet": "workspace:*",
+        "@lucid-agents/xmpt": "workspace:*",
         "@lucid-dreams/agent-auth": "latest",
         "@x402/core": "catalog:",
         "@x402/evm": "catalog:",
@@ -200,7 +202,7 @@
     },
     "packages/express": {
       "name": "@lucid-agents/express",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "dependencies": {
         "@lucid-agents/core": "workspace:*",
         "@lucid-agents/payments": "workspace:*",
@@ -220,7 +222,7 @@
     },
     "packages/hono": {
       "name": "@lucid-agents/hono",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "dependencies": {
         "@lucid-agents/ap2": "workspace:*",
         "@lucid-agents/core": "workspace:*",
@@ -241,7 +243,7 @@
     },
     "packages/http": {
       "name": "@lucid-agents/http",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "dependencies": {
         "@lucid-agents/types": "workspace:*",
         "hono": "catalog:",
@@ -257,7 +259,7 @@
     },
     "packages/identity": {
       "name": "@lucid-agents/identity",
-      "version": "2.4.3",
+      "version": "2.5.0",
       "dependencies": {
         "@lucid-agents/types": "workspace:*",
         "@lucid-agents/wallet": "workspace:*",
@@ -272,7 +274,7 @@
     },
     "packages/payments": {
       "name": "@lucid-agents/payments",
-      "version": "2.4.3",
+      "version": "2.5.0",
       "dependencies": {
         "@ax-llm/ax": "catalog:",
         "@lucid-agents/types": "workspace:*",
@@ -296,7 +298,7 @@
     },
     "packages/scheduler": {
       "name": "@lucid-agents/scheduler",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@lucid-agents/types": "workspace:*",
       },
@@ -307,7 +309,7 @@
     },
     "packages/tanstack": {
       "name": "@lucid-agents/tanstack",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "dependencies": {
         "@lucid-agents/core": "workspace:*",
         "@lucid-agents/payments": "workspace:*",
@@ -325,7 +327,7 @@
     },
     "packages/types": {
       "name": "@lucid-agents/types",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "devDependencies": {
         "tsup": "catalog:",
         "typescript": "catalog:",
@@ -339,7 +341,7 @@
     },
     "packages/wallet": {
       "name": "@lucid-agents/wallet",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "@lucid-agents/types": "workspace:*",
         "viem": "catalog:",
@@ -350,6 +352,22 @@
       },
       "peerDependencies": {
         "thirdweb": "^5.84.0",
+      },
+    },
+    "packages/xmpt": {
+      "name": "@lucid-agents/xmpt",
+      "version": "0.1.0",
+      "dependencies": {
+        "@lucid-agents/a2a": "workspace:*",
+        "@lucid-agents/types": "workspace:*",
+        "zod": "catalog:",
+      },
+      "devDependencies": {
+        "@lucid-agents/core": "workspace:*",
+        "@lucid-agents/hono": "workspace:*",
+        "@lucid-agents/http": "workspace:*",
+        "tsup": "catalog:",
+        "typescript": "catalog:",
       },
     },
   },
@@ -717,6 +735,8 @@
     "@lucid-agents/types": ["@lucid-agents/types@workspace:packages/types"],
 
     "@lucid-agents/wallet": ["@lucid-agents/wallet@workspace:packages/wallet"],
+
+    "@lucid-agents/xmpt": ["@lucid-agents/xmpt@workspace:packages/xmpt"],
 
     "@lucid-dreams/agent-auth": ["@lucid-dreams/agent-auth@0.2.24", "", { "dependencies": { "@lucid-dreams/sdk": "^0.2.24", "viem": "^2.38.5" } }, "sha512-QiJQ2FTJXtd1o6c1fkEq/qawBJbhZdmGukwt+B8LztTmjjkdhfRZvWbNk3DUBIZIPsbInWdwbgPAUkzGMUNyDg=="],
 
@@ -3110,7 +3130,7 @@
 
     "@hey-api/openapi-ts/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
-    "@lucid-agents/examples/bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
+    "@lucid-agents/examples/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 

--- a/lucid-docs/content/docs/examples/index.mdx
+++ b/lucid-docs/content/docs/examples/index.mdx
@@ -42,6 +42,11 @@ bun run packages/examples/src/core/full-agent.ts
     href="/docs/examples/a2a"
   />
   <Card
+    title="XMPT Messaging"
+    description="Thread-aware inbox messaging between agents over A2A"
+    href="/docs/examples/xmpt"
+  />
+  <Card
     title="Wallet"
     description="Wallet connectors including thirdweb Engine integration"
     href="/docs/examples/wallet"
@@ -91,6 +96,7 @@ AGENT_DOMAIN=my-agent.example.com
 | **Full Agent**           | Complete agent with all extensions, streaming entrypoints  |
 | **Identity Quick Start** | Simplest path to on-chain registration                     |
 | **A2A Integration**      | Agent discovery, task operations, multi-turn conversations |
+| **XMPT Messaging**       | Inbox handling, thread IDs, send-and-wait reply flows      |
 | **Thirdweb Wallets**     | Enterprise wallet management with thirdweb Engine          |
 | **Payment Policies**     | Spending limits, allowlists, blocklists                    |
 | **Stripe Destination**   | Dynamic payTo resolution with Stripe PaymentIntents        |

--- a/lucid-docs/content/docs/examples/meta.json
+++ b/lucid-docs/content/docs/examples/meta.json
@@ -5,6 +5,7 @@
     "---Fundamentals---",
     "core",
     "a2a",
+    "xmpt",
     "---Payments---",
     "calling-paid-endpoints",
     "stripe-destination-mode",

--- a/lucid-docs/content/docs/examples/xmpt.mdx
+++ b/lucid-docs/content/docs/examples/xmpt.mdx
@@ -1,0 +1,113 @@
+---
+title: XMPT Examples
+description: Inbox-first, thread-aware messaging between agents.
+icon: MessagesSquare
+---
+
+This example shows two local agents exchanging XMPT messages with `sendAndWait`, including thread history inspection.
+
+## Local messaging (two agents)
+
+**File:** `packages/examples/src/xmpt/local-messaging.ts`
+
+### What it demonstrates
+
+- adding XMPT to both sender and receiver agents
+- configuring an inbox handler that returns a reply
+- sending a message with explicit `threadId`
+- waiting for task completion with `sendAndWait`
+- listing local message history by thread
+
+### The code
+
+```typescript title="local-messaging.ts"
+import { a2a } from '@lucid-agents/a2a';
+import { createAgent } from '@lucid-agents/core';
+import { createAgentApp } from '@lucid-agents/hono';
+import { http } from '@lucid-agents/http';
+import { xmpt } from '@lucid-agents/xmpt';
+
+const alpha = await createAgent({
+  name: 'alpha',
+  version: '1.0.0',
+  description: 'XMPT sender',
+})
+  .use(a2a())
+  .use(http())
+  .use(xmpt())
+  .build();
+
+const beta = await createAgent({
+  name: 'beta',
+  version: '1.0.0',
+  description: 'XMPT receiver',
+})
+  .use(a2a())
+  .use(http())
+  .use(
+    xmpt({
+      inbox: {
+        handler: async ({ message }) => ({
+          content: {
+            text: `ack:${message.content.text ?? ''}`,
+          },
+        }),
+      },
+    })
+  )
+  .build();
+
+const alphaApp = await createAgentApp(alpha);
+const betaApp = await createAgentApp(beta);
+
+const alphaServer = Bun.serve({ port: 8789, fetch: alphaApp.app.fetch });
+const betaServer = Bun.serve({ port: 8790, fetch: betaApp.app.fetch });
+
+const result = await alpha.xmpt!.sendAndWait(
+  { url: 'http://localhost:8790' },
+  {
+    threadId: 'example-thread',
+    content: { text: 'hello from alpha' },
+  },
+  { timeoutMs: 5000 }
+);
+
+console.log(result.delivery);
+console.log(result.task.result?.output);
+
+const betaMessages = await beta.xmpt!.listMessages({
+  threadId: 'example-thread',
+});
+console.log(betaMessages);
+
+alphaServer.stop();
+betaServer.stop();
+```
+
+### Run it
+
+```bash
+bun run packages/examples/src/xmpt/local-messaging.ts
+```
+
+## Use case patterns
+
+### 1. Supervisor to specialist delegation
+
+Use `threadId` to keep all messages for one job in a single conversation.
+
+### 2. Agent handoffs
+
+Send one message per step as control moves between planner, executor, and validator agents.
+
+### 3. Async tool execution with reply
+
+Use `sendAndWait` to simplify async task completion and reply handling.
+
+### 4. Operational audit trails
+
+Store inbound and outbound message records for troubleshooting and observability.
+
+## Next step
+
+If you need lower-level protocol control (task listing, cancellation, capability checks), combine XMPT with direct A2A client calls from `/docs/examples/a2a`.

--- a/lucid-docs/content/docs/packages/index.mdx
+++ b/lucid-docs/content/docs/packages/index.mdx
@@ -59,6 +59,11 @@ Optional capabilities you can add to your agent:
     href="/docs/packages/a2a"
   />
   <Card
+    title="@lucid-agents/xmpt"
+    description="Thread-aware agent messaging with inbox semantics over A2A"
+    href="/docs/packages/xmpt"
+  />
+  <Card
     title="@lucid-agents/wallet"
     description="Wallet connectors for agent operations"
     href="/docs/packages/wallet"
@@ -136,7 +141,7 @@ Integrate agents with your preferred web framework:
                             │
 ┌─────────────────────────────────────────────────────────┐
 │                      Extensions                          │
-│   http │ payments │ identity │ a2a │ wallet │ ap2       │
+│ http │ payments │ identity │ a2a │ xmpt │ wallet │ ap2  │
 └─────────────────────────────────────────────────────────┘
                             │
 ┌─────────────────────────────────────────────────────────┐

--- a/lucid-docs/content/docs/packages/meta.json
+++ b/lucid-docs/content/docs/packages/meta.json
@@ -13,6 +13,7 @@
     "facilitator",
     "identity",
     "a2a",
+    "xmpt",
     "wallet",
     "ap2",
     "---Adapters---",

--- a/lucid-docs/content/docs/packages/xmpt.mdx
+++ b/lucid-docs/content/docs/packages/xmpt.mdx
@@ -1,0 +1,157 @@
+---
+title: "@lucid-agents/xmpt"
+description: High-level inbox and thread-aware messaging over A2A tasks.
+icon: MessagesSquare
+---
+
+The XMPT extension provides a messaging abstraction on top of A2A:
+
+- inbox semantics with a default `xmpt-inbox` skill
+- normalized message envelopes (`id`, `threadId`, `content`, metadata)
+- `send`, `sendAndWait`, and `receive` APIs
+- local message observability (`onMessage`) and history (`listMessages`)
+- Agent Card discoverability tags (`xmpt`, `xmpt-inbox`)
+
+## When to use XMPT
+
+Use XMPT when you need conversation-style, thread-aware agent communication.
+
+Use plain A2A when you only need one-off skill invocation.
+
+| Need | Prefer |
+|------|--------|
+| Simple remote call to a known skill | `@lucid-agents/a2a` |
+| Inbox semantics + message envelopes | `@lucid-agents/xmpt` |
+| Thread IDs and message history at runtime | `@lucid-agents/xmpt` |
+| Fine-grained protocol-level control | `@lucid-agents/a2a` |
+
+## Installation
+
+```bash
+bun add @lucid-agents/xmpt
+```
+
+## Basic usage
+
+```typescript
+import { a2a } from '@lucid-agents/a2a';
+import { createAgent } from '@lucid-agents/core';
+import { http } from '@lucid-agents/http';
+import { xmpt } from '@lucid-agents/xmpt';
+
+const agent = await createAgent({
+  name: 'alpha',
+  version: '1.0.0',
+})
+  .use(a2a())
+  .use(http())
+  .use(
+    xmpt({
+      inbox: {
+        handler: async ({ message }) => ({
+          content: {
+            text: `ack:${message.content.text ?? ''}`,
+          },
+        }),
+      },
+    })
+  )
+  .build();
+```
+
+## Sending messages
+
+### Fire-and-continue
+
+```typescript
+const delivery = await agent.xmpt!.send(
+  { url: 'https://beta.example.com' },
+  {
+    threadId: 'trading-session-42',
+    content: { text: 'fetch latest order book snapshot' },
+  }
+);
+
+console.log(delivery.taskId, delivery.status, delivery.messageId);
+```
+
+### Send and wait for reply
+
+```typescript
+const result = await agent.xmpt!.sendAndWait(
+  { url: 'https://beta.example.com' },
+  {
+    threadId: 'trading-session-42',
+    content: { text: 'compute hedge ratio' },
+  },
+  { timeoutMs: 15_000 }
+);
+
+console.log(result.task.status);
+console.log(result.task.result?.output);
+```
+
+## Observability and local history
+
+```typescript
+const unsubscribe = agent.xmpt!.onMessage(message => {
+  console.log('Inbound message:', message.threadId, message.content.text);
+});
+
+const history = await agent.xmpt!.listMessages({
+  threadId: 'trading-session-42',
+});
+
+console.log(history.length);
+unsubscribe();
+```
+
+## Configuration
+
+```typescript
+xmpt({
+  inbox: {
+    key: 'trader-inbox',
+    handler: async ({ message }) => ({
+      content: { text: `received:${message.id}` },
+    }),
+  },
+  discovery: {
+    preferredSkillId: 'trader-inbox',
+  },
+  store: myStore,
+});
+```
+
+### Options
+
+- `inbox.key` - inbox entrypoint key (default: `xmpt-inbox`)
+- `inbox.handler` - optional handler for inbound messages
+- `discovery.preferredSkillId` - preferred remote inbox skill id
+- `store` - pluggable store with `append` and `list`
+
+## Runtime semantics
+
+- A2A delivery failures fail `send` and `sendAndWait`
+- store persistence failures are best-effort and do not fail delivery
+- `onMessage` subscriber failures are best-effort and do not fail delivery
+
+## Error handling
+
+XMPT throws `XMPTError` with stable codes:
+
+- `XMPT_PEER_UNREACHABLE`
+- `XMPT_INBOX_SKILL_MISSING`
+- `XMPT_INVALID_MESSAGE_PAYLOAD`
+- `XMPT_TIMEOUT`
+
+## Use cases
+
+- supervisor/worker orchestration with explicit thread IDs
+- facilitator agents routing tasks across specialist agents
+- cross-agent negotiation loops with reply semantics
+- local audit trails for inbound/outbound message flows
+
+## Related example
+
+- `/docs/examples/xmpt`

--- a/lucid-docs/src/routes/docs/$.tsx
+++ b/lucid-docs/src/routes/docs/$.tsx
@@ -3,14 +3,7 @@ import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import { createServerFn } from '@tanstack/react-start';
 import { source } from '@/lib/source';
 import type * as PageTree from 'fumadocs-core/page-tree';
-import {
-  Children,
-  isValidElement,
-  useMemo,
-  useState,
-  type ReactElement,
-  type ReactNode,
-} from 'react';
+import { useMemo } from 'react';
 import browserCollections from 'fumadocs-mdx:collections/browser';
 import {
   DocsBody,
@@ -19,6 +12,8 @@ import {
   DocsTitle,
 } from 'fumadocs-ui/layouts/docs/page';
 import defaultMdxComponents from 'fumadocs-ui/mdx';
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { Step, Steps } from 'fumadocs-ui/components/steps';
 import { baseOptions } from '@/lib/layout.shared';
 import { LLMCopyButton, ViewOptions } from '@/components/page-actions';
 
@@ -49,77 +44,6 @@ const loader = createServerFn({
 type DocsPageProps = {
   markdownUrl: string;
 };
-
-type TabsProps = {
-  items?: string[];
-  children?: ReactNode;
-};
-
-type TabProps = {
-  value?: string;
-  children?: ReactNode;
-};
-
-function Tab(_props: TabProps): null {
-  return null;
-}
-
-function Tabs({ items, children }: TabsProps) {
-  const tabs = useMemo(() => {
-    return Children.toArray(children)
-      .filter((child): child is ReactElement<TabProps> => isValidElement(child))
-      .map((child, index) => ({
-        label: child.props.value ?? items?.[index] ?? `Tab ${index + 1}`,
-        content: child.props.children,
-      }));
-  }, [children, items]);
-
-  const [activeTab, setActiveTab] = useState(0);
-
-  if (tabs.length === 0) {
-    return null;
-  }
-
-  const safeActiveTab = Math.min(activeTab, tabs.length - 1);
-
-  return (
-    <div className="my-6 overflow-hidden rounded-lg border border-fd-border bg-fd-card">
-      <div className="flex flex-wrap gap-2 border-b border-fd-border bg-fd-muted/30 p-2">
-        {tabs.map((tab, index) => (
-          <button
-            key={tab.label + index}
-            type="button"
-            onClick={() => setActiveTab(index)}
-            className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
-              index === safeActiveTab
-                ? 'bg-fd-primary text-fd-primary-foreground'
-                : 'bg-fd-secondary text-fd-secondary-foreground hover:bg-fd-accent'
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
-      <div className="p-4">{tabs[safeActiveTab]?.content}</div>
-    </div>
-  );
-}
-
-type StepsProps = {
-  children?: ReactNode;
-};
-
-function Steps({ children }: StepsProps) {
-  return <ol className="my-6 list-decimal space-y-2 pl-6">{children}</ol>;
-}
-
-type StepProps = {
-  children?: ReactNode;
-};
-
-function Step({ children }: StepProps) {
-  return <li>{children}</li>;
-}
 
 const clientLoader = browserCollections.docs.createClientLoader<DocsPageProps>({
   component({ toc, frontmatter, default: MDX }, { markdownUrl }) {

--- a/lucid-docs/src/routes/docs/$.tsx
+++ b/lucid-docs/src/routes/docs/$.tsx
@@ -3,7 +3,14 @@ import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import { createServerFn } from '@tanstack/react-start';
 import { source } from '@/lib/source';
 import type * as PageTree from 'fumadocs-core/page-tree';
-import { useMemo } from 'react';
+import {
+  Children,
+  isValidElement,
+  useMemo,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
 import browserCollections from 'fumadocs-mdx:collections/browser';
 import {
   DocsBody,
@@ -43,6 +50,77 @@ type DocsPageProps = {
   markdownUrl: string;
 };
 
+type TabsProps = {
+  items?: string[];
+  children?: ReactNode;
+};
+
+type TabProps = {
+  value?: string;
+  children?: ReactNode;
+};
+
+function Tab(_props: TabProps): null {
+  return null;
+}
+
+function Tabs({ items, children }: TabsProps) {
+  const tabs = useMemo(() => {
+    return Children.toArray(children)
+      .filter((child): child is ReactElement<TabProps> => isValidElement(child))
+      .map((child, index) => ({
+        label: child.props.value ?? items?.[index] ?? `Tab ${index + 1}`,
+        content: child.props.children,
+      }));
+  }, [children, items]);
+
+  const [activeTab, setActiveTab] = useState(0);
+
+  if (tabs.length === 0) {
+    return null;
+  }
+
+  const safeActiveTab = Math.min(activeTab, tabs.length - 1);
+
+  return (
+    <div className="my-6 overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+      <div className="flex flex-wrap gap-2 border-b border-fd-border bg-fd-muted/30 p-2">
+        {tabs.map((tab, index) => (
+          <button
+            key={tab.label + index}
+            type="button"
+            onClick={() => setActiveTab(index)}
+            className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
+              index === safeActiveTab
+                ? 'bg-fd-primary text-fd-primary-foreground'
+                : 'bg-fd-secondary text-fd-secondary-foreground hover:bg-fd-accent'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div className="p-4">{tabs[safeActiveTab]?.content}</div>
+    </div>
+  );
+}
+
+type StepsProps = {
+  children?: ReactNode;
+};
+
+function Steps({ children }: StepsProps) {
+  return <ol className="my-6 list-decimal space-y-2 pl-6">{children}</ol>;
+}
+
+type StepProps = {
+  children?: ReactNode;
+};
+
+function Step({ children }: StepProps) {
+  return <li>{children}</li>;
+}
+
 const clientLoader = browserCollections.docs.createClientLoader<DocsPageProps>({
   component({ toc, frontmatter, default: MDX }, { markdownUrl }) {
     return (
@@ -60,6 +138,10 @@ const clientLoader = browserCollections.docs.createClientLoader<DocsPageProps>({
           <MDX
             components={{
               ...defaultMdxComponents,
+              Tabs,
+              Tab,
+              Steps,
+              Step,
             }}
           />
         </DocsBody>

--- a/packages/a2a/src/client.ts
+++ b/packages/a2a/src/client.ts
@@ -465,12 +465,17 @@ export async function waitForTask<TOutput = unknown>(
   client: A2AClient,
   card: AgentCard,
   taskId: string,
-  maxWaitMs = 30000
+  maxWaitMs = 30000,
+  fetchImpl?: FetchFunction
 ): Promise<Task<TOutput>> {
   const startTime = Date.now();
   while (Date.now() - startTime < maxWaitMs) {
-    const task = await client.getTask(card, taskId);
-    if (task.status === 'completed' || task.status === 'failed') {
+    const task = await client.getTask(card, taskId, fetchImpl);
+    if (
+      task.status === 'completed' ||
+      task.status === 'failed' ||
+      task.status === 'cancelled'
+    ) {
       return task as Task<TOutput>;
     }
     await new Promise(resolve => setTimeout(resolve, 100));

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,6 +71,7 @@
     "@lucid-agents/http": "workspace:*",
     "@lucid-agents/identity": "workspace:*",
     "@lucid-agents/scheduler": "workspace:*",
-    "@lucid-agents/wallet": "workspace:*"
+    "@lucid-agents/wallet": "workspace:*",
+    "@lucid-agents/xmpt": "workspace:*"
   }
 }

--- a/packages/core/src/__tests__/runtime.test.ts
+++ b/packages/core/src/__tests__/runtime.test.ts
@@ -16,6 +16,7 @@ import type {
   PaymentTracker,
 } from '@lucid-agents/types/payments';
 import { wallets } from '@lucid-agents/wallet';
+import { xmpt } from '@lucid-agents/xmpt';
 import { describe, expect, it, mock } from 'bun:test';
 import { z } from 'zod';
 
@@ -932,6 +933,42 @@ describe('A2A Extension', () => {
     // buildAgentCard adds trailing slash to origin
     expect(card?.url).toBe('https://agent.example.com/');
     expect(card?.entrypoints).toBeDefined();
+  });
+});
+
+describe('XMPT Extension', () => {
+  it('adds xmpt runtime and inbox entrypoint', async () => {
+    const agent = await createAgent({
+      name: 'xmpt-agent',
+      version: '1.0.0',
+    })
+      .use(a2a())
+      .use(http())
+      .use(xmpt())
+      .build();
+
+    expect(agent.xmpt).toBeDefined();
+    const inboxEntrypoint = agent.entrypoints
+      .snapshot()
+      .find(entrypoint => entrypoint.key === 'xmpt-inbox');
+    expect(inboxEntrypoint).toBeDefined();
+  });
+
+  it('marks inbox skill for manifest discoverability', async () => {
+    const agent = await createAgent({
+      name: 'xmpt-agent',
+      version: '1.0.0',
+    })
+      .use(a2a())
+      .use(http())
+      .use(xmpt())
+      .build();
+
+    const card = agent.manifest.build('https://agent.example.com');
+    const inboxSkill = card.skills?.find(skill => skill.id === 'xmpt-inbox');
+    expect(inboxSkill).toBeDefined();
+    expect(inboxSkill?.tags).toContain('xmpt');
+    expect(inboxSkill?.tags).toContain('xmpt-inbox');
   });
 });
 

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -7,6 +7,7 @@ This package contains example implementations demonstrating how to use the lucid
 - `src/core/` - Core framework examples (HTTP, payments, identity, streaming)
 - `src/identity/` - ERC-8004 identity examples
 - `src/a2a/` - Agent-to-Agent protocol examples
+- `src/xmpt/` - XMPT inbox and thread-aware messaging examples
 
 ## Running Examples
 
@@ -15,9 +16,11 @@ Examples can be run directly with Bun:
 ```bash
 # From the examples package
 bun run src/core/full-agent.ts
+bun run src/xmpt/local-messaging.ts
 
 # Or from the repo root
 bun run packages/examples/src/core/full-agent.ts
+bun run packages/examples/src/xmpt/local-messaging.ts
 ```
 
 ## Type Checking

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -25,6 +25,7 @@
     "@lucid-agents/scheduler": "workspace:*",
     "@lucid-agents/types": "workspace:*",
     "@lucid-agents/wallet": "workspace:*",
+    "@lucid-agents/xmpt": "workspace:*",
     "@lucid-dreams/agent-auth": "latest",
     "thirdweb": "^5.113.0",
     "viem": "catalog:",

--- a/packages/examples/src/README.md
+++ b/packages/examples/src/README.md
@@ -105,6 +105,25 @@ SCOPES       # Comma-separated scopes fed into the runtime (default agents.read)
 Because the auth server is mocked, no real credentials are required—the
 `signChallenge` implementation simply echoes the challenge ID.
 
+## XMPT Local Messaging
+
+`xmpt/local-messaging.ts` runs two local agents and sends a thread-aware XMPT
+message end-to-end.
+
+Run the script with Bun:
+
+```bash
+bun run src/xmpt/local-messaging.ts
+```
+
+The script starts:
+
+- `alpha` on `http://localhost:8789`
+- `beta` on `http://localhost:8790`
+
+Then it sends `hello from alpha` via `runtime.xmpt.sendAndWait(...)` and prints
+the delivery metadata, task result, and `beta` message history.
+
 ## Payment Policy Enforcement
 
 Four-agent example demonstrating payment policy enforcement with realistic testnet-friendly prices:

--- a/packages/examples/src/xmpt/local-messaging.ts
+++ b/packages/examples/src/xmpt/local-messaging.ts
@@ -1,0 +1,81 @@
+import { a2a } from '@lucid-agents/a2a';
+import { createAgent } from '@lucid-agents/core';
+import { createAgentApp } from '@lucid-agents/hono';
+import { http } from '@lucid-agents/http';
+import { xmpt } from '@lucid-agents/xmpt';
+
+async function main(): Promise<void> {
+  const alpha = await createAgent({
+    name: 'alpha',
+    version: '1.0.0',
+    description: 'XMPT sender',
+  })
+    .use(a2a())
+    .use(http())
+    .use(xmpt())
+    .build();
+
+  const beta = await createAgent({
+    name: 'beta',
+    version: '1.0.0',
+    description: 'XMPT receiver',
+  })
+    .use(a2a())
+    .use(http())
+    .use(
+      xmpt({
+        inbox: {
+          handler: async ({ message }) => ({
+            content: {
+              text: `ack:${message.content.text ?? ''}`,
+            },
+          }),
+        },
+      })
+    )
+    .build();
+
+  const alphaApp = await createAgentApp(alpha);
+  const betaApp = await createAgentApp(beta);
+
+  const alphaServer = Bun.serve({
+    port: 8789,
+    fetch: alphaApp.app.fetch,
+  });
+
+  const betaServer = Bun.serve({
+    port: 8790,
+    fetch: betaApp.app.fetch,
+  });
+
+  try {
+    console.log('Alpha listening on http://localhost:8789');
+    console.log('Beta listening on http://localhost:8790');
+
+    const result = await alpha.xmpt!.sendAndWait(
+      { url: 'http://localhost:8790' },
+      {
+        threadId: 'example-thread',
+        content: { text: 'hello from alpha' },
+      },
+      {
+        timeoutMs: 5000,
+      }
+    );
+
+    console.log('Delivery:', result.delivery);
+    console.log('Task status:', result.task.status);
+    console.log('Reply output:', result.task.result?.output);
+
+    const betaMessages = await beta.xmpt!.listMessages({
+      threadId: 'example-thread',
+    });
+
+    console.log('Beta message history:', betaMessages);
+  } finally {
+    alphaServer.stop();
+    betaServer.stop();
+  }
+}
+
+await main();

--- a/packages/http/src/__tests__/tasks.test.ts
+++ b/packages/http/src/__tests__/tasks.test.ts
@@ -243,6 +243,69 @@ describe('Task Operations', () => {
       const response = await handlers.tasks(request);
       expect(response.status).toBe(400);
     });
+
+    it('passes task metadata through to the handler context', async () => {
+      const { handlers, entrypoints } = makeTestHandlers();
+      let seenMetadata: Record<string, unknown> | undefined;
+
+      entrypoints.set('echo', {
+        key: 'echo',
+        description: 'Echo endpoint',
+        input: z.object({ text: z.string() }),
+        output: z.object({ text: z.string() }),
+        handler: async ctx => {
+          seenMetadata = ctx.metadata;
+          const input = ctx.input as { text: string };
+          return {
+            output: { text: input.text },
+            usage: { total_tokens: 0 },
+          };
+        },
+      });
+
+      const requestBody: SendMessageRequest = {
+        message: {
+          role: 'user',
+          content: { text: JSON.stringify({ text: 'hello' }) },
+        },
+        skillId: 'echo',
+        metadata: {
+          source: 'xmpt',
+          xmpt: {
+            messageId: 'msg-1',
+            threadId: 'thread-1',
+          },
+        },
+      };
+
+      const request = new Request('http://localhost/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestBody),
+      });
+
+      const response = await handlers.tasks(request);
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as {
+        taskId: string;
+        status: TaskStatus;
+      };
+      expect(data.status).toBe('running');
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(seenMetadata).toEqual(
+        expect.objectContaining({
+          source: 'xmpt',
+          xmpt: {
+            messageId: 'msg-1',
+            threadId: 'thread-1',
+          },
+          headers: expect.any(Headers),
+        })
+      );
+    });
   });
 
   describe('GET /tasks/{taskId} - Get Task Status', () => {

--- a/packages/http/src/extension.ts
+++ b/packages/http/src/extension.ts
@@ -397,7 +397,7 @@ export function http(
             );
           }
 
-          const { skillId, message, contextId } = requestBody;
+          const { skillId, message, contextId, metadata } = requestBody;
 
           const taskEntrypoint = runtime.agent.getEntrypoint(skillId);
           if (!taskEntrypoint) {
@@ -490,6 +490,7 @@ export function http(
           invokeHandler(taskEntrypoint, rawInput, {
             signal: abortController.signal,
             headers: req.headers,
+            metadata,
             runId: taskId,
             runtime,
           })

--- a/packages/http/src/invoke.ts
+++ b/packages/http/src/invoke.ts
@@ -30,6 +30,7 @@ export async function invokeHandler(
   context: {
     signal: AbortSignal;
     headers: Headers;
+    metadata?: Record<string, unknown>;
     runId: string;
     runtime: AgentRuntime;
   }
@@ -47,6 +48,7 @@ export async function invokeHandler(
     input: resolvedInput,
     signal: context.signal,
     metadata: {
+      ...(context.metadata ?? {}),
       headers: context.headers,
     },
     runId: context.runId,
@@ -136,4 +138,3 @@ export async function invoke(
     );
   }
 }
-

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -56,6 +56,11 @@
       "import": "./dist/wallets/index.js",
       "default": "./dist/wallets/index.js"
     },
+    "./xmpt": {
+      "types": "./dist/xmpt/index.d.ts",
+      "import": "./dist/xmpt/index.js",
+      "default": "./dist/xmpt/index.js"
+    },
     "./package.json": "./package.json"
   },
   "sideEffects": false,

--- a/packages/types/src/core/runtime.ts
+++ b/packages/types/src/core/runtime.ts
@@ -8,6 +8,7 @@ import type { EntrypointsRuntime } from './entrypoint';
 import type { AnalyticsRuntime } from '../analytics';
 import type { SchedulerRuntime } from '../scheduler';
 import type { AgentCore } from './agent';
+import type { XMPTRuntime } from '../xmpt';
 
 /**
  * Agent runtime interface.
@@ -25,6 +26,7 @@ export type AgentRuntime = {
   payments?: PaymentsRuntime;
   analytics?: AnalyticsRuntime;
   a2a?: A2ARuntime;
+  xmpt?: XMPTRuntime;
   ap2?: AP2Runtime;
   scheduler?: SchedulerRuntime;
   handlers?: AgentHttpHandlers;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,3 +9,4 @@ export * from './identity';
 export * from './payments';
 export * from './scheduler';
 export * from './wallets';
+export * from './xmpt';

--- a/packages/types/src/xmpt/index.ts
+++ b/packages/types/src/xmpt/index.ts
@@ -1,0 +1,107 @@
+import type { AgentCard, Task } from '../a2a';
+import type { AgentRuntime } from '../core';
+import type { FetchFunction } from '../http';
+
+export type XMPTContent = {
+  text?: string;
+  data?: unknown;
+  mime?: string;
+};
+
+export type XMPTMessage = {
+  id: string;
+  threadId: string;
+  from?: string;
+  to?: string;
+  content: XMPTContent;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+};
+
+export type XMPTPeer = { url: string } | { card: AgentCard };
+
+export type XMPTDeliveryResult = {
+  taskId: string;
+  status: string;
+  messageId: string;
+};
+
+export type XMPTMessageDirection = 'inbound' | 'outbound';
+
+export type XMPTMessageRecord = XMPTMessage & {
+  direction: XMPTMessageDirection;
+  peer?: string;
+  taskId?: string;
+};
+
+export type XMPTListMessagesFilters = {
+  threadId?: string;
+  direction?: XMPTMessageDirection;
+  limit?: number;
+  offset?: number;
+};
+
+export type XMPTOnMessageHandler = (
+  message: XMPTMessage
+) => void | Promise<void>;
+
+export type XMPTInboxReply = {
+  content: XMPTContent;
+  metadata?: Record<string, unknown>;
+  threadId?: string;
+  to?: string;
+};
+
+export type XMPTInboxHandlerArgs = {
+  message: XMPTMessage;
+  runtime: AgentRuntime;
+};
+
+export type XMPTInboxHandler = (
+  args: XMPTInboxHandlerArgs
+) => XMPTInboxReply | void | Promise<XMPTInboxReply | void>;
+
+export type XMPTStore = {
+  append(message: XMPTMessageRecord): void | Promise<void>;
+  list(
+    filters?: XMPTListMessagesFilters
+  ): XMPTMessageRecord[] | Promise<XMPTMessageRecord[]>;
+};
+
+export type XMPTSendOptions = {
+  skillId?: string;
+  timeoutMs?: number;
+  fetch?: FetchFunction;
+  metadata?: Record<string, unknown>;
+};
+
+export type XMPTSendInput = {
+  id?: string;
+  threadId?: string;
+  from?: string;
+  to?: string;
+  content: XMPTContent;
+  metadata?: Record<string, unknown>;
+  createdAt?: string;
+};
+
+export type XMPTSendAndWaitResult = {
+  delivery: XMPTDeliveryResult;
+  task: Task<XMPTMessage | null>;
+};
+
+export type XMPTRuntime = {
+  send(
+    peer: XMPTPeer,
+    message: XMPTSendInput,
+    options?: XMPTSendOptions
+  ): Promise<XMPTDeliveryResult>;
+  sendAndWait(
+    peer: XMPTPeer,
+    message: XMPTSendInput,
+    options?: XMPTSendOptions
+  ): Promise<XMPTSendAndWaitResult>;
+  receive(message: XMPTMessage): Promise<XMPTMessage | undefined>;
+  onMessage(handler: XMPTOnMessageHandler): () => void;
+  listMessages(filters?: XMPTListMessagesFilters): Promise<XMPTMessageRecord[]>;
+};

--- a/packages/types/tsup.config.ts
+++ b/packages/types/tsup.config.ts
@@ -1,9 +1,9 @@
 import { definePackageConfig } from '../tsup.config.base';
 
 export default definePackageConfig({
-  entry: ['src/index.ts', 'src/core/index.ts', 'src/a2a/index.ts', 'src/analytics/index.ts', 'src/ap2/index.ts', 'src/http/index.ts', 'src/identity/index.ts', 'src/payments/index.ts', 'src/scheduler/index.ts', 'src/wallets/index.ts'],
+  entry: ['src/index.ts', 'src/core/index.ts', 'src/a2a/index.ts', 'src/analytics/index.ts', 'src/ap2/index.ts', 'src/http/index.ts', 'src/identity/index.ts', 'src/payments/index.ts', 'src/scheduler/index.ts', 'src/wallets/index.ts', 'src/xmpt/index.ts'],
   dts: {
-    entry: ['src/index.ts', 'src/core/index.ts', 'src/a2a/index.ts', 'src/analytics/index.ts', 'src/ap2/index.ts', 'src/http/index.ts', 'src/identity/index.ts', 'src/payments/index.ts', 'src/scheduler/index.ts', 'src/wallets/index.ts'],
+    entry: ['src/index.ts', 'src/core/index.ts', 'src/a2a/index.ts', 'src/analytics/index.ts', 'src/ap2/index.ts', 'src/http/index.ts', 'src/identity/index.ts', 'src/payments/index.ts', 'src/scheduler/index.ts', 'src/wallets/index.ts', 'src/xmpt/index.ts'],
   },
   external: ['zod', 'x402'],
 });

--- a/packages/xmpt/CHANGELOG.md
+++ b/packages/xmpt/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @lucid-agents/xmpt
+
+## 0.1.0
+
+### Minor Changes
+
+- Add XMPT extension package with inbox, send/receive APIs, threading, and in-memory store.

--- a/packages/xmpt/README.md
+++ b/packages/xmpt/README.md
@@ -1,18 +1,32 @@
 # @lucid-agents/xmpt
 
-XMPT is a high-level messaging extension for Lucid agents.
+XMPT is the high-level messaging layer for Lucid Agents.
 
-It provides:
+It sits on top of A2A tasks and adds:
 
 - inbox semantics (`xmpt-inbox` by default)
-- thread-aware send/receive APIs
-- local message observability with a pluggable store
-- manifest discoverability tags for XMPT inbox skills
+- a normalized message envelope (`id`, `threadId`, `content`, metadata)
+- thread-aware `send`, `sendAndWait`, and `receive` APIs
+- local message observability (`onMessage`) and history (`listMessages`)
+- manifest discovery tags (`xmpt`, `xmpt-inbox`) so peers can find inbox skills
 
-Runtime semantics:
+## When to use XMPT
 
-- A2A delivery errors fail `send`/`sendAndWait`
-- local message-store persistence and `onMessage` subscriber failures are best-effort and do not fail delivery
+Use XMPT when your agent needs conversation-like messaging between agents:
+
+- multi-step delegation flows where context must persist via `threadId`
+- async request/reply patterns where `sendAndWait` is simpler than raw task polling
+- inbox behavior for peer-to-peer agent messaging
+- local transcript/history or analytics hooks through the pluggable store
+
+Use plain A2A directly when you only need one-off skill invocation and do not need messaging semantics.
+
+## Delivery and failure semantics
+
+- A2A delivery failures throw and fail `send`/`sendAndWait`
+- timeout waiting for task completion throws `XMPT_TIMEOUT`
+- local store append failures are best-effort and do not fail delivery
+- `onMessage` subscriber failures are best-effort and do not fail delivery
 
 ## Install
 
@@ -20,7 +34,7 @@ Runtime semantics:
 bun add @lucid-agents/xmpt
 ```
 
-## Usage
+## Quick start
 
 ```ts
 import { createAgent } from '@lucid-agents/core';
@@ -50,3 +64,98 @@ await runtime.xmpt?.send(
   { content: { text: 'hello' }, threadId: 't-1' }
 );
 ```
+
+## API overview
+
+`runtime.xmpt` exposes:
+
+- `send(peer, message, options?)` - deliver a message and return task metadata
+- `sendAndWait(peer, message, options?)` - deliver and wait for task completion
+- `receive(message)` - process an inbound XMPT message (inbox entrypoint uses this)
+- `onMessage(handler)` - subscribe to inbound message events
+- `listMessages(filters?)` - query local message records
+
+### `sendAndWait` example
+
+```ts
+const result = await runtime.xmpt!.sendAndWait(
+  { url: 'https://beta.example.com' },
+  {
+    threadId: 'portfolio-rebalance-42',
+    content: { text: 'calculate hedge ratio' },
+  },
+  { timeoutMs: 15_000 }
+);
+
+console.log(result.delivery.taskId);
+console.log(result.task.status);
+console.log(result.task.result?.output);
+```
+
+### Message observability and history
+
+```ts
+const unsubscribe = runtime.xmpt!.onMessage(message => {
+  console.log('Inbound message:', message.threadId, message.content.text);
+});
+
+const threadHistory = await runtime.xmpt!.listMessages({
+  threadId: 'portfolio-rebalance-42',
+});
+
+unsubscribe();
+```
+
+## Configuration
+
+```ts
+xmpt({
+  inbox: {
+    key: 'custom-inbox',
+    handler: async ({ message }) => ({
+      content: { text: `ack:${message.content.text ?? ''}` },
+    }),
+  },
+  discovery: {
+    preferredSkillId: 'custom-inbox',
+  },
+  store: myStore,
+});
+```
+
+### Options
+
+- `inbox.key` - inbox entrypoint key (defaults to `xmpt-inbox`)
+- `inbox.handler` - optional handler to process inbound messages and produce a reply
+- `discovery.preferredSkillId` - preferred remote skill id during inbox resolution
+- `store` - pluggable local store for message records (`append`, `list`)
+
+## Use cases
+
+- Supervisor/worker orchestration where every job runs in a thread
+- Facilitator agents that route requests across specialist agents
+- Cross-agent negotiation loops that need durable conversation IDs
+- Human-in-the-loop systems that need local message audit trails
+
+## Running the working example
+
+A local two-agent XMPT example is available at:
+
+- `packages/examples/src/xmpt/local-messaging.ts`
+
+Run it from repo root:
+
+```bash
+bun run packages/examples/src/xmpt/local-messaging.ts
+```
+
+This example starts two agents (`alpha`, `beta`), sends a message with `sendAndWait`, and prints delivery status plus thread history.
+
+## Error codes
+
+XMPT throws structured `XMPTError` instances with these codes:
+
+- `XMPT_PEER_UNREACHABLE`
+- `XMPT_INBOX_SKILL_MISSING`
+- `XMPT_INVALID_MESSAGE_PAYLOAD`
+- `XMPT_TIMEOUT`

--- a/packages/xmpt/README.md
+++ b/packages/xmpt/README.md
@@ -109,6 +109,10 @@ unsubscribe();
 ## Configuration
 
 ```ts
+import { createMemoryXMPTStore, xmpt } from '@lucid-agents/xmpt';
+
+const store = createMemoryXMPTStore();
+
 xmpt({
   inbox: {
     key: 'custom-inbox',
@@ -119,7 +123,7 @@ xmpt({
   discovery: {
     preferredSkillId: 'custom-inbox',
   },
-  store: myStore,
+  store,
 });
 ```
 
@@ -155,7 +159,7 @@ This example starts two agents (`alpha`, `beta`), sends a message with `sendAndW
 
 XMPT throws structured `XMPTError` instances with these codes:
 
-- `XMPT_PEER_UNREACHABLE`
-- `XMPT_INBOX_SKILL_MISSING`
-- `XMPT_INVALID_MESSAGE_PAYLOAD`
-- `XMPT_TIMEOUT`
+- `XMPT_PEER_UNREACHABLE` - A2A is unavailable, peer card fetch fails, message send fails, or remote task polling fails.
+- `XMPT_INBOX_SKILL_MISSING` - Peer card does not expose an inbox skill matching preferred/default/tag-based discovery.
+- `XMPT_INVALID_MESSAGE_PAYLOAD` - Message payload/content shape is invalid (missing required ids/timestamps or invalid field types).
+- `XMPT_TIMEOUT` - `sendAndWait` exceeded `timeoutMs` before the remote task completed.

--- a/packages/xmpt/README.md
+++ b/packages/xmpt/README.md
@@ -1,0 +1,47 @@
+# @lucid-agents/xmpt
+
+XMPT is a high-level messaging extension for Lucid agents.
+
+It provides:
+
+- inbox semantics (`xmpt-inbox` by default)
+- thread-aware send/receive APIs
+- local message observability with a pluggable store
+- manifest discoverability tags for XMPT inbox skills
+
+## Install
+
+```bash
+bun add @lucid-agents/xmpt
+```
+
+## Usage
+
+```ts
+import { createAgent } from '@lucid-agents/core';
+import { a2a } from '@lucid-agents/a2a';
+import { http } from '@lucid-agents/http';
+import { xmpt } from '@lucid-agents/xmpt';
+
+const runtime = await createAgent({
+  name: 'alpha',
+  version: '0.1.0',
+})
+  .use(http())
+  .use(a2a())
+  .use(
+    xmpt({
+      inbox: {
+        handler: async ({ message }) => ({
+          content: { text: `ack:${message.content.text ?? ''}` },
+        }),
+      },
+    })
+  )
+  .build();
+
+await runtime.xmpt?.send(
+  { url: 'http://localhost:8788' },
+  { content: { text: 'hello' }, threadId: 't-1' }
+);
+```

--- a/packages/xmpt/README.md
+++ b/packages/xmpt/README.md
@@ -9,6 +9,11 @@ It provides:
 - local message observability with a pluggable store
 - manifest discoverability tags for XMPT inbox skills
 
+Runtime semantics:
+
+- A2A delivery errors fail `send`/`sendAndWait`
+- local message-store persistence and `onMessage` subscriber failures are best-effort and do not fail delivery
+
 ## Install
 
 ```bash

--- a/packages/xmpt/package.json
+++ b/packages/xmpt/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@lucid-agents/xmpt",
+  "version": "0.1.0",
+  "description": "XMPT messaging extension for Lucid agents",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/daydreamsai/lucid-agents",
+    "directory": "packages/xmpt"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "clean": "rm -rf dist",
+    "test": "bun test",
+    "type-check": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@lucid-agents/a2a": "workspace:*",
+    "@lucid-agents/types": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@lucid-agents/core": "workspace:*",
+    "@lucid-agents/http": "workspace:*",
+    "@lucid-agents/hono": "workspace:*",
+    "tsup": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/xmpt/src/__tests__/e2e.test.ts
+++ b/packages/xmpt/src/__tests__/e2e.test.ts
@@ -1,0 +1,81 @@
+import { a2a } from '@lucid-agents/a2a';
+import { createAgent } from '@lucid-agents/core';
+import { createAgentApp } from '@lucid-agents/hono';
+import { http } from '@lucid-agents/http';
+import { describe, expect, it } from 'bun:test';
+
+import { xmpt } from '../extension';
+
+describe('xmpt local e2e', () => {
+  it('exchanges messages between two local agents', async () => {
+    const alpha = await createAgent({
+      name: 'alpha',
+      version: '1.0.0',
+    })
+      .use(a2a())
+      .use(http())
+      .use(xmpt())
+      .build();
+
+    const beta = await createAgent({
+      name: 'beta',
+      version: '1.0.0',
+    })
+      .use(a2a())
+      .use(http())
+      .use(
+        xmpt({
+          inbox: {
+            handler: async ({ message }) => ({
+              content: {
+                text: `ack:${message.content.text ?? ''}`,
+              },
+            }),
+          },
+        })
+      )
+      .build();
+
+    const alphaApp = await createAgentApp(alpha);
+    const betaApp = await createAgentApp(beta);
+
+    const alphaServer = Bun.serve({
+      port: 0,
+      fetch: alphaApp.app.fetch,
+    });
+
+    const betaServer = Bun.serve({
+      port: 0,
+      fetch: betaApp.app.fetch,
+    });
+
+    try {
+      const betaUrl = `http://127.0.0.1:${betaServer.port}`;
+
+      const result = await alpha.xmpt!.sendAndWait(
+        { url: betaUrl },
+        {
+          threadId: 'thread-e2e',
+          content: { text: 'hello' },
+        },
+        {
+          timeoutMs: 3000,
+        }
+      );
+
+      expect(result.task.status).toBe('completed');
+      expect(result.task.result?.output?.threadId).toBe('thread-e2e');
+      expect(result.task.result?.output?.content.text).toBe('ack:hello');
+
+      const betaMessages = await beta.xmpt!.listMessages({
+        threadId: 'thread-e2e',
+      });
+      expect(betaMessages).toHaveLength(2);
+      expect(betaMessages[0]?.direction).toBe('inbound');
+      expect(betaMessages[1]?.direction).toBe('outbound');
+    } finally {
+      alphaServer.stop();
+      betaServer.stop();
+    }
+  });
+});

--- a/packages/xmpt/src/__tests__/extension.test.ts
+++ b/packages/xmpt/src/__tests__/extension.test.ts
@@ -1,0 +1,102 @@
+import { a2a } from '@lucid-agents/a2a';
+import { createAgent } from '@lucid-agents/core';
+import { http } from '@lucid-agents/http';
+import { describe, expect, it } from 'bun:test';
+import { z } from 'zod';
+
+import { xmpt } from '../extension';
+
+describe('xmpt extension', () => {
+  it('adds runtime slice and inbox entrypoint', async () => {
+    const runtime = await createAgent({
+      name: 'xmpt-agent',
+      version: '1.0.0',
+    })
+      .use(a2a())
+      .use(http())
+      .use(
+        xmpt({
+          inbox: {
+            handler: async ({ message }) => ({
+              content: {
+                text: `ack:${message.content.text ?? ''}`,
+              },
+            }),
+          },
+        })
+      )
+      .build();
+
+    expect(runtime.xmpt).toBeDefined();
+
+    const entrypoint = runtime.entrypoints
+      .snapshot()
+      .find(value => value.key === 'xmpt-inbox');
+
+    expect(entrypoint).toBeDefined();
+    expect(entrypoint?.handler).toBeDefined();
+  });
+
+  it('tags inbox skill for manifest discoverability', async () => {
+    const runtime = await createAgent({
+      name: 'discoverable-agent',
+      version: '1.0.0',
+    })
+      .use(a2a())
+      .use(http())
+      .use(xmpt())
+      .build();
+
+    const manifest = runtime.manifest.build('https://agent.example.com');
+    const inboxSkill = manifest.skills?.find(
+      skill => skill.id === 'xmpt-inbox'
+    );
+
+    expect(inboxSkill).toBeDefined();
+    expect(inboxSkill?.tags).toContain('xmpt');
+    expect(inboxSkill?.tags).toContain('xmpt-inbox');
+  });
+
+  it('keeps existing manifest skills unchanged', async () => {
+    const runtime = await createAgent({
+      name: 'compat-agent',
+      version: '1.0.0',
+    })
+      .addEntrypoint({
+        key: 'echo',
+        input: z.object({ text: z.string() }),
+        output: z.object({ text: z.string() }),
+        handler: async ctx => ({
+          output: { text: (ctx.input as { text: string }).text },
+        }),
+      })
+      .use(a2a())
+      .use(http())
+      .use(xmpt())
+      .build();
+
+    const manifest = runtime.manifest.build('https://agent.example.com');
+    const echoSkill = manifest.skills?.find(skill => skill.id === 'echo');
+
+    expect(echoSkill).toBeDefined();
+    expect(echoSkill?.tags).toBeUndefined();
+  });
+
+  it('fails to build when a2a runtime is missing', async () => {
+    await expect(
+      createAgent({
+        name: 'missing-a2a',
+        version: '1.0.0',
+      })
+        .use(http())
+        .use(xmpt())
+        .build()
+    ).rejects.toThrow('[XMPT_PEER_UNREACHABLE]');
+  });
+
+  it('fails fast for invalid configuration', () => {
+    expect(() => xmpt({ inbox: { key: '   ' } })).toThrow(
+      '[XMPT_INVALID_CONFIG]'
+    );
+  });
+});

--- a/packages/xmpt/src/__tests__/runtime.test.ts
+++ b/packages/xmpt/src/__tests__/runtime.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it, mock } from 'bun:test';
+import type { AgentCard, A2AClient, A2ARuntime } from '@lucid-agents/types/a2a';
+import type { AgentRuntime } from '@lucid-agents/types/core';
+import type { XMPTMessage } from '@lucid-agents/types/xmpt';
+
+import { createXMPTRuntime } from '../runtime';
+
+const peerCard: AgentCard = {
+  name: 'peer-agent',
+  version: '1.0.0',
+  url: 'https://peer.example.com/',
+  skills: [
+    {
+      id: 'xmpt-inbox',
+      tags: ['xmpt-inbox'],
+    },
+  ],
+};
+
+function createMockRuntime(options?: {
+  fetchCard?: ReturnType<typeof mock>;
+  sendMessage?: ReturnType<typeof mock>;
+  getTask?: ReturnType<typeof mock>;
+}): AgentRuntime {
+  const fetchCard =
+    options?.fetchCard ??
+    mock(async () => {
+      return peerCard;
+    });
+
+  const sendMessage =
+    options?.sendMessage ??
+    mock(async () => ({
+      taskId: 'task-1',
+      status: 'running' as const,
+    }));
+
+  const getTask =
+    options?.getTask ??
+    mock(async () => ({
+      taskId: 'task-1',
+      status: 'completed' as const,
+      result: {
+        output: {
+          id: 'reply-1',
+          threadId: 'thread-1',
+          content: { text: 'ack:hello' },
+          createdAt: new Date().toISOString(),
+        },
+      },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }));
+
+  const client: A2AClient = {
+    invoke: mock(async () => ({ status: 'succeeded' })),
+    stream: mock(async () => {}),
+    fetchAndInvoke: mock(async () => ({ status: 'succeeded' })),
+    sendMessage,
+    getTask,
+    subscribeTask: mock(async () => {}),
+    fetchAndSendMessage: mock(async () => ({
+      taskId: 'task-1',
+      status: 'running' as const,
+    })),
+    listTasks: mock(async () => ({ tasks: [] })),
+    cancelTask: mock(async () => ({
+      taskId: 'task-1',
+      status: 'cancelled' as const,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    })),
+  };
+
+  const a2aRuntime: A2ARuntime = {
+    buildCard: mock(() => ({ ...peerCard, entrypoints: {} })),
+    fetchCard,
+    fetchCardWithEntrypoints: mock(async () => ({
+      ...peerCard,
+      entrypoints: {},
+    })),
+    client,
+  };
+
+  return {
+    agent: {
+      config: {
+        meta: {
+          name: 'alpha',
+          version: '1.0.0',
+        },
+      },
+      addEntrypoint: mock(),
+      getEntrypoint: mock(),
+      listEntrypoints: mock(() => []),
+    },
+    a2a: a2aRuntime,
+    entrypoints: {
+      add: mock(),
+      list: mock(() => []),
+      snapshot: mock(() => []),
+    },
+    manifest: {
+      build: mock(() => ({ ...peerCard, entrypoints: {} })),
+      invalidate: mock(),
+    },
+  };
+}
+
+describe('createXMPTRuntime', () => {
+  it('send() resolves peer URL and creates task message', async () => {
+    const fetchCard = mock(async () => peerCard);
+    const sendMessage = mock(async () => ({
+      taskId: 'task-123',
+      status: 'running' as const,
+    }));
+
+    const runtime = createMockRuntime({ fetchCard, sendMessage });
+    const xmpt = createXMPTRuntime({ runtime });
+
+    const result = await xmpt.send(
+      { url: 'https://peer.example.com' },
+      {
+        threadId: 'thread-123',
+        content: { text: 'hello' },
+      }
+    );
+
+    expect(result.taskId).toBe('task-123');
+    expect(result.status).toBe('running');
+    expect(result.messageId).toBeDefined();
+    expect(fetchCard).toHaveBeenCalledWith(
+      'https://peer.example.com',
+      undefined
+    );
+
+    const firstCall = sendMessage.mock.calls[0];
+    expect(firstCall).toBeDefined();
+
+    const [, skillId, input, , taskOptions] = firstCall as unknown as [
+      AgentCard,
+      string,
+      XMPTMessage,
+      unknown,
+      { contextId: string },
+    ];
+
+    expect(skillId).toBe('xmpt-inbox');
+    expect(input.threadId).toBe('thread-123');
+    expect(taskOptions.contextId).toBe('thread-123');
+  });
+
+  it('receive() invokes inbox handler and returns reply', async () => {
+    const inboxHandler = mock(
+      async ({ message }: { message: XMPTMessage }) => ({
+        content: { text: `ack:${message.content.text}` },
+      })
+    );
+
+    const runtime = createMockRuntime();
+    const xmpt = createXMPTRuntime({ runtime, inboxHandler });
+
+    const incoming: XMPTMessage = {
+      id: 'incoming-1',
+      threadId: 'thread-1',
+      from: 'beta',
+      content: { text: 'hello' },
+      createdAt: new Date().toISOString(),
+    };
+
+    const reply = await xmpt.receive(incoming);
+
+    expect(reply).toBeDefined();
+    expect(reply?.threadId).toBe('thread-1');
+    expect(reply?.content.text).toBe('ack:hello');
+    expect(inboxHandler).toHaveBeenCalledTimes(1);
+
+    const messages = await xmpt.listMessages({ threadId: 'thread-1' });
+    expect(messages).toHaveLength(2);
+    expect(messages[0]?.direction).toBe('inbound');
+    expect(messages[1]?.direction).toBe('outbound');
+  });
+
+  it('sendAndWait() returns completed task result', async () => {
+    const runtime = createMockRuntime({
+      getTask: mock(async () => ({
+        taskId: 'task-1',
+        status: 'completed' as const,
+        result: {
+          output: {
+            id: 'reply-1',
+            threadId: 'thread-send-and-wait',
+            content: { text: 'ack:hello' },
+            createdAt: new Date().toISOString(),
+          },
+        },
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })),
+    });
+
+    const xmpt = createXMPTRuntime({ runtime });
+
+    const result = await xmpt.sendAndWait(
+      { card: peerCard },
+      {
+        threadId: 'thread-send-and-wait',
+        content: { text: 'hello' },
+      }
+    );
+
+    expect(result.delivery.taskId).toBe('task-1');
+    expect(result.task.status).toBe('completed');
+    expect(result.task.result?.output?.threadId).toBe('thread-send-and-wait');
+    expect(result.task.result?.output?.content.text).toBe('ack:hello');
+  });
+
+  it('throws deterministic error when inbox skill is missing', async () => {
+    const fetchCard = mock(async () => ({
+      ...peerCard,
+      skills: [],
+    }));
+
+    const runtime = createMockRuntime({ fetchCard });
+    const xmpt = createXMPTRuntime({ runtime });
+
+    await expect(
+      xmpt.send(
+        { url: 'https://peer.example.com' },
+        {
+          content: { text: 'hello' },
+        }
+      )
+    ).rejects.toThrow('[XMPT_INBOX_SKILL_MISSING]');
+  });
+
+  it('listMessages() filters by thread and records inbound/outbound flows', async () => {
+    const runtime = createMockRuntime();
+    const xmpt = createXMPTRuntime({ runtime });
+
+    await xmpt.send(
+      { card: peerCard },
+      {
+        threadId: 'thread-1',
+        content: { text: 'outbound' },
+      }
+    );
+
+    await xmpt.receive({
+      id: 'inbound-1',
+      threadId: 'thread-1',
+      from: 'peer',
+      content: { text: 'inbound' },
+      createdAt: new Date().toISOString(),
+    });
+
+    await xmpt.receive({
+      id: 'other-thread',
+      threadId: 'thread-2',
+      from: 'peer',
+      content: { text: 'other' },
+      createdAt: new Date().toISOString(),
+    });
+
+    const threadMessages = await xmpt.listMessages({ threadId: 'thread-1' });
+    expect(threadMessages).toHaveLength(2);
+    expect(
+      threadMessages.some(message => message.direction === 'inbound')
+    ).toBe(true);
+    expect(
+      threadMessages.some(message => message.direction === 'outbound')
+    ).toBe(true);
+  });
+
+  it('onMessage() subscribes and unsubscribes handlers', async () => {
+    const runtime = createMockRuntime();
+    const xmpt = createXMPTRuntime({ runtime });
+
+    const handler = mock(async (_message: XMPTMessage) => {});
+    const unsubscribe = xmpt.onMessage(handler);
+
+    await xmpt.receive({
+      id: 'm-1',
+      threadId: 'thread-1',
+      content: { text: 'hello' },
+      createdAt: new Date().toISOString(),
+    });
+
+    unsubscribe();
+
+    await xmpt.receive({
+      id: 'm-2',
+      threadId: 'thread-2',
+      content: { text: 'hello-again' },
+      createdAt: new Date().toISOString(),
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/xmpt/src/__tests__/runtime.test.ts
+++ b/packages/xmpt/src/__tests__/runtime.test.ts
@@ -215,6 +215,74 @@ describe('createXMPTRuntime', () => {
     expect(result.task.result?.output?.content.text).toBe('ack:hello');
   });
 
+  it('sendAndWait() returns cancelled tasks instead of timing out', async () => {
+    const runtime = createMockRuntime({
+      getTask: mock(async () => ({
+        taskId: 'task-cancelled',
+        status: 'cancelled' as const,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })),
+      sendMessage: mock(async () => ({
+        taskId: 'task-cancelled',
+        status: 'running' as const,
+      })),
+    });
+
+    const xmpt = createXMPTRuntime({ runtime });
+
+    const result = await xmpt.sendAndWait(
+      { card: peerCard },
+      {
+        threadId: 'thread-cancelled',
+        content: { text: 'hello' },
+      },
+      { timeoutMs: 20 }
+    );
+
+    expect(result.delivery.taskId).toBe('task-cancelled');
+    expect(result.task.status).toBe('cancelled');
+  });
+
+  it('sendAndWait() forwards fetch override to task polling', async () => {
+    const fetchOverride = mock(async () => new Response('ok'));
+    const getTask = mock(async () => ({
+      taskId: 'task-fetch',
+      status: 'completed' as const,
+      result: {
+        output: {
+          id: 'reply-fetch',
+          threadId: 'thread-fetch',
+          content: { text: 'ack:hello' },
+          createdAt: new Date().toISOString(),
+        },
+      },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }));
+    const runtime = createMockRuntime({
+      getTask,
+      sendMessage: mock(async () => ({
+        taskId: 'task-fetch',
+        status: 'running' as const,
+      })),
+    });
+
+    const xmpt = createXMPTRuntime({ runtime });
+
+    const result = await xmpt.sendAndWait(
+      { card: peerCard },
+      {
+        threadId: 'thread-fetch',
+        content: { text: 'hello' },
+      },
+      { fetch: fetchOverride }
+    );
+
+    expect(result.task.status).toBe('completed');
+    expect(getTask).toHaveBeenCalledWith(peerCard, 'task-fetch', fetchOverride);
+  });
+
   it('send() succeeds even when store append fails after peer delivery', async () => {
     const sendMessage = mock(async () => ({
       taskId: 'task-store-failure',

--- a/packages/xmpt/src/__tests__/store.test.ts
+++ b/packages/xmpt/src/__tests__/store.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'bun:test';
+import type { XMPTMessageRecord } from '@lucid-agents/types/xmpt';
+
+import { createMemoryXMPTStore } from '../store/memory';
+
+const makeMessage = (
+  id: string,
+  threadId: string,
+  direction: XMPTMessageRecord['direction']
+): XMPTMessageRecord => ({
+  id,
+  threadId,
+  direction,
+  content: { text: id },
+  createdAt: new Date().toISOString(),
+});
+
+describe('createMemoryXMPTStore', () => {
+  it('stores and lists messages', async () => {
+    const store = createMemoryXMPTStore();
+
+    const first = makeMessage('m-1', 't-1', 'inbound');
+    const second = makeMessage('m-2', 't-1', 'outbound');
+
+    await store.append(first);
+    await store.append(second);
+
+    const listed = await store.list();
+    expect(listed).toHaveLength(2);
+    expect(listed[0]?.id).toBe('m-1');
+    expect(listed[1]?.id).toBe('m-2');
+  });
+
+  it('filters by threadId and direction', async () => {
+    const store = createMemoryXMPTStore([
+      makeMessage('m-1', 't-1', 'inbound'),
+      makeMessage('m-2', 't-1', 'outbound'),
+      makeMessage('m-3', 't-2', 'inbound'),
+    ]);
+
+    const threadMessages = await store.list({ threadId: 't-1' });
+    expect(threadMessages).toHaveLength(2);
+
+    const outboundMessages = await store.list({ direction: 'outbound' });
+    expect(outboundMessages).toHaveLength(1);
+    expect(outboundMessages[0]?.id).toBe('m-2');
+  });
+
+  it('supports offset and limit', async () => {
+    const store = createMemoryXMPTStore([
+      makeMessage('m-1', 't-1', 'inbound'),
+      makeMessage('m-2', 't-1', 'outbound'),
+      makeMessage('m-3', 't-1', 'inbound'),
+    ]);
+
+    const paged = await store.list({ offset: 1, limit: 1 });
+    expect(paged).toHaveLength(1);
+    expect(paged[0]?.id).toBe('m-2');
+  });
+});

--- a/packages/xmpt/src/client.ts
+++ b/packages/xmpt/src/client.ts
@@ -1,0 +1,174 @@
+import { randomUUID } from 'node:crypto';
+
+import type { AgentCard } from '@lucid-agents/types/a2a';
+import type {
+  XMPTMessage,
+  XMPTPeer,
+  XMPTSendInput,
+} from '@lucid-agents/types/xmpt';
+
+import { XMPTError } from './errors';
+
+export const XMPT_INBOX_DISCOVERY_TAG = 'xmpt-inbox';
+export const XMPT_DISCOVERY_TAG = 'xmpt';
+
+export function resolvePeerUrl(peer: XMPTPeer): string | undefined {
+  if ('url' in peer) {
+    return peer.url;
+  }
+  return peer.card.url;
+}
+
+export function resolveInboxSkillId(
+  card: AgentCard,
+  defaultInboxSkillId: string,
+  preferredSkillId?: string
+): string | undefined {
+  const skills = card.skills ?? [];
+
+  if (preferredSkillId) {
+    const preferred = skills.find(skill => skill.id === preferredSkillId);
+    if (preferred) {
+      return preferred.id;
+    }
+  }
+
+  const defaultSkill = skills.find(skill => skill.id === defaultInboxSkillId);
+  if (defaultSkill) {
+    return defaultSkill.id;
+  }
+
+  const taggedSkill = skills.find(skill =>
+    skill.tags?.some(tag => {
+      const normalized = tag.toLowerCase();
+      return (
+        normalized === XMPT_DISCOVERY_TAG ||
+        normalized === XMPT_INBOX_DISCOVERY_TAG
+      );
+    })
+  );
+
+  return taggedSkill?.id;
+}
+
+export function normalizeXMPTMessage(
+  input: XMPTSendInput,
+  defaults: {
+    from?: string;
+    to?: string;
+    now: string;
+  }
+): XMPTMessage {
+  assertXMPTContent(input.content);
+
+  const id = normalizeOptionalString(input.id) ?? randomUUID();
+  const threadId = normalizeOptionalString(input.threadId) ?? randomUUID();
+
+  return {
+    id,
+    threadId,
+    from: normalizeOptionalString(input.from) ?? defaults.from,
+    to: normalizeOptionalString(input.to) ?? defaults.to,
+    content: input.content,
+    metadata: input.metadata,
+    createdAt: normalizeOptionalString(input.createdAt) ?? defaults.now,
+  };
+}
+
+export function parseXMPTMessage(payload: unknown): XMPTMessage {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new XMPTError(
+      'XMPT_INVALID_MESSAGE_PAYLOAD',
+      'Message payload must be an object'
+    );
+  }
+
+  const value = payload as Record<string, unknown>;
+
+  const id = asRequiredString(value.id, 'id');
+  const threadId = asRequiredString(value.threadId, 'threadId');
+  const createdAt = asRequiredString(value.createdAt, 'createdAt');
+
+  const content = value.content;
+  assertXMPTContent(content);
+
+  const metadata =
+    value.metadata && typeof value.metadata === 'object'
+      ? (value.metadata as Record<string, unknown>)
+      : undefined;
+
+  return {
+    id,
+    threadId,
+    from: asOptionalString(value.from),
+    to: asOptionalString(value.to),
+    content,
+    metadata,
+    createdAt,
+  };
+}
+
+function assertXMPTContent(
+  content: unknown
+): asserts content is XMPTMessage['content'] {
+  if (!content || typeof content !== 'object' || Array.isArray(content)) {
+    throw new XMPTError(
+      'XMPT_INVALID_MESSAGE_PAYLOAD',
+      'Message content must be an object'
+    );
+  }
+
+  const value = content as Record<string, unknown>;
+
+  if (
+    value.text === undefined &&
+    value.data === undefined &&
+    value.mime === undefined
+  ) {
+    throw new XMPTError(
+      'XMPT_INVALID_MESSAGE_PAYLOAD',
+      'Message content requires at least one of text, data, or mime'
+    );
+  }
+
+  if (value.text !== undefined && typeof value.text !== 'string') {
+    throw new XMPTError(
+      'XMPT_INVALID_MESSAGE_PAYLOAD',
+      'Message content.text must be a string'
+    );
+  }
+
+  if (value.mime !== undefined && typeof value.mime !== 'string') {
+    throw new XMPTError(
+      'XMPT_INVALID_MESSAGE_PAYLOAD',
+      'Message content.mime must be a string'
+    );
+  }
+}
+
+function asRequiredString(value: unknown, key: string): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new XMPTError(
+      'XMPT_INVALID_MESSAGE_PAYLOAD',
+      `Message ${key} must be a non-empty string`
+    );
+  }
+
+  return value;
+}
+
+function asOptionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized ? normalized : undefined;
+}
+
+function normalizeOptionalString(
+  value: string | undefined
+): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}

--- a/packages/xmpt/src/errors.ts
+++ b/packages/xmpt/src/errors.ts
@@ -1,0 +1,15 @@
+export type XMPTErrorCode =
+  | 'XMPT_PEER_UNREACHABLE'
+  | 'XMPT_INBOX_SKILL_MISSING'
+  | 'XMPT_INVALID_MESSAGE_PAYLOAD'
+  | 'XMPT_TIMEOUT';
+
+export class XMPTError extends Error {
+  readonly code: XMPTErrorCode;
+
+  constructor(code: XMPTErrorCode, message: string, cause?: unknown) {
+    super(`[${code}] ${message}`, cause ? { cause } : undefined);
+    this.name = 'XMPTError';
+    this.code = code;
+  }
+}

--- a/packages/xmpt/src/extension.ts
+++ b/packages/xmpt/src/extension.ts
@@ -1,0 +1,134 @@
+import type { AgentCardWithEntrypoints } from '@lucid-agents/types/a2a';
+import type {
+  AgentRuntime,
+  BuildContext,
+  Extension,
+} from '@lucid-agents/types/core';
+import type {
+  XMPTInboxHandler,
+  XMPTMessage,
+  XMPTRuntime,
+  XMPTStore,
+} from '@lucid-agents/types/xmpt';
+import { z } from 'zod';
+
+import { XMPT_DISCOVERY_TAG, XMPT_INBOX_DISCOVERY_TAG } from './client';
+import { createXMPTRuntime, DEFAULT_XMPT_INBOX_SKILL_ID } from './runtime';
+
+export type XMPTExtensionOptions = {
+  inbox?: {
+    key?: string;
+    handler?: XMPTInboxHandler;
+  };
+  store?: XMPTStore;
+  discovery?: {
+    preferredSkillId?: string;
+  };
+};
+
+export function xmpt(
+  options: XMPTExtensionOptions = {}
+): Extension<{ xmpt: XMPTRuntime }> {
+  const inboxKey = options.inbox?.key?.trim() || DEFAULT_XMPT_INBOX_SKILL_ID;
+
+  if (options.inbox?.key !== undefined && !options.inbox.key.trim()) {
+    throw new Error(
+      '[XMPT_INVALID_CONFIG] inbox.key must be a non-empty string'
+    );
+  }
+
+  if (
+    options.inbox?.handler !== undefined &&
+    typeof options.inbox.handler !== 'function'
+  ) {
+    throw new Error('[XMPT_INVALID_CONFIG] inbox.handler must be a function');
+  }
+
+  if (
+    options.discovery?.preferredSkillId !== undefined &&
+    !options.discovery.preferredSkillId.trim()
+  ) {
+    throw new Error(
+      '[XMPT_INVALID_CONFIG] discovery.preferredSkillId must be a non-empty string'
+    );
+  }
+
+  const messageSchema = z.object({
+    id: z.string().min(1),
+    threadId: z.string().min(1),
+    from: z.string().min(1).optional(),
+    to: z.string().min(1).optional(),
+    content: z
+      .object({
+        text: z.string().optional(),
+        data: z.unknown().optional(),
+        mime: z.string().optional(),
+      })
+      .refine(
+        value =>
+          value.text !== undefined ||
+          value.data !== undefined ||
+          value.mime !== undefined,
+        {
+          message: 'content must include text, data, or mime',
+        }
+      ),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+    createdAt: z.string().min(1),
+  });
+
+  return {
+    name: 'xmpt',
+
+    build(_ctx: BuildContext): { xmpt: XMPTRuntime } {
+      return {
+        xmpt: {} as XMPTRuntime,
+      };
+    },
+
+    onBuild(runtime: AgentRuntime): void {
+      const xmptRuntime = createXMPTRuntime({
+        runtime,
+        inboxSkillId: inboxKey,
+        inboxHandler: options.inbox?.handler,
+        store: options.store,
+        preferredSkillId: options.discovery?.preferredSkillId,
+      });
+
+      runtime.xmpt = xmptRuntime;
+
+      runtime.entrypoints.add({
+        key: inboxKey,
+        description: 'XMPT inbox for receiving messages from peer agents',
+        input: messageSchema,
+        output: messageSchema.nullable(),
+        handler: async ctx => {
+          const reply = await runtime.xmpt!.receive(ctx.input as XMPTMessage);
+          return {
+            output: reply ?? null,
+            usage: { total_tokens: 0 },
+          };
+        },
+      });
+    },
+
+    onManifestBuild(
+      card: AgentCardWithEntrypoints,
+      _runtime: AgentRuntime
+    ): AgentCardWithEntrypoints {
+      const skills = card.skills ?? [];
+      const inboxSkill = skills.find(skill => skill.id === inboxKey);
+      if (!inboxSkill) {
+        return card;
+      }
+
+      const tags = new Set<string>(inboxSkill.tags ?? []);
+      tags.add(XMPT_DISCOVERY_TAG);
+      tags.add(XMPT_INBOX_DISCOVERY_TAG);
+      inboxSkill.tags = Array.from(tags);
+      inboxSkill.x_xmpt = { inbox: true };
+
+      return card;
+    },
+  };
+}

--- a/packages/xmpt/src/index.ts
+++ b/packages/xmpt/src/index.ts
@@ -1,0 +1,8 @@
+export { xmpt, type XMPTExtensionOptions } from './extension';
+export {
+  createXMPTRuntime,
+  DEFAULT_XMPT_INBOX_SKILL_ID,
+  type CreateXMPTRuntimeOptions,
+} from './runtime';
+export { createMemoryXMPTStore } from './store/memory';
+export { XMPTError, type XMPTErrorCode } from './errors';

--- a/packages/xmpt/src/runtime.ts
+++ b/packages/xmpt/src/runtime.ts
@@ -1,0 +1,299 @@
+import { waitForTask } from '@lucid-agents/a2a';
+import type { AgentCard, Task } from '@lucid-agents/types/a2a';
+import type { AgentRuntime } from '@lucid-agents/types/core';
+import type {
+  XMPTDeliveryResult,
+  XMPTInboxHandler,
+  XMPTListMessagesFilters,
+  XMPTMessage,
+  XMPTMessageRecord,
+  XMPTOnMessageHandler,
+  XMPTPeer,
+  XMPTRuntime,
+  XMPTSendAndWaitResult,
+  XMPTSendInput,
+  XMPTSendOptions,
+  XMPTStore,
+} from '@lucid-agents/types/xmpt';
+
+import {
+  normalizeXMPTMessage,
+  parseXMPTMessage,
+  resolveInboxSkillId,
+  resolvePeerUrl,
+} from './client';
+import { XMPTError } from './errors';
+import { createMemoryXMPTStore } from './store/memory';
+
+export const DEFAULT_XMPT_INBOX_SKILL_ID = 'xmpt-inbox';
+
+export type CreateXMPTRuntimeOptions = {
+  runtime: AgentRuntime;
+  inboxSkillId?: string;
+  inboxHandler?: XMPTInboxHandler;
+  store?: XMPTStore;
+  preferredSkillId?: string;
+  now?: () => string;
+};
+
+export function createXMPTRuntime(
+  options: CreateXMPTRuntimeOptions
+): XMPTRuntime {
+  if (!options.runtime.a2a) {
+    throw new XMPTError(
+      'XMPT_PEER_UNREACHABLE',
+      'A2A runtime is required for XMPT'
+    );
+  }
+
+  const runtime = options.runtime;
+  const store = options.store ?? createMemoryXMPTStore();
+  const now = options.now ?? (() => new Date().toISOString());
+  const inboxSkillId =
+    options.inboxSkillId?.trim() || DEFAULT_XMPT_INBOX_SKILL_ID;
+  const subscribers = new Set<XMPTOnMessageHandler>();
+
+  const notifySubscribers = async (message: XMPTMessage): Promise<void> => {
+    for (const handler of subscribers) {
+      await handler(message);
+    }
+  };
+
+  const appendRecord = async (message: XMPTMessageRecord): Promise<void> => {
+    await Promise.resolve(store.append(message));
+  };
+
+  const resolvePeerCard = async (
+    peer: XMPTPeer,
+    fetchImpl: XMPTSendOptions['fetch']
+  ): Promise<AgentCard> => {
+    if ('card' in peer) {
+      return peer.card;
+    }
+
+    try {
+      return await runtime.a2a!.fetchCard(peer.url, fetchImpl);
+    } catch (error) {
+      throw new XMPTError(
+        'XMPT_PEER_UNREACHABLE',
+        `Unable to fetch peer card from ${peer.url}`,
+        error
+      );
+    }
+  };
+
+  const sendInternal = async (
+    peer: XMPTPeer,
+    message: XMPTSendInput,
+    optionsArg?: XMPTSendOptions
+  ): Promise<{
+    card: AgentCard;
+    normalized: XMPTMessage;
+    delivery: XMPTDeliveryResult;
+    peerUrl?: string;
+  }> => {
+    const normalized = normalizeXMPTMessage(message, {
+      from: runtime.agent.config.meta.name,
+      to: undefined,
+      now: now(),
+    });
+
+    const card = await resolvePeerCard(peer, optionsArg?.fetch);
+
+    const resolvedSkillId =
+      optionsArg?.skillId ??
+      resolveInboxSkillId(card, inboxSkillId, options.preferredSkillId);
+
+    if (!resolvedSkillId) {
+      throw new XMPTError(
+        'XMPT_INBOX_SKILL_MISSING',
+        `Peer does not expose an inbox skill (expected ${inboxSkillId})`
+      );
+    }
+
+    try {
+      const task = await runtime.a2a!.client.sendMessage(
+        card,
+        resolvedSkillId,
+        normalized,
+        optionsArg?.fetch,
+        {
+          contextId: normalized.threadId,
+          metadata: {
+            ...(optionsArg?.metadata ?? {}),
+            xmpt: {
+              messageId: normalized.id,
+              threadId: normalized.threadId,
+            },
+          },
+        }
+      );
+
+      const delivery: XMPTDeliveryResult = {
+        taskId: task.taskId,
+        status: task.status,
+        messageId: normalized.id,
+      };
+
+      const peerUrl = resolvePeerUrl(peer);
+      await appendRecord({
+        ...normalized,
+        direction: 'outbound',
+        peer: peerUrl,
+        taskId: task.taskId,
+      });
+
+      return {
+        card,
+        normalized,
+        delivery,
+        peerUrl,
+      };
+    } catch (error) {
+      throw new XMPTError(
+        'XMPT_PEER_UNREACHABLE',
+        'Failed to send message to peer inbox',
+        error
+      );
+    }
+  };
+
+  const receive = async (
+    message: XMPTMessage
+  ): Promise<XMPTMessage | undefined> => {
+    const parsedMessage = parseXMPTMessage(message);
+
+    await appendRecord({
+      ...parsedMessage,
+      direction: 'inbound',
+      peer: parsedMessage.from,
+    });
+
+    await notifySubscribers(parsedMessage);
+
+    const inboxHandler = options.inboxHandler;
+    if (!inboxHandler) {
+      return undefined;
+    }
+
+    const reply = await inboxHandler({
+      message: parsedMessage,
+      runtime,
+    });
+
+    if (!reply) {
+      return undefined;
+    }
+
+    const replyMessage = normalizeXMPTMessage(
+      {
+        content: reply.content,
+        metadata: reply.metadata,
+        threadId: reply.threadId ?? parsedMessage.threadId,
+        to: reply.to ?? parsedMessage.from,
+      },
+      {
+        from: runtime.agent.config.meta.name,
+        to: parsedMessage.from,
+        now: now(),
+      }
+    );
+
+    await appendRecord({
+      ...replyMessage,
+      direction: 'outbound',
+      peer: parsedMessage.from,
+    });
+
+    return replyMessage;
+  };
+
+  return {
+    async send(
+      peer: XMPTPeer,
+      message: XMPTSendInput,
+      optionsArg?: XMPTSendOptions
+    ): Promise<XMPTDeliveryResult> {
+      const sent = await sendInternal(peer, message, optionsArg);
+      return sent.delivery;
+    },
+
+    async sendAndWait(
+      peer: XMPTPeer,
+      message: XMPTSendInput,
+      optionsArg?: XMPTSendOptions
+    ): Promise<XMPTSendAndWaitResult> {
+      const sent = await sendInternal(peer, message, optionsArg);
+
+      let task: Task<XMPTMessage | null>;
+      try {
+        const resolvedTask = await waitForTask(
+          runtime.a2a!.client,
+          sent.card,
+          sent.delivery.taskId,
+          optionsArg?.timeoutMs ?? 30000
+        );
+
+        if (
+          resolvedTask.status === 'completed' &&
+          resolvedTask.result?.output !== undefined &&
+          resolvedTask.result?.output !== null
+        ) {
+          const parsedReply = parseXMPTMessage(resolvedTask.result.output);
+
+          await appendRecord({
+            ...parsedReply,
+            direction: 'inbound',
+            peer: sent.peerUrl,
+            taskId: sent.delivery.taskId,
+          });
+
+          await notifySubscribers(parsedReply);
+
+          task = {
+            ...resolvedTask,
+            result: {
+              ...resolvedTask.result,
+              output: parsedReply,
+            },
+          };
+        } else {
+          task = resolvedTask as Task<XMPTMessage | null>;
+        }
+      } catch (error) {
+        if (error instanceof XMPTError) {
+          throw error;
+        }
+
+        const messageText =
+          error instanceof Error ? error.message : 'Task wait failed';
+
+        if (messageText.includes('did not complete within')) {
+          throw new XMPTError('XMPT_TIMEOUT', messageText, error);
+        }
+
+        throw new XMPTError('XMPT_PEER_UNREACHABLE', messageText, error);
+      }
+
+      return {
+        delivery: sent.delivery,
+        task,
+      };
+    },
+
+    receive,
+
+    onMessage(handler: XMPTOnMessageHandler): () => void {
+      subscribers.add(handler);
+      return () => {
+        subscribers.delete(handler);
+      };
+    },
+
+    async listMessages(
+      filters?: XMPTListMessagesFilters
+    ): Promise<XMPTMessageRecord[]> {
+      return await Promise.resolve(store.list(filters));
+    },
+  };
+}

--- a/packages/xmpt/src/runtime.ts
+++ b/packages/xmpt/src/runtime.ts
@@ -247,7 +247,8 @@ export function createXMPTRuntime(
           runtime.a2a!.client,
           sent.card,
           sent.delivery.taskId,
-          optionsArg?.timeoutMs ?? 30000
+          optionsArg?.timeoutMs ?? 30000,
+          optionsArg?.fetch
         );
 
         if (

--- a/packages/xmpt/src/store/memory.ts
+++ b/packages/xmpt/src/store/memory.ts
@@ -1,0 +1,42 @@
+import type {
+  XMPTListMessagesFilters,
+  XMPTMessageRecord,
+  XMPTStore,
+} from '@lucid-agents/types/xmpt';
+
+export function createMemoryXMPTStore(
+  initialMessages: XMPTMessageRecord[] = []
+): XMPTStore {
+  const messages: XMPTMessageRecord[] = [...initialMessages];
+
+  return {
+    append(message: XMPTMessageRecord): void {
+      messages.push(message);
+    },
+
+    list(filters?: XMPTListMessagesFilters): XMPTMessageRecord[] {
+      let result = [...messages];
+
+      if (filters?.threadId) {
+        result = result.filter(
+          message => message.threadId === filters.threadId
+        );
+      }
+
+      if (filters?.direction) {
+        result = result.filter(
+          message => message.direction === filters.direction
+        );
+      }
+
+      const offset = Math.max(filters?.offset ?? 0, 0);
+      const limit = filters?.limit;
+
+      if (limit !== undefined) {
+        return result.slice(offset, offset + Math.max(limit, 0));
+      }
+
+      return result.slice(offset);
+    },
+  };
+}

--- a/packages/xmpt/tsconfig.build.json
+++ b/packages/xmpt/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.build.base.json",
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "**/*.test.ts",
+    "**/__tests__/**"
+  ]
+}

--- a/packages/xmpt/tsconfig.json
+++ b/packages/xmpt/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/xmpt/tsup.config.ts
+++ b/packages/xmpt/tsup.config.ts
@@ -1,0 +1,11 @@
+import { definePackageConfig } from '../tsup.config.base';
+
+export default definePackageConfig({
+  entry: ['src/index.ts'],
+  dts: true,
+  external: [
+    '@lucid-agents/types',
+    '@lucid-agents/a2a',
+    'zod',
+  ],
+});

--- a/scripts/build-packages.ts
+++ b/scripts/build-packages.ts
@@ -97,6 +97,7 @@ async function buildPackages() {
     '@lucid-agents/analytics',
     '@lucid-agents/identity',
     '@lucid-agents/a2a',
+    '@lucid-agents/xmpt',
     '@lucid-agents/ap2',
     '@lucid-agents/http',
     '@lucid-agents/scheduler',


### PR DESCRIPTION
This PR introduces a new `@lucid-agents/xmpt` package that provides inbox-based, thread-aware messaging over A2A tasks with send, sendAndWait, receive, onMessage, listMessages, deterministic XMPT error codes, and an in-memory store.
It wires XMPT into `@lucid-agents/types` (including `AgentRuntime.xmpt` and the `./xmpt` export), adds core integration and discoverability coverage, and updates workspace build/dependency wiring.
It also adds a local two-agent XMPT example plus documentation updates in repo and examples READMEs.
Validation run: `bun run build:packages`, `bun test packages/xmpt/src/__tests__`, `bun test packages/core/src/__tests__/runtime.test.ts`, `bun run --cwd packages/xmpt type-check`, and `bun run --cwd packages/core type-check`.
Fixes #171.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added XMPT messaging extension: inbox-first agent-to-agent messaging with threading, send/sendAndWait, delivery results, subscriptions, and message history.

* **Documentation**
  * Added full XMPT docs, package README, and examples demonstrating local messaging flows, APIs, configuration, and use cases.

* **Tests**
  * Added unit and end-to-end tests covering send/receive, inbox handling, runtime behavior, store, subscriptions, and error/timeouts.

* **Chores**
  * Added initial XMPT package and updated build/configuration and package listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->