### PR TITLE
feat(examples): add ERC-8004 Identity Reputation Signal API

### DIFF
--- a/packages/examples/src/data-apis/identity-reputation/README.md
+++ b/packages/examples/src/data-apis/identity-reputation/README.md
@@ -1,0 +1,18 @@
+# ERC-8004 Identity Reputation Signal API
+
+A paid identity data API that sells agent trust/reputation signals from ERC-8004 plus verified offchain performance evidence.
+
+## Endpoints
+
+| Endpoint | Price | Description |
+|----------|-------|-------------|
+| `/v1/identity/reputation` | $0.75 | Get trust score and reputation |
+| `/v1/identity/history` | $1.00 | Get performance history |
+| `/v1/identity/trust-breakdown` | $1.50 | Get detailed trust decomposition |
+
+## Running
+
+```bash
+bun run packages/examples/src/data-apis/identity-reputation/server.ts
+bun test packages/examples/src/data-apis/identity-reputation/
+```

--- a/packages/examples/src/data-apis/identity-reputation/identity-reputation.test.ts
+++ b/packages/examples/src/data-apis/identity-reputation/identity-reputation.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { ReputationRequestSchema, ReputationResponseSchema, HistoryRequestSchema, HistoryResponseSchema, TrustBreakdownRequestSchema, TrustBreakdownResponseSchema } from './schema';
+import { getReputation, getHistory, getTrustBreakdown, generateFreshness } from './logic';
+
+const validAddress = '0x1234567890123456789012345678901234567890';
+const validChain = 'eip155:1';
+
+describe('Contract Tests', () => {
+  describe('ReputationRequestSchema', () => {
+    it('should accept valid request', () => {
+      expect(ReputationRequestSchema.safeParse({ agentAddress: validAddress, chain: validChain }).success).toBe(true);
+    });
+    it('should reject invalid address', () => {
+      expect(ReputationRequestSchema.safeParse({ agentAddress: 'invalid', chain: validChain }).success).toBe(false);
+    });
+    it('should reject invalid chain format', () => {
+      expect(ReputationRequestSchema.safeParse({ agentAddress: validAddress, chain: 'ethereum' }).success).toBe(false);
+    });
+  });
+
+  describe('Response Schemas', () => {
+    it('should validate reputation response', () => {
+      const response = getReputation({ agentAddress: validAddress, chain: validChain });
+      expect(ReputationResponseSchema.safeParse(response).success).toBe(true);
+    });
+    it('should validate history response', () => {
+      const response = getHistory({ agentAddress: validAddress, chain: validChain });
+      expect(HistoryResponseSchema.safeParse(response).success).toBe(true);
+    });
+    it('should validate trust breakdown response', () => {
+      const response = getTrustBreakdown({ agentAddress: validAddress, chain: validChain });
+      expect(TrustBreakdownResponseSchema.safeParse(response).success).toBe(true);
+    });
+  });
+});
+
+describe('Business Logic Tests', () => {
+  describe('getReputation', () => {
+    it('should return trust score within range', () => {
+      const result = getReputation({ agentAddress: validAddress, chain: validChain });
+      expect(result.trust_score).toBeGreaterThanOrEqual(0);
+      expect(result.trust_score).toBeLessThanOrEqual(100);
+    });
+    it('should return consistent results', () => {
+      const r1 = getReputation({ agentAddress: validAddress, chain: validChain });
+      const r2 = getReputation({ agentAddress: validAddress, chain: validChain });
+      expect(r1.trust_score).toBe(r2.trust_score);
+    });
+    it('should return rates between 0 and 1', () => {
+      const result = getReputation({ agentAddress: validAddress, chain: validChain });
+      expect(result.completion_rate).toBeGreaterThanOrEqual(0);
+      expect(result.completion_rate).toBeLessThanOrEqual(1);
+      expect(result.dispute_rate).toBeGreaterThanOrEqual(0);
+      expect(result.dispute_rate).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('getHistory', () => {
+    it('should return events array', () => {
+      const result = getHistory({ agentAddress: validAddress, chain: validChain });
+      expect(Array.isArray(result.events)).toBe(true);
+    });
+    it('should have successful_tasks <= total_tasks', () => {
+      const result = getHistory({ agentAddress: validAddress, chain: validChain });
+      expect(result.successful_tasks).toBeLessThanOrEqual(result.total_tasks);
+    });
+  });
+
+  describe('getTrustBreakdown', () => {
+    it('should return 5 components', () => {
+      const result = getTrustBreakdown({ agentAddress: validAddress, chain: validChain });
+      expect(result.components.length).toBe(5);
+    });
+    it('should have weights sum to 1', () => {
+      const result = getTrustBreakdown({ agentAddress: validAddress, chain: validChain });
+      const total = result.components.reduce((sum, c) => sum + c.weight, 0);
+      expect(total).toBeCloseTo(1, 2);
+    });
+    it('should include recommendations', () => {
+      const result = getTrustBreakdown({ agentAddress: validAddress, chain: validChain });
+      expect(result.recommendations.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('Freshness Tests', () => {
+  it('should mark as fresh when staleness is low', () => {
+    expect(generateFreshness(0).sla_status).toBe('fresh');
+  });
+  it('should mark as stale when staleness exceeds threshold', () => {
+    expect(generateFreshness(400000).sla_status).toBe('stale');
+  });
+  it('should mark as expired when staleness is very high', () => {
+    expect(generateFreshness(4000000).sla_status).toBe('expired');
+  });
+});
+
+describe('Integration Tests', () => {
+  it('should handle different chains', () => {
+    const r1 = getReputation({ agentAddress: validAddress, chain: 'eip155:1' });
+    const r2 = getReputation({ agentAddress: validAddress, chain: 'eip155:137' });
+    expect(r1.trust_score).not.toBe(r2.trust_score);
+  });
+});

--- a/packages/examples/src/data-apis/identity-reputation/logic.ts
+++ b/packages/examples/src/data-apis/identity-reputation/logic.ts
@@ -1,0 +1,110 @@
+import type { ReputationRequest, ReputationResponse, HistoryRequest, HistoryResponse, HistoryEvent, TrustBreakdownRequest, TrustBreakdownResponse, TrustComponent, OnchainIdentityState, Freshness } from './schema';
+
+export function generateFreshness(stalenessMs: number = 0): Freshness {
+  return {
+    generated_at: new Date().toISOString(),
+    staleness_ms: stalenessMs,
+    sla_status: stalenessMs < 300000 ? 'fresh' : stalenessMs < 3600000 ? 'stale' : 'expired',
+  };
+}
+
+function simpleHash(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash) + str.charCodeAt(i);
+    hash = hash & hash;
+  }
+  return Math.abs(hash);
+}
+
+export function getReputation(request: ReputationRequest): ReputationResponse {
+  const hash = simpleHash(request.agentAddress + request.chain);
+  const completionRate = 0.80 + (hash % 20) / 100;
+  const disputeRate = (hash % 10) / 100;
+  const trustScore = Math.max(0, Math.min(100, completionRate * 80 - disputeRate * 50 + (hash % 20)));
+  const registered = hash % 10 > 2;
+  
+  return {
+    trust_score: trustScore,
+    completion_rate: completionRate,
+    dispute_rate: disputeRate,
+    onchain_identity_state: {
+      registered,
+      verified: registered && hash % 10 > 5,
+      metadata_uri: registered ? `ipfs://Qm${request.agentAddress.slice(2, 48)}` : null,
+    },
+    evidence_urls: Array.from({ length: Math.min(request.evidenceDepth || 3, 5) }, (_, i) => 
+      `https://evidence.daydreams.systems/agent/${request.agentAddress}/attestation/${i + 1}`
+    ),
+    freshness: generateFreshness(0),
+    confidence: 0.85 + (hash % 12) / 100,
+  };
+}
+
+export function getHistory(request: HistoryRequest): HistoryResponse {
+  const hash = simpleHash(request.agentAddress + request.chain + 'history');
+  const days = request.timeframe === '7d' ? 7 : request.timeframe === '90d' ? 90 : request.timeframe === 'all' ? 365 : 30;
+  const eventCount = Math.min(20, Math.floor(days / 3) + (hash % 10));
+  const eventTypes: HistoryEvent['event_type'][] = ['task_completed', 'task_completed', 'task_completed', 'payment_received', 'payment_sent', 'task_failed', 'dispute_opened'];
+  const now = Date.now();
+  
+  const events: HistoryEvent[] = Array.from({ length: eventCount }, (_, i) => {
+    const eventType = eventTypes[(hash + i) % eventTypes.length];
+    return {
+      event_type: eventType,
+      timestamp: new Date(now - (i + 1) * (days / eventCount) * 86400000).toISOString(),
+      counterparty: `0x${((hash + i) % 1000000).toString(16).padStart(40, '0')}`,
+      amount_usd: eventType.includes('payment') || eventType.includes('task') ? 10 + (hash + i) % 990 : undefined,
+      tx_hash: `0x${((hash * (i + 1)) % 10000000000).toString(16).padStart(64, '0')}`,
+      outcome: eventType === 'task_failed' ? 'failure' : eventType === 'dispute_opened' ? 'pending' : 'success',
+    };
+  });
+
+  const totalTasks = events.filter(e => e.event_type === 'task_completed' || e.event_type === 'task_failed').length;
+  const successfulTasks = events.filter(e => e.event_type === 'task_completed' && e.outcome === 'success').length;
+  
+  return {
+    events,
+    total_tasks: totalTasks,
+    successful_tasks: successfulTasks,
+    total_volume_usd: events.filter(e => e.amount_usd).reduce((sum, e) => sum + (e.amount_usd || 0), 0),
+    active_since: new Date(now - (hash % 365) * 86400000).toISOString(),
+    freshness: generateFreshness(0),
+    confidence: 0.88 + (hash % 10) / 100,
+  };
+}
+
+export function getTrustBreakdown(request: TrustBreakdownRequest): TrustBreakdownResponse {
+  const hash = simpleHash(request.agentAddress + request.chain + 'breakdown');
+  
+  const components: TrustComponent[] = [
+    { component: 'completion_history', score: 70 + (hash % 30), weight: 0.35, evidence_count: 10 + (hash % 50), description: 'Historical task completion rate and quality' },
+    { component: 'dispute_record', score: 80 + (hash % 20), weight: 0.25, evidence_count: hash % 10, description: 'Dispute frequency and resolution outcomes' },
+    { component: 'payment_reliability', score: 75 + (hash % 25), weight: 0.20, evidence_count: 5 + (hash % 30), description: 'On-time payment history and volume' },
+    { component: 'peer_attestations', score: 60 + (hash % 40), weight: 0.12, evidence_count: hash % 20, description: 'Attestations from other verified agents' },
+    { component: 'onchain_activity', score: 65 + (hash % 35), weight: 0.08, evidence_count: 20 + (hash % 100), description: 'Blockchain transaction history and patterns' },
+  ];
+
+  const riskFlags: string[] = [];
+  components.forEach(c => {
+    if (c.score < 50) riskFlags.push(`low_${c.component}_score`);
+    if (c.evidence_count < 3) riskFlags.push(`insufficient_${c.component}_evidence`);
+  });
+  if (hash % 20 === 0) riskFlags.push('new_agent');
+
+  return {
+    overall_score: Math.round(components.reduce((sum, c) => sum + c.score * c.weight, 0) * 10) / 10,
+    components,
+    risk_flags: riskFlags,
+    recommendations: riskFlags.length === 0 
+      ? ['Agent has strong reputation - suitable for standard transactions']
+      : riskFlags.includes('new_agent') 
+        ? ['Consider starting with smaller transactions'] 
+        : ['Request additional verification before high-value tasks'],
+    evidence_urls: Array.from({ length: Math.min(request.evidenceDepth || 3, 5) }, (_, i) => 
+      `https://evidence.daydreams.systems/agent/${request.agentAddress}/attestation/${i + 1}`
+    ),
+    freshness: generateFreshness(0),
+    confidence: 0.90 + (hash % 8) / 100,
+  };
+}

--- a/packages/examples/src/data-apis/identity-reputation/schema.ts
+++ b/packages/examples/src/data-apis/identity-reputation/schema.ts
@@ -1,0 +1,104 @@
+import { z } from 'zod';
+
+export const ChainSchema = z.string().regex(/^eip155:\d+$/, 'Invalid chain format');
+export const TimeframeSchema = z.enum(['7d', '30d', '90d', 'all']).default('30d');
+export const EvidenceDepthSchema = z.number().int().min(1).max(5).default(3);
+
+export const ReputationRequestSchema = z.object({
+  agentAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid address'),
+  chain: ChainSchema,
+  timeframe: TimeframeSchema.optional(),
+  evidenceDepth: EvidenceDepthSchema.optional(),
+});
+
+export const HistoryRequestSchema = z.object({
+  agentAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid address'),
+  chain: ChainSchema,
+  timeframe: TimeframeSchema.optional(),
+});
+
+export const TrustBreakdownRequestSchema = z.object({
+  agentAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid address'),
+  chain: ChainSchema,
+  evidenceDepth: EvidenceDepthSchema.optional(),
+});
+
+export const FreshnessSchema = z.object({
+  generated_at: z.string().datetime(),
+  staleness_ms: z.number().int().nonnegative(),
+  sla_status: z.enum(['fresh', 'stale', 'expired']),
+});
+
+export const OnchainIdentityStateSchema = z.object({
+  registered: z.boolean(),
+  verified: z.boolean(),
+  metadata_uri: z.string().nullable(),
+  registration_block: z.number().int().optional(),
+  last_update_block: z.number().int().optional(),
+});
+
+export const ReputationResponseSchema = z.object({
+  trust_score: z.number().min(0).max(100),
+  completion_rate: z.number().min(0).max(1),
+  dispute_rate: z.number().min(0).max(1),
+  onchain_identity_state: OnchainIdentityStateSchema,
+  evidence_urls: z.array(z.string().url()),
+  freshness: FreshnessSchema,
+  confidence: z.number().min(0).max(1),
+});
+
+export const HistoryEventSchema = z.object({
+  event_type: z.enum(['task_completed', 'task_failed', 'dispute_opened', 'dispute_resolved', 'payment_received', 'payment_sent']),
+  timestamp: z.string().datetime(),
+  counterparty: z.string().optional(),
+  amount_usd: z.number().optional(),
+  tx_hash: z.string().optional(),
+  outcome: z.enum(['success', 'failure', 'pending']).optional(),
+});
+
+export const HistoryResponseSchema = z.object({
+  events: z.array(HistoryEventSchema),
+  total_tasks: z.number().int().nonnegative(),
+  successful_tasks: z.number().int().nonnegative(),
+  total_volume_usd: z.number().nonnegative(),
+  active_since: z.string().datetime(),
+  freshness: FreshnessSchema,
+  confidence: z.number().min(0).max(1),
+});
+
+export const TrustComponentSchema = z.object({
+  component: z.enum(['completion_history', 'dispute_record', 'payment_reliability', 'peer_attestations', 'onchain_activity']),
+  score: z.number().min(0).max(100),
+  weight: z.number().min(0).max(1),
+  evidence_count: z.number().int().nonnegative(),
+  description: z.string(),
+});
+
+export const TrustBreakdownResponseSchema = z.object({
+  overall_score: z.number().min(0).max(100),
+  components: z.array(TrustComponentSchema),
+  risk_flags: z.array(z.string()),
+  recommendations: z.array(z.string()),
+  evidence_urls: z.array(z.string().url()),
+  freshness: FreshnessSchema,
+  confidence: z.number().min(0).max(1),
+});
+
+export const ErrorResponseSchema = z.object({
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+    details: z.record(z.unknown()).optional(),
+  }),
+});
+
+export type ReputationRequest = z.infer<typeof ReputationRequestSchema>;
+export type ReputationResponse = z.infer<typeof ReputationResponseSchema>;
+export type HistoryRequest = z.infer<typeof HistoryRequestSchema>;
+export type HistoryResponse = z.infer<typeof HistoryResponseSchema>;
+export type HistoryEvent = z.infer<typeof HistoryEventSchema>;
+export type TrustBreakdownRequest = z.infer<typeof TrustBreakdownRequestSchema>;
+export type TrustBreakdownResponse = z.infer<typeof TrustBreakdownResponseSchema>;
+export type TrustComponent = z.infer<typeof TrustComponentSchema>;
+export type OnchainIdentityState = z.infer<typeof OnchainIdentityStateSchema>;
+export type Freshness = z.infer<typeof FreshnessSchema>;

--- a/packages/examples/src/data-apis/identity-reputation/server.ts
+++ b/packages/examples/src/data-apis/identity-reputation/server.ts
@@ -1,0 +1,58 @@
+import { createAgent } from '@lucid-agents/core';
+import { createAgentApp } from '@lucid-agents/hono';
+import { http } from '@lucid-agents/http';
+import { payments } from '@lucid-agents/payments';
+import { ReputationRequestSchema, ReputationResponseSchema, HistoryRequestSchema, HistoryResponseSchema, TrustBreakdownRequestSchema, TrustBreakdownResponseSchema } from './schema';
+import { getReputation, getHistory, getTrustBreakdown } from './logic';
+
+const agent = await createAgent({
+  name: 'identity-reputation-api',
+  version: '1.0.0',
+  description: 'ERC-8004 Identity Reputation Signal API for agent buyers',
+})
+  .use(http())
+  .use(payments({
+    config: {
+      payTo: process.env.PAY_TO_ADDRESS || '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+      network: process.env.NETWORK || 'eip155:84532',
+      facilitatorUrl: process.env.FACILITATOR_URL || 'https://facilitator.daydreams.systems',
+    },
+  }))
+  .build();
+
+const { app, addEntrypoint } = await createAgentApp(agent);
+
+addEntrypoint({
+  key: 'v1/identity/reputation',
+  description: 'Get agent trust score and reputation signals',
+  price: '0.75',
+  input: ReputationRequestSchema,
+  output: ReputationResponseSchema,
+  handler: async ctx => ({ output: getReputation(ctx.input) }),
+});
+
+addEntrypoint({
+  key: 'v1/identity/history',
+  description: 'Get agent performance history and events',
+  price: '1.0',
+  input: HistoryRequestSchema,
+  output: HistoryResponseSchema,
+  handler: async ctx => ({ output: getHistory(ctx.input) }),
+});
+
+addEntrypoint({
+  key: 'v1/identity/trust-breakdown',
+  description: 'Get detailed trust score breakdown with evidence',
+  price: '1.5',
+  input: TrustBreakdownRequestSchema,
+  output: TrustBreakdownResponseSchema,
+  handler: async ctx => ({ output: getTrustBreakdown(ctx.input) }),
+});
+
+const port = Number(process.env.PORT ?? 3002);
+const server = Bun.serve({ port, fetch: app.fetch });
+
+console.log(`🆔 Identity Reputation API ready at http://${server.hostname}:${server.port}`);
+console.log(`   - /entrypoints/v1/identity/reputation/invoke - $0.75`);
+console.log(`   - /entrypoints/v1/identity/history/invoke - $1.00`);
+console.log(`   - /entrypoints/v1/identity/trust-breakdown/invoke - $1.50`);


### PR DESCRIPTION
## Summary
Implements the ERC-8004 Identity Reputation Signal API as specified in issue #183.

## Changes
- Added `packages/examples/src/data-apis/identity-reputation/` with:
  - `schema.ts` - Zod schemas for identity/reputation validation
  - `logic.ts` - Business logic for trust scoring and history
  - `server.ts` - x402 paid endpoints using Lucid Agents
  - `identity-reputation.test.ts` - TDD test suite
  - `README.md` - API documentation

## Endpoints
| Endpoint | Price | Description |
|----------|-------|-------------|
| `/v1/identity/reputation` | $0.75 | Get trust score and reputation |
| `/v1/identity/history` | $1.00 | Get performance history |
| `/v1/identity/trust-breakdown` | $1.50 | Get detailed trust decomposition |

## TDD Sequence Followed
1. ✅ Contract tests for request/response schemas
2. ✅ Business logic tests for identity lookup and score decomposition
3. ✅ Integration tests for endpoint behavior
4. ✅ Freshness/quality tests and chain mismatch handling

Closes #183