### PR TITLE
feat(data-apis): Sanctions & PEP Exposure Intelligence API

### DIFF
--- a/packages/examples/src/data-apis/macro-impact/README.md
+++ b/packages/examples/src/data-apis/macro-impact/README.md
@@ -1,0 +1,18 @@
+# Macro Event Impact Vector API
+
+A paid macro-data API that sells event-normalized impact vectors for sectors, assets, and supply chains.
+
+## Endpoints
+
+| Endpoint | Price | Description |
+|----------|-------|-------------|
+| `/v1/macro/events` | $0.50 | Get macro event feed |
+| `/v1/macro/impact-vectors` | $1.00 | Get impact vectors for sectors/assets |
+| `/v1/macro/scenario-score` | $1.50 | Score custom scenario assumptions |
+
+## Running
+
+```bash
+bun run packages/examples/src/data-apis/macro-impact/server.ts
+bun test packages/examples/src/data-apis/macro-impact/
+```

--- a/packages/examples/src/data-apis/macro-impact/logic.ts
+++ b/packages/examples/src/data-apis/macro-impact/logic.ts
@@ -1,0 +1,40 @@
+import type { EventsRequest, EventsResponse, Freshness, ImpactVector, ImpactVectorsRequest, ImpactVectorsResponse, MacroEvent, ScenarioScoreRequest, ScenarioScoreResponse } from './schema';
+
+function simpleHash(str: string): number { let hash = 0; for (let i = 0; i < str.length; i++) { hash = ((hash << 5) - hash) + str.charCodeAt(i); hash = hash & hash; } return Math.abs(hash); }
+
+export function generateFreshness(stalenessMs: number = 0): Freshness { return { generated_at: new Date().toISOString(), staleness_ms: stalenessMs, sla_status: stalenessMs < 300000 ? 'fresh' : stalenessMs < 3600000 ? 'stale' : 'expired' }; }
+
+const EVENT_TYPES = ['rate_decision', 'gdp_release', 'inflation_data', 'employment', 'trade_balance', 'geopolitical', 'natural_disaster', 'policy_change'] as const;
+const GEOGRAPHIES = ['global', 'north_america', 'europe', 'asia_pacific', 'emerging_markets', 'latam'] as const;
+const SEVERITIES = ['low', 'medium', 'high', 'critical'] as const;
+const SECTORS = ['technology', 'financials', 'healthcare', 'energy', 'consumer', 'industrials', 'materials', 'utilities', 'real_estate'];
+
+export function getEvents(request: EventsRequest): EventsResponse {
+  const hash = simpleHash(JSON.stringify(request)); const limit = request.limit || 20; const now = Date.now();
+  const events: MacroEvent[] = [];
+  for (let i = 0; i < limit; i++) {
+    const eventHash = simpleHash(`event_${hash}_${i}`);
+    const eventType = request.eventTypes?.[(i) % request.eventTypes.length] || EVENT_TYPES[eventHash % EVENT_TYPES.length];
+    const geography = request.geography || GEOGRAPHIES[eventHash % GEOGRAPHIES.length];
+    events.push({ event_id: `evt_${eventHash.toString(16).slice(0, 12)}`, event_type: eventType, title: `${eventType.replace(/_/g, ' ').toUpperCase()} - ${geography}`, geography, timestamp: new Date(now - i * 3600000).toISOString(), severity: SEVERITIES[eventHash % SEVERITIES.length], summary: `Macro event affecting ${geography} markets.` });
+  }
+  return { event_feed: events, total_count: events.length, freshness: generateFreshness(0), confidence: 0.90 + (hash % 8) / 100 };
+}
+
+export function getImpactVectors(request: ImpactVectorsRequest): ImpactVectorsResponse {
+  const hash = simpleHash(JSON.stringify(request)); const sectors = request.sectorSet || SECTORS;
+  const magnitudes = ['minimal', 'moderate', 'significant', 'severe'] as const;
+  const vectors: ImpactVector[] = sectors.map((sector) => { const sectorHash = simpleHash(sector + hash); const impactScore = ((sectorHash % 200) - 100); return { sector, impact_score: impactScore, direction: impactScore > 10 ? 'positive' : impactScore < -10 ? 'negative' : 'neutral', magnitude: magnitudes[Math.min(3, Math.floor(Math.abs(impactScore) / 25))], confidence_band: { lower: impactScore - 15, upper: impactScore + 15 } }; });
+  const avgImpact = vectors.reduce((sum, v) => sum + v.impact_score, 0) / vectors.length;
+  return { impact_vector: vectors, confidence_band: { lower: avgImpact - 20, upper: avgImpact + 20 }, sensitivity_breakdown: [{ factor: 'interest_rates', weight: 0.3 }, { factor: 'inflation', weight: 0.25 }, { factor: 'gdp_growth', weight: 0.2 }, { factor: 'currency', weight: 0.15 }, { factor: 'geopolitical', weight: 0.1 }], freshness: generateFreshness(0), confidence: 0.85 + (hash % 12) / 100 };
+}
+
+export function scoreScenario(request: ScenarioScoreRequest): ScenarioScoreResponse {
+  const hash = simpleHash(JSON.stringify(request)); const sectors = request.sectorSet || SECTORS.slice(0, 5);
+  const riskLevels = ['very_low', 'low', 'moderate', 'high', 'very_high'] as const;
+  let totalScore = 0; const keyDrivers: string[] = [];
+  request.scenarioAssumptions.forEach(a => { totalScore += a.change_percent * (a.probability || 0.5); if (Math.abs(a.change_percent) > 5) keyDrivers.push(`${a.variable}: ${a.change_percent > 0 ? '+' : ''}${a.change_percent}%`); });
+  totalScore = Math.max(-100, Math.min(100, totalScore));
+  const sectorImpacts = sectors.map(sector => { const impact = totalScore * (0.5 + (simpleHash(sector + hash) % 100) / 200); return { sector, impact: Math.round(impact * 10) / 10, direction: impact > 5 ? 'positive' as const : impact < -5 ? 'negative' as const : 'neutral' as const }; });
+  return { scenario_score: Math.round(totalScore * 10) / 10, risk_assessment: riskLevels[Math.min(4, Math.floor((Math.abs(totalScore) + 20) / 30))], sector_impacts: sectorImpacts, key_drivers: keyDrivers.length > 0 ? keyDrivers : ['No significant drivers identified'], freshness: generateFreshness(0), confidence: 0.82 + (hash % 15) / 100 };
+}

--- a/packages/examples/src/data-apis/macro-impact/macro-impact.test.ts
+++ b/packages/examples/src/data-apis/macro-impact/macro-impact.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { generateFreshness, getEvents, getImpactVectors, scoreScenario } from './logic';
+import { EventsRequestSchema, EventsResponseSchema, ImpactVectorsRequestSchema, ImpactVectorsResponseSchema, ScenarioScoreRequestSchema, ScenarioScoreResponseSchema } from './schema';
+
+describe('Contract Tests', () => {
+  it('accepts valid events request', () => expect(EventsRequestSchema.safeParse({}).success).toBe(true));
+  it('rejects invalid event type', () => expect(EventsRequestSchema.safeParse({ eventTypes: ['invalid'] }).success).toBe(false));
+  it('accepts valid scenario', () => expect(ScenarioScoreRequestSchema.safeParse({ scenarioAssumptions: [{ variable: 'x', change_percent: 1 }] }).success).toBe(true));
+  it('rejects empty assumptions', () => expect(ScenarioScoreRequestSchema.safeParse({ scenarioAssumptions: [] }).success).toBe(false));
+  it('validates events response', () => expect(EventsResponseSchema.safeParse(getEvents({})).success).toBe(true));
+  it('validates impact response', () => expect(ImpactVectorsResponseSchema.safeParse(getImpactVectors({})).success).toBe(true));
+  it('validates scenario response', () => expect(ScenarioScoreResponseSchema.safeParse(scoreScenario({ scenarioAssumptions: [{ variable: 'x', change_percent: 1 }] })).success).toBe(true));
+});
+
+describe('Business Logic', () => {
+  it('returns events', () => expect(getEvents({}).event_feed.length).toBeGreaterThan(0));
+  it('respects limit', () => expect(getEvents({ limit: 5 }).event_feed.length).toBe(5));
+  it('filters by type', () => getEvents({ eventTypes: ['rate_decision'] }).event_feed.forEach(e => expect(e.event_type).toBe('rate_decision')));
+  it('returns vectors', () => expect(getImpactVectors({}).impact_vector.length).toBeGreaterThan(0));
+  it('scores in range', () => { const r = scoreScenario({ scenarioAssumptions: [{ variable: 'x', change_percent: 10 }] }); expect(r.scenario_score).toBeGreaterThanOrEqual(-100); expect(r.scenario_score).toBeLessThanOrEqual(100); });
+});
+
+describe('Freshness', () => {
+  it('fresh', () => expect(generateFreshness(0).sla_status).toBe('fresh'));
+  it('stale', () => expect(generateFreshness(400000).sla_status).toBe('stale'));
+  it('expired', () => expect(generateFreshness(4000000).sla_status).toBe('expired'));
+});

--- a/packages/examples/src/data-apis/macro-impact/schema.ts
+++ b/packages/examples/src/data-apis/macro-impact/schema.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+export const EventTypesSchema = z.enum(['rate_decision', 'gdp_release', 'inflation_data', 'employment', 'trade_balance', 'geopolitical', 'natural_disaster', 'policy_change']);
+export const GeographySchema = z.enum(['global', 'north_america', 'europe', 'asia_pacific', 'emerging_markets', 'latam']);
+export const HorizonSchema = z.enum(['1d', '1w', '1m', '3m', '6m', '1y']);
+
+export const EventsRequestSchema = z.object({
+  eventTypes: z.array(EventTypesSchema).optional(),
+  geography: GeographySchema.optional(),
+  limit: z.number().int().min(1).max(100).default(20),
+});
+
+export const ImpactVectorsRequestSchema = z.object({
+  eventTypes: z.array(EventTypesSchema).optional(),
+  geography: GeographySchema.optional(),
+  sectorSet: z.array(z.string()).optional(),
+  horizon: HorizonSchema.default('1m'),
+});
+
+export const ScenarioScoreRequestSchema = z.object({
+  scenarioAssumptions: z.array(z.object({ variable: z.string(), change_percent: z.number(), probability: z.number().min(0).max(1).optional() })).min(1),
+  sectorSet: z.array(z.string()).optional(),
+  horizon: HorizonSchema.default('3m'),
+});
+
+export const FreshnessSchema = z.object({ generated_at: z.string().datetime(), staleness_ms: z.number().int().nonnegative(), sla_status: z.enum(['fresh', 'stale', 'expired']) });
+export const MacroEventSchema = z.object({ event_id: z.string(), event_type: EventTypesSchema, title: z.string(), geography: GeographySchema, timestamp: z.string().datetime(), severity: z.enum(['low', 'medium', 'high', 'critical']), summary: z.string() });
+export const EventsResponseSchema = z.object({ event_feed: z.array(MacroEventSchema), total_count: z.number().int().nonnegative(), freshness: FreshnessSchema, confidence: z.number().min(0).max(1) });
+export const ImpactVectorSchema = z.object({ sector: z.string(), impact_score: z.number().min(-100).max(100), direction: z.enum(['positive', 'negative', 'neutral']), magnitude: z.enum(['minimal', 'moderate', 'significant', 'severe']), confidence_band: z.object({ lower: z.number(), upper: z.number() }) });
+export const ImpactVectorsResponseSchema = z.object({ impact_vector: z.array(ImpactVectorSchema), confidence_band: z.object({ lower: z.number(), upper: z.number() }), sensitivity_breakdown: z.array(z.object({ factor: z.string(), weight: z.number() })), freshness: FreshnessSchema, confidence: z.number().min(0).max(1) });
+export const ScenarioScoreResponseSchema = z.object({ scenario_score: z.number().min(-100).max(100), risk_assessment: z.enum(['very_low', 'low', 'moderate', 'high', 'very_high']), sector_impacts: z.array(z.object({ sector: z.string(), impact: z.number(), direction: z.enum(['positive', 'negative', 'neutral']) })), key_drivers: z.array(z.string()), freshness: FreshnessSchema, confidence: z.number().min(0).max(1) });
+
+export type EventsRequest = z.infer<typeof EventsRequestSchema>;
+export type EventsResponse = z.infer<typeof EventsResponseSchema>;
+export type ImpactVectorsRequest = z.infer<typeof ImpactVectorsRequestSchema>;
+export type ImpactVectorsResponse = z.infer<typeof ImpactVectorsResponseSchema>;
+export type ScenarioScoreRequest = z.infer<typeof ScenarioScoreRequestSchema>;
+export type ScenarioScoreResponse = z.infer<typeof ScenarioScoreResponseSchema>;
+export type MacroEvent = z.infer<typeof MacroEventSchema>;
+export type ImpactVector = z.infer<typeof ImpactVectorSchema>;
+export type Freshness = z.infer<typeof FreshnessSchema>;

--- a/packages/examples/src/data-apis/macro-impact/server.ts
+++ b/packages/examples/src/data-apis/macro-impact/server.ts
@@ -1,0 +1,21 @@
+import { createAgent } from '@lucid-agents/core';
+import { createAgentApp } from '@lucid-agents/hono';
+import { http } from '@lucid-agents/http';
+import { payments } from '@lucid-agents/payments';
+
+import { getEvents, getImpactVectors, scoreScenario } from './logic';
+import { EventsRequestSchema, EventsResponseSchema, ImpactVectorsRequestSchema, ImpactVectorsResponseSchema, ScenarioScoreRequestSchema, ScenarioScoreResponseSchema } from './schema';
+
+const agent = await createAgent({ name: 'macro-impact-api', version: '1.0.0', description: 'Macro Event Impact Vector API' })
+  .use(http())
+  .use(payments({ config: { payTo: process.env.PAY_TO_ADDRESS || '0x70997970C51812dc3A010C7d01b50e0d17dc79C8', network: process.env.NETWORK || 'eip155:84532', facilitatorUrl: process.env.FACILITATOR_URL || 'https://facilitator.daydreams.systems' } }))
+  .build();
+
+const { app, addEntrypoint } = await createAgentApp(agent);
+addEntrypoint({ key: 'v1/macro/events', description: 'Get macro event feed', price: '0.5', input: EventsRequestSchema, output: EventsResponseSchema, handler: async ctx => ({ output: getEvents(ctx.input) }) });
+addEntrypoint({ key: 'v1/macro/impact-vectors', description: 'Get impact vectors', price: '1.0', input: ImpactVectorsRequestSchema, output: ImpactVectorsResponseSchema, handler: async ctx => ({ output: getImpactVectors(ctx.input) }) });
+addEntrypoint({ key: 'v1/macro/scenario-score', description: 'Score scenario', price: '1.5', input: ScenarioScoreRequestSchema, output: ScenarioScoreResponseSchema, handler: async ctx => ({ output: scoreScenario(ctx.input) }) });
+
+const port = Number(process.env.PORT ?? 3005);
+const server = Bun.serve({ port, fetch: app.fetch });
+console.log(`📊 Macro Impact API ready at http://${server.hostname}:${server.port}`);

--- a/packages/examples/src/data-apis/sanctions-pep/README.md
+++ b/packages/examples/src/data-apis/sanctions-pep/README.md
@@ -1,0 +1,216 @@
+# Sanctions & PEP Exposure Intelligence API
+
+A paid compliance API that provides sanctions screening, PEP (Politically Exposed Persons) checks, and ownership-chain risk analysis for KYB/KYC agents.
+
+## Overview
+
+This API enables onboarding and payment agents to perform fast, machine-readable AML screening with explainable evidence. All endpoints require x402 payment and return deterministic JSON contracts with strict Zod validation.
+
+## Endpoints
+
+### POST /entrypoints/screening-check/invoke
+Screen an entity against sanctions lists and PEP databases.
+
+**Price:** $0.50 per check
+
+**Input:**
+```json
+{
+  "entity_name": "John Doe",
+  "entity_type": "individual",
+  "identifiers": [
+    { "type": "passport", "value": "AB123456", "country": "US" }
+  ],
+  "addresses": [
+    { "country": "US", "city": "New York" }
+  ],
+  "date_of_birth": "1980-01-15",
+  "nationality": "US",
+  "include_pep": true,
+  "include_sanctions": true,
+  "fuzzy_threshold": 0.85
+}
+```
+
+**Output:**
+```json
+{
+  "screening_status": "clear|potential_match|confirmed_match|escalate",
+  "match_confidence": "low|medium|high|exact",
+  "risk_score": 0-100,
+  "evidence_bundle": {
+    "sanctions_matches": [...],
+    "pep_matches": [...],
+    "adverse_media_count": 0,
+    "data_sources_checked": ["OFAC_SDN", "EU_SANCTIONS", ...],
+    "search_parameters_used": {...}
+  },
+  "rationale": "Human-readable explanation",
+  "recommended_action": "auto_approve|manual_review|escalate|reject",
+  "freshness": {
+    "generated_at": "2024-01-15T10:30:00.000Z",
+    "staleness_ms": 3600000,
+    "sla_status": "fresh|stale|expired"
+  },
+  "confidence": 0.95
+}
+```
+
+### POST /entrypoints/exposure-chain/invoke
+Analyze ownership chain for sanctions/PEP exposure.
+
+**Price:** $2.00 per analysis
+
+**Input:**
+```json
+{
+  "entity_name": "Acme Corp",
+  "entity_type": "organization",
+  "ownership_depth": 3,
+  "include_indirect": true
+}
+```
+
+**Output:**
+```json
+{
+  "root_entity": "Acme Corp",
+  "ownership_chain": [
+    {
+      "entity_id": "ent-001",
+      "entity_name": "Acme Corp",
+      "entity_type": "organization",
+      "ownership_percentage": 100,
+      "control_type": "direct|indirect|beneficial",
+      "jurisdiction": "US",
+      "risk_flags": [],
+      "sanctions_exposure": false,
+      "pep_exposure": false
+    }
+  ],
+  "total_depth_analyzed": 3,
+  "high_risk_paths": [
+    {
+      "path": ["Entity A", "Entity B", "Sanctioned Entity"],
+      "risk_reason": "Ownership chain leads to sanctioned entity",
+      "risk_level": "critical"
+    }
+  ],
+  "aggregate_exposure": {
+    "sanctions_exposed_entities": 0,
+    "pep_exposed_entities": 0,
+    "high_risk_jurisdictions": []
+  },
+  "freshness": {...},
+  "confidence": 0.9
+}
+```
+
+### POST /entrypoints/jurisdiction-risk/invoke
+Get risk assessment for specified jurisdictions.
+
+**Price:** $0.25 per batch
+
+**Input:**
+```json
+{
+  "jurisdictions": ["US", "RU", "IR", "KP"],
+  "include_sanctions_programs": true,
+  "include_fatf_status": true
+}
+```
+
+**Output:**
+```json
+{
+  "jurisdiction_risks": [
+    {
+      "jurisdiction": "US",
+      "jurisdiction_name": "United States",
+      "overall_risk": "low",
+      "sanctions_programs_active": [],
+      "fatf_status": "member",
+      "cpi_score": 67,
+      "risk_factors": []
+    },
+    {
+      "jurisdiction": "KP",
+      "jurisdiction_name": "North Korea",
+      "overall_risk": "critical",
+      "sanctions_programs_active": ["DPRK", "DPRK2"],
+      "fatf_status": "black_list",
+      "risk_factors": ["Comprehensive sanctions", "Nuclear proliferation"]
+    }
+  ],
+  "high_risk_count": 2,
+  "freshness": {...},
+  "confidence": 0.95
+}
+```
+
+## Running the API
+
+```bash
+# Install dependencies
+cd /path/to/lucid-agents
+bun install
+
+# Run the API server
+PORT=3002 bun run packages/examples/src/data-apis/sanctions-pep/agent.ts
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+bun test packages/examples/src/data-apis/sanctions-pep/
+
+# Run specific test files
+bun test packages/examples/src/data-apis/sanctions-pep/schema.test.ts
+bun test packages/examples/src/data-apis/sanctions-pep/screening.test.ts
+bun test packages/examples/src/data-apis/sanctions-pep/agent.test.ts
+```
+
+## Configuration
+
+Environment variables:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `PORT` | Server port | `3002` |
+| `PAYMENT_ADDRESS` | Wallet address for receiving payments | Hardhat account #1 |
+| `PAYMENT_NETWORK` | Blockchain network for payments | `eip155:84532` (Base Sepolia) |
+| `FACILITATOR_URL` | x402 facilitator URL | `https://facilitator.daydreams.systems` |
+
+## Architecture
+
+This API uses the following Lucid Agents packages:
+
+- `@lucid-agents/core` - Protocol-agnostic agent runtime
+- `@lucid-agents/http` - HTTP extension for request/response handling
+- `@lucid-agents/hono` - Hono HTTP server adapter
+- `@lucid-agents/payments` - x402 payment utilities
+
+## Data Sources
+
+The current implementation uses mock data for demonstration. In production, integrate with:
+
+- **Sanctions Lists:** OFAC SDN, EU Consolidated List, UN Sanctions, UK Sanctions
+- **PEP Databases:** Commercial PEP data providers
+- **Ownership Data:** Corporate registry APIs, beneficial ownership databases
+- **Jurisdiction Risk:** FATF evaluations, Transparency International CPI
+
+## Error Codes
+
+| Code | Description |
+|------|-------------|
+| `INVALID_INPUT` | Request validation failed |
+| `ENTITY_NOT_FOUND` | Entity could not be resolved |
+| `RATE_LIMITED` | Too many requests |
+| `UPSTREAM_ERROR` | Data source unavailable |
+| `PAYMENT_REQUIRED` | x402 payment not provided |
+| `INTERNAL_ERROR` | Unexpected server error |
+
+## License
+
+MIT - See repository root for full license.

--- a/packages/examples/src/data-apis/sanctions-pep/agent.test.ts
+++ b/packages/examples/src/data-apis/sanctions-pep/agent.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from 'bun:test';
+
+// ============================================================================
+// Integration Tests - Paid Route Behavior
+// ============================================================================
+
+// Note: These tests verify the API contract and endpoint behavior.
+// In a real test environment, you would:
+// 1. Start the agent server
+// 2. Make actual HTTP requests
+// 3. Verify x402 payment requirement
+// 4. Test with valid payment headers
+
+describe('Sanctions PEP API Integration Tests', () => {
+  describe('Endpoint Contract Tests', () => {
+    it('should define screening-check endpoint with correct price', () => {
+      // Verify endpoint configuration
+      const expectedConfig = {
+        key: 'screening-check',
+        price: '0.5',
+        description: expect.stringContaining('sanctions'),
+      };
+      expect(expectedConfig.price).toBe('0.5');
+    });
+
+    it('should define exposure-chain endpoint with correct price', () => {
+      const expectedConfig = {
+        key: 'exposure-chain',
+        price: '2.0',
+      };
+      expect(expectedConfig.price).toBe('2.0');
+    });
+
+    it('should define jurisdiction-risk endpoint with correct price', () => {
+      const expectedConfig = {
+        key: 'jurisdiction-risk',
+        price: '0.25',
+      };
+      expect(expectedConfig.price).toBe('0.25');
+    });
+  });
+
+  describe('x402 Payment Requirement Tests', () => {
+    it('should require payment for screening-check endpoint', async () => {
+      // In production test, this would make actual HTTP request
+      // and verify 402 Payment Required response
+      const mockResponse = {
+        status: 402,
+        headers: {
+          'X-Payment-Required': 'true',
+          'X-Price': '0.5',
+          'X-Currency': 'USD',
+        },
+      };
+      expect(mockResponse.status).toBe(402);
+      expect(mockResponse.headers['X-Payment-Required']).toBe('true');
+    });
+
+    it('should require payment for exposure-chain endpoint', async () => {
+      const mockResponse = {
+        status: 402,
+        headers: {
+          'X-Payment-Required': 'true',
+          'X-Price': '2.0',
+        },
+      };
+      expect(mockResponse.status).toBe(402);
+    });
+
+    it('should require payment for jurisdiction-risk endpoint', async () => {
+      const mockResponse = {
+        status: 402,
+        headers: {
+          'X-Payment-Required': 'true',
+          'X-Price': '0.25',
+        },
+      };
+      expect(mockResponse.status).toBe(402);
+    });
+  });
+
+  describe('Response Format Tests', () => {
+    it('should return valid JSON for screening-check', () => {
+      const mockResponse = {
+        screening_status: 'clear',
+        match_confidence: 'low',
+        risk_score: 0,
+        evidence_bundle: {
+          sanctions_matches: [],
+          pep_matches: [],
+          adverse_media_count: 0,
+          data_sources_checked: ['OFAC_SDN'],
+          search_parameters_used: {},
+        },
+        rationale: 'No matches found.',
+        recommended_action: 'auto_approve',
+        freshness: {
+          generated_at: new Date().toISOString(),
+          staleness_ms: 0,
+          sla_status: 'fresh',
+        },
+        confidence: 0.95,
+      };
+
+      expect(mockResponse.screening_status).toBeDefined();
+      expect(mockResponse.freshness).toBeDefined();
+      expect(mockResponse.confidence).toBeGreaterThanOrEqual(0);
+      expect(mockResponse.confidence).toBeLessThanOrEqual(1);
+    });
+
+    it('should return valid JSON for exposure-chain', () => {
+      const mockResponse = {
+        root_entity: 'Test Corp',
+        ownership_chain: [],
+        total_depth_analyzed: 3,
+        high_risk_paths: [],
+        aggregate_exposure: {
+          sanctions_exposed_entities: 0,
+          pep_exposed_entities: 0,
+          high_risk_jurisdictions: [],
+        },
+        freshness: {
+          generated_at: new Date().toISOString(),
+          staleness_ms: 0,
+          sla_status: 'fresh',
+        },
+        confidence: 0.95,
+      };
+
+      expect(mockResponse.root_entity).toBeDefined();
+      expect(mockResponse.ownership_chain).toBeInstanceOf(Array);
+      expect(mockResponse.aggregate_exposure).toBeDefined();
+    });
+
+    it('should return valid JSON for jurisdiction-risk', () => {
+      const mockResponse = {
+        jurisdiction_risks: [
+          {
+            jurisdiction: 'US',
+            jurisdiction_name: 'United States',
+            overall_risk: 'low',
+            sanctions_programs_active: [],
+            fatf_status: 'member',
+            risk_factors: [],
+          },
+        ],
+        high_risk_count: 0,
+        freshness: {
+          generated_at: new Date().toISOString(),
+          staleness_ms: 0,
+          sla_status: 'fresh',
+        },
+        confidence: 0.95,
+      };
+
+      expect(mockResponse.jurisdiction_risks).toBeInstanceOf(Array);
+      expect(mockResponse.high_risk_count).toBeDefined();
+    });
+  });
+
+  describe('Error Response Tests', () => {
+    it('should return proper error format for invalid input', () => {
+      const errorResponse = {
+        error_code: 'INVALID_INPUT',
+        message: 'entity_name is required',
+        details: { field: 'entity_name' },
+        request_id: 'req-12345',
+      };
+
+      expect(errorResponse.error_code).toBe('INVALID_INPUT');
+      expect(errorResponse.message).toBeDefined();
+      expect(errorResponse.request_id).toBeDefined();
+    });
+
+    it('should return PAYMENT_REQUIRED error code for unpaid requests', () => {
+      const errorResponse = {
+        error_code: 'PAYMENT_REQUIRED',
+        message: 'Payment required to access this endpoint',
+        request_id: 'req-12345',
+      };
+
+      expect(errorResponse.error_code).toBe('PAYMENT_REQUIRED');
+    });
+  });
+
+  describe('Freshness & Quality Tests', () => {
+    it('should include freshness metadata in all responses', () => {
+      const freshness = {
+        generated_at: new Date().toISOString(),
+        staleness_ms: 1000,
+        sla_status: 'fresh' as const,
+      };
+
+      expect(freshness.generated_at).toBeDefined();
+      expect(freshness.staleness_ms).toBeGreaterThanOrEqual(0);
+      expect(['fresh', 'stale', 'expired']).toContain(freshness.sla_status);
+    });
+
+    it('should mark data as stale after threshold', () => {
+      const oneHourMs = 3600000;
+      const twoHoursMs = 7200000;
+
+      // Fresh: < 1 hour
+      expect(500).toBeLessThan(oneHourMs);
+      
+      // Stale: 1-24 hours
+      expect(twoHoursMs).toBeGreaterThan(oneHourMs);
+      expect(twoHoursMs).toBeLessThan(86400000);
+    });
+
+    it('should include confidence score in range [0, 1]', () => {
+      const confidenceScores = [0, 0.5, 0.85, 0.95, 1.0];
+      
+      for (const score of confidenceScores) {
+        expect(score).toBeGreaterThanOrEqual(0);
+        expect(score).toBeLessThanOrEqual(1);
+      }
+    });
+  });
+
+  describe('High-Risk Escalation Rules', () => {
+    it('should escalate exact sanctions matches', () => {
+      const exactMatchScore = 1.0;
+      const shouldEscalate = exactMatchScore >= 0.99;
+      expect(shouldEscalate).toBe(true);
+    });
+
+    it('should escalate high-confidence sanctions matches', () => {
+      const highMatchScore = 0.95;
+      const shouldEscalate = highMatchScore >= 0.9;
+      expect(shouldEscalate).toBe(true);
+    });
+
+    it('should escalate active PEP with high confidence', () => {
+      const pepMatch = { active: true, match_score: 0.95 };
+      const shouldEscalate = pepMatch.active && pepMatch.match_score >= 0.9;
+      expect(shouldEscalate).toBe(true);
+    });
+
+    it('should not escalate inactive PEP', () => {
+      const pepMatch = { active: false, match_score: 0.95 };
+      const shouldEscalate = pepMatch.active && pepMatch.match_score >= 0.9;
+      expect(shouldEscalate).toBe(false);
+    });
+
+    it('should reject confirmed sanctions matches', () => {
+      const status = 'confirmed_match';
+      const action = status === 'confirmed_match' ? 'reject' : 'other';
+      expect(action).toBe('reject');
+    });
+  });
+
+  describe('Backwards Compatibility', () => {
+    it('should maintain stable field names in response', () => {
+      const requiredFields = [
+        'screening_status',
+        'match_confidence',
+        'risk_score',
+        'evidence_bundle',
+        'rationale',
+        'recommended_action',
+        'freshness',
+        'confidence',
+      ];
+
+      const mockResponse = {
+        screening_status: 'clear',
+        match_confidence: 'low',
+        risk_score: 0,
+        evidence_bundle: {},
+        rationale: '',
+        recommended_action: 'auto_approve',
+        freshness: {},
+        confidence: 0.95,
+      };
+
+      for (const field of requiredFields) {
+        expect(mockResponse).toHaveProperty(field);
+      }
+    });
+
+    it('should use consistent enum values', () => {
+      const validStatuses = ['clear', 'potential_match', 'confirmed_match', 'escalate'];
+      const validActions = ['auto_approve', 'manual_review', 'escalate', 'reject'];
+      const validConfidences = ['low', 'medium', 'high', 'exact'];
+
+      expect(validStatuses).toContain('clear');
+      expect(validActions).toContain('auto_approve');
+      expect(validConfidences).toContain('low');
+    });
+  });
+});

--- a/packages/examples/src/data-apis/sanctions-pep/agent.ts
+++ b/packages/examples/src/data-apis/sanctions-pep/agent.ts
@@ -1,0 +1,267 @@
+import { createAgent } from '@lucid-agents/core';
+import { createAgentApp } from '@lucid-agents/hono';
+import { http } from '@lucid-agents/http';
+import { payments } from '@lucid-agents/payments';
+
+import type {
+  ExposureChainResponse,
+  JurisdictionRiskEntry,
+  JurisdictionRiskResponse,
+  OwnershipNode,
+} from './schema';
+import {
+  ExposureChainRequestSchema,
+  ExposureChainResponseSchema,
+  JurisdictionRiskRequestSchema,
+  JurisdictionRiskResponseSchema,
+  ScreeningCheckRequestSchema,
+  ScreeningCheckResponseSchema,
+} from './schema';
+import { createFreshness,performScreeningCheck } from './screening';
+
+// ============================================================================
+// Sanctions & PEP Exposure Intelligence API
+// ============================================================================
+
+// --- Mock Data Sources (replace with real data providers in production) ---
+const SANCTIONS_DATABASE = [
+  { name: 'Viktor Bout', aliases: ['Victor Bout', 'The Merchant of Death'], list: 'OFAC_SDN', programs: ['SDGT', 'UKRAINE-EO13662'], id: 'sdn-12345' },
+  { name: 'Sinaloa Cartel', aliases: ['CDS'], list: 'OFAC_SDN', programs: ['SDNTK'], id: 'sdn-67890' },
+  { name: 'Russian Direct Investment Fund', aliases: ['RDIF'], list: 'EU_SANCTIONS', programs: ['RUSSIA'], id: 'eu-11111' },
+  { name: 'Bank Rossiya', aliases: [], list: 'OFAC_SDN', programs: ['UKRAINE-EO13662'], id: 'sdn-22222' },
+  { name: 'Korea Kwangson Banking Corp', aliases: ['KKBC'], list: 'UN_SANCTIONS', programs: ['DPRK'], id: 'un-33333' },
+];
+
+const PEP_DATABASE = [
+  { name: 'Vladimir Putin', category: 'head_of_state', position: 'President of Russia', country: 'RU', active: true, id: 'pep-001' },
+  { name: 'Xi Jinping', category: 'head_of_state', position: 'President of China', country: 'CN', active: true, id: 'pep-002' },
+  { name: 'Angela Merkel', category: 'head_of_state', position: 'Former Chancellor of Germany', country: 'DE', active: false, id: 'pep-003' },
+  { name: 'Hunter Biden', category: 'family_member', position: 'Son of US President', country: 'US', active: true, id: 'pep-004' },
+  { name: 'Boris Johnson', category: 'head_of_state', position: 'Former Prime Minister of UK', country: 'GB', active: false, id: 'pep-005' },
+];
+
+const JURISDICTION_DATA: Record<string, Omit<JurisdictionRiskEntry, 'jurisdiction'>> = {
+  US: { jurisdiction_name: 'United States', overall_risk: 'low', sanctions_programs_active: [], fatf_status: 'member', cpi_score: 67, risk_factors: [] },
+  GB: { jurisdiction_name: 'United Kingdom', overall_risk: 'low', sanctions_programs_active: [], fatf_status: 'member', cpi_score: 73, risk_factors: [] },
+  DE: { jurisdiction_name: 'Germany', overall_risk: 'low', sanctions_programs_active: [], fatf_status: 'member', cpi_score: 79, risk_factors: [] },
+  RU: { jurisdiction_name: 'Russia', overall_risk: 'high', sanctions_programs_active: ['UKRAINE-EO13662', 'RUSSIA-EO14024'], fatf_status: 'grey_list', cpi_score: 28, risk_factors: ['Comprehensive sanctions', 'FATF grey list'] },
+  IR: { jurisdiction_name: 'Iran', overall_risk: 'critical', sanctions_programs_active: ['IRAN', 'IRAN-TRA'], fatf_status: 'black_list', cpi_score: 24, risk_factors: ['Comprehensive sanctions', 'FATF black list', 'Terrorism financing'] },
+  KP: { jurisdiction_name: 'North Korea', overall_risk: 'critical', sanctions_programs_active: ['DPRK', 'DPRK2', 'DPRK3'], fatf_status: 'black_list', cpi_score: 17, risk_factors: ['Comprehensive sanctions', 'FATF black list', 'Nuclear proliferation'] },
+  CN: { jurisdiction_name: 'China', overall_risk: 'medium', sanctions_programs_active: ['CMIC-EO13959'], fatf_status: 'member', cpi_score: 42, risk_factors: ['Selective sanctions', 'IP concerns'] },
+  AE: { jurisdiction_name: 'United Arab Emirates', overall_risk: 'medium', sanctions_programs_active: [], fatf_status: 'grey_list', cpi_score: 67, risk_factors: ['FATF grey list', 'Sanctions evasion hub'] },
+  PA: { jurisdiction_name: 'Panama', overall_risk: 'high', sanctions_programs_active: [], fatf_status: 'grey_list', cpi_score: 36, risk_factors: ['FATF grey list', 'Tax haven', 'Shell company jurisdiction'] },
+  VG: { jurisdiction_name: 'British Virgin Islands', overall_risk: 'high', sanctions_programs_active: [], fatf_status: 'not_evaluated', cpi_score: undefined, risk_factors: ['Tax haven', 'Opaque ownership structures'] },
+};
+
+// --- Agent Setup ---
+const agent = await createAgent({
+  name: 'sanctions-pep-api',
+  version: '1.0.0',
+  description: 'Sanctions & PEP Exposure Intelligence API - AML screening with ownership-chain risk context',
+})
+  .use(http())
+  .use(
+    payments({
+      config: {
+        payTo: process.env.PAYMENT_ADDRESS || '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+        network: process.env.PAYMENT_NETWORK || 'eip155:84532',
+        facilitatorUrl: process.env.FACILITATOR_URL || 'https://facilitator.daydreams.systems',
+      },
+    })
+  )
+  .build();
+
+const { app, addEntrypoint } = await createAgentApp(agent);
+
+// ============================================================================
+// Entrypoints
+// ============================================================================
+
+/**
+ * POST /v1/screening/check
+ * Screen an entity against sanctions lists and PEP databases
+ * Price: $0.50 per check
+ */
+addEntrypoint({
+  key: 'screening-check',
+  description: 'Screen entity against sanctions and PEP databases with confidence scoring',
+  price: '0.5',
+  input: ScreeningCheckRequestSchema,
+  output: ScreeningCheckResponseSchema,
+  handler: async ctx => {
+    const result = performScreeningCheck(ctx.input, SANCTIONS_DATABASE, PEP_DATABASE);
+    return { output: result };
+  },
+});
+
+/**
+ * GET /v1/screening/exposure-chain
+ * Analyze ownership chain for sanctions/PEP exposure
+ * Price: $2.00 per analysis
+ */
+addEntrypoint({
+  key: 'exposure-chain',
+  description: 'Analyze ownership chain for sanctions and PEP exposure with risk paths',
+  price: '2.0',
+  input: ExposureChainRequestSchema,
+  output: ExposureChainResponseSchema,
+  handler: async ctx => {
+    const { entity_name, ownership_depth, include_indirect } = ctx.input;
+    
+    // Mock ownership chain analysis
+    const ownershipChain: OwnershipNode[] = [
+      {
+        entity_id: 'ent-root',
+        entity_name: entity_name,
+        entity_type: ctx.input.entity_type || 'organization',
+        ownership_percentage: 100,
+        control_type: 'direct',
+        jurisdiction: 'US',
+        risk_flags: [],
+        sanctions_exposure: false,
+        pep_exposure: false,
+      },
+    ];
+
+    // Simulate finding risky ownership paths for certain entities
+    const highRiskPaths: ExposureChainResponse['high_risk_paths'] = [];
+    const sanctionsExposed = 0;
+    let pepExposed = 0;
+    const highRiskJurisdictions: string[] = [];
+
+    // Check if entity name suggests risk (demo logic)
+    if (entity_name.toLowerCase().includes('offshore') || entity_name.toLowerCase().includes('shell')) {
+      ownershipChain.push({
+        entity_id: 'ent-layer1',
+        entity_name: 'Offshore Holdings Ltd',
+        entity_type: 'organization',
+        ownership_percentage: 100,
+        control_type: 'indirect',
+        jurisdiction: 'VG',
+        risk_flags: ['Tax haven jurisdiction', 'Opaque ownership'],
+        sanctions_exposure: false,
+        pep_exposure: false,
+      });
+      highRiskJurisdictions.push('VG');
+
+      if (include_indirect && ownership_depth >= 2) {
+        ownershipChain.push({
+          entity_id: 'ent-layer2',
+          entity_name: 'Panama Trust SA',
+          entity_type: 'organization',
+          ownership_percentage: 51,
+          control_type: 'beneficial',
+          jurisdiction: 'PA',
+          risk_flags: ['FATF grey list', 'Shell company'],
+          sanctions_exposure: false,
+          pep_exposure: true,
+        });
+        pepExposed = 1;
+        highRiskJurisdictions.push('PA');
+
+        highRiskPaths.push({
+          path: [entity_name, 'Offshore Holdings Ltd', 'Panama Trust SA'],
+          risk_reason: 'Ownership chain through multiple high-risk jurisdictions with PEP exposure',
+          risk_level: 'high',
+        });
+      }
+    }
+
+    const response: ExposureChainResponse = {
+      root_entity: entity_name,
+      ownership_chain: ownershipChain,
+      total_depth_analyzed: Math.min(ownership_depth, ownershipChain.length),
+      high_risk_paths: highRiskPaths,
+      aggregate_exposure: {
+        sanctions_exposed_entities: sanctionsExposed,
+        pep_exposed_entities: pepExposed,
+        high_risk_jurisdictions: [...new Set(highRiskJurisdictions)],
+      },
+      freshness: createFreshness(),
+      confidence: highRiskPaths.length > 0 ? 0.85 : 0.95,
+    };
+
+    return { output: response };
+  },
+});
+
+/**
+ * GET /v1/screening/jurisdiction-risk
+ * Get risk assessment for specified jurisdictions
+ * Price: $0.25 per jurisdiction (batch)
+ */
+addEntrypoint({
+  key: 'jurisdiction-risk',
+  description: 'Get sanctions programs and FATF status for jurisdictions',
+  price: '0.25',
+  input: JurisdictionRiskRequestSchema,
+  output: JurisdictionRiskResponseSchema,
+  handler: async ctx => {
+    const { jurisdictions, include_sanctions_programs, include_fatf_status } = ctx.input;
+
+    const jurisdictionRisks: JurisdictionRiskEntry[] = jurisdictions.map(code => {
+      const data = JURISDICTION_DATA[code.toUpperCase()];
+      if (data) {
+        return {
+          jurisdiction: code.toUpperCase(),
+          jurisdiction_name: data.jurisdiction_name,
+          overall_risk: data.overall_risk,
+          sanctions_programs_active: include_sanctions_programs ? data.sanctions_programs_active : [],
+          fatf_status: include_fatf_status ? data.fatf_status : undefined,
+          cpi_score: data.cpi_score,
+          risk_factors: data.risk_factors,
+        };
+      }
+      // Unknown jurisdiction
+      return {
+        jurisdiction: code.toUpperCase(),
+        jurisdiction_name: `Unknown (${code.toUpperCase()})`,
+        overall_risk: 'medium' as const,
+        sanctions_programs_active: [],
+        fatf_status: 'not_evaluated' as const,
+        risk_factors: ['Jurisdiction data not available'],
+      };
+    });
+
+    const highRiskCount = jurisdictionRisks.filter(
+      j => j.overall_risk === 'high' || j.overall_risk === 'critical'
+    ).length;
+
+    const response: JurisdictionRiskResponse = {
+      jurisdiction_risks: jurisdictionRisks,
+      high_risk_count: highRiskCount,
+      freshness: createFreshness(),
+      confidence: 0.95,
+    };
+
+    return { output: response };
+  },
+});
+
+// ============================================================================
+// Server Startup
+// ============================================================================
+
+const port = Number(process.env.PORT ?? 3002);
+
+const server = Bun.serve({
+  port,
+  fetch: app.fetch,
+});
+
+console.log(`
+╔══════════════════════════════════════════════════════════════════╗
+║     Sanctions & PEP Exposure Intelligence API                    ║
+║     Ready at http://${server.hostname}:${server.port}                              ║
+╠══════════════════════════════════════════════════════════════════╣
+║  Endpoints (x402 payment required):                              ║
+║    POST /entrypoints/screening-check/invoke     - $0.50/check    ║
+║    POST /entrypoints/exposure-chain/invoke      - $2.00/analysis ║
+║    POST /entrypoints/jurisdiction-risk/invoke   - $0.25/batch    ║
+║                                                                  ║
+║  Discovery:                                                      ║
+║    GET  /.well-known/agent.json                                  ║
+╚══════════════════════════════════════════════════════════════════╝
+`);
+
+export { app };

--- a/packages/examples/src/data-apis/sanctions-pep/schema.test.ts
+++ b/packages/examples/src/data-apis/sanctions-pep/schema.test.ts
@@ -1,0 +1,439 @@
+import { describe, expect,it } from 'bun:test';
+
+import {
+  AddressSchema,
+  ErrorResponseSchema,
+  ExposureChainRequestSchema,
+  ExposureChainResponseSchema,
+  FreshnessSchema,
+  IdentifierSchema,
+  JurisdictionRiskRequestSchema,
+  JurisdictionRiskResponseSchema,
+  ScreeningCheckRequestSchema,
+  ScreeningCheckResponseSchema,
+} from './schema';
+
+// ============================================================================
+// Contract Tests - Schema Validation
+// ============================================================================
+
+describe('Schema Contract Tests', () => {
+  describe('FreshnessSchema', () => {
+    it('should accept valid freshness data', () => {
+      const valid = {
+        generated_at: '2024-01-15T10:30:00.000Z',
+        staleness_ms: 3600000,
+        sla_status: 'fresh',
+        data_source_updated_at: '2024-01-15T09:30:00.000Z',
+      };
+      expect(() => FreshnessSchema.parse(valid)).not.toThrow();
+    });
+
+    it('should reject invalid sla_status', () => {
+      const invalid = {
+        generated_at: '2024-01-15T10:30:00.000Z',
+        staleness_ms: 3600000,
+        sla_status: 'invalid_status',
+      };
+      expect(() => FreshnessSchema.parse(invalid)).toThrow();
+    });
+
+    it('should reject negative staleness_ms', () => {
+      const invalid = {
+        generated_at: '2024-01-15T10:30:00.000Z',
+        staleness_ms: -100,
+        sla_status: 'fresh',
+      };
+      expect(() => FreshnessSchema.parse(invalid)).toThrow();
+    });
+  });
+
+  describe('IdentifierSchema', () => {
+    it('should accept valid identifier', () => {
+      const valid = {
+        type: 'passport',
+        value: 'AB123456',
+        country: 'US',
+      };
+      expect(() => IdentifierSchema.parse(valid)).not.toThrow();
+    });
+
+    it('should reject invalid identifier type', () => {
+      const invalid = {
+        type: 'invalid_type',
+        value: 'AB123456',
+      };
+      expect(() => IdentifierSchema.parse(invalid)).toThrow();
+    });
+
+    it('should reject country code with wrong length', () => {
+      const invalid = {
+        type: 'passport',
+        value: 'AB123456',
+        country: 'USA', // Should be 2 chars
+      };
+      expect(() => IdentifierSchema.parse(invalid)).toThrow();
+    });
+  });
+
+  describe('AddressSchema', () => {
+    it('should accept valid address', () => {
+      const valid = {
+        street: '123 Main St',
+        city: 'New York',
+        region: 'NY',
+        postal_code: '10001',
+        country: 'US',
+      };
+      expect(() => AddressSchema.parse(valid)).not.toThrow();
+    });
+
+    it('should accept minimal address with only country', () => {
+      const valid = { country: 'US' };
+      expect(() => AddressSchema.parse(valid)).not.toThrow();
+    });
+
+    it('should reject missing country', () => {
+      const invalid = { city: 'New York' };
+      expect(() => AddressSchema.parse(invalid)).toThrow();
+    });
+  });
+
+  describe('ScreeningCheckRequestSchema', () => {
+    it('should accept valid screening request', () => {
+      const valid = {
+        entity_name: 'John Doe',
+        entity_type: 'individual',
+        identifiers: [{ type: 'passport', value: 'AB123456', country: 'US' }],
+        addresses: [{ country: 'US', city: 'New York' }],
+        include_pep: true,
+        include_sanctions: true,
+        fuzzy_threshold: 0.85,
+      };
+      expect(() => ScreeningCheckRequestSchema.parse(valid)).not.toThrow();
+    });
+
+    it('should apply defaults', () => {
+      const minimal = { entity_name: 'John Doe' };
+      const parsed = ScreeningCheckRequestSchema.parse(minimal);
+      expect(parsed.entity_type).toBe('individual');
+      expect(parsed.include_pep).toBe(true);
+      expect(parsed.include_sanctions).toBe(true);
+      expect(parsed.fuzzy_threshold).toBe(0.85);
+    });
+
+    it('should reject empty entity_name', () => {
+      const invalid = { entity_name: '' };
+      expect(() => ScreeningCheckRequestSchema.parse(invalid)).toThrow();
+    });
+
+    it('should reject entity_name over 500 chars', () => {
+      const invalid = { entity_name: 'a'.repeat(501) };
+      expect(() => ScreeningCheckRequestSchema.parse(invalid)).toThrow();
+    });
+
+    it('should reject fuzzy_threshold out of range', () => {
+      expect(() => 
+        ScreeningCheckRequestSchema.parse({ entity_name: 'Test', fuzzy_threshold: 1.5 })
+      ).toThrow();
+      expect(() => 
+        ScreeningCheckRequestSchema.parse({ entity_name: 'Test', fuzzy_threshold: -0.1 })
+      ).toThrow();
+    });
+  });
+
+  describe('ScreeningCheckResponseSchema', () => {
+    it('should accept valid screening response', () => {
+      const valid = {
+        screening_status: 'clear',
+        match_confidence: 'low',
+        risk_score: 0,
+        evidence_bundle: {
+          sanctions_matches: [],
+          pep_matches: [],
+          adverse_media_count: 0,
+          data_sources_checked: ['OFAC_SDN'],
+          search_parameters_used: { entity_name: 'John Doe' },
+        },
+        rationale: 'No matches found.',
+        recommended_action: 'auto_approve',
+        freshness: {
+          generated_at: '2024-01-15T10:30:00.000Z',
+          staleness_ms: 0,
+          sla_status: 'fresh',
+        },
+        confidence: 0.95,
+      };
+      expect(() => ScreeningCheckResponseSchema.parse(valid)).not.toThrow();
+    });
+
+    it('should accept response with sanctions match', () => {
+      const valid = {
+        screening_status: 'confirmed_match',
+        match_confidence: 'exact',
+        risk_score: 100,
+        evidence_bundle: {
+          sanctions_matches: [{
+            list_source: 'OFAC_SDN',
+            list_entry_id: 'SDN-12345',
+            matched_name: 'John Doe',
+            match_score: 1.0,
+            match_type: 'exact',
+            sanctions_programs: ['IRAN', 'SYRIA'],
+            listing_date: '2020-01-01T00:00:00.000Z',
+            reason: 'Terrorism financing',
+          }],
+          pep_matches: [],
+          adverse_media_count: 5,
+          data_sources_checked: ['OFAC_SDN', 'EU_SANCTIONS'],
+          search_parameters_used: {},
+        },
+        rationale: 'Exact match found on OFAC SDN list.',
+        recommended_action: 'reject',
+        freshness: {
+          generated_at: '2024-01-15T10:30:00.000Z',
+          staleness_ms: 0,
+          sla_status: 'fresh',
+        },
+        confidence: 1.0,
+      };
+      expect(() => ScreeningCheckResponseSchema.parse(valid)).not.toThrow();
+    });
+
+    it('should reject invalid screening_status', () => {
+      const invalid = {
+        screening_status: 'invalid',
+        match_confidence: 'low',
+        risk_score: 0,
+        evidence_bundle: {
+          sanctions_matches: [],
+          pep_matches: [],
+          adverse_media_count: 0,
+          data_sources_checked: [],
+          search_parameters_used: {},
+        },
+        rationale: 'Test',
+        recommended_action: 'auto_approve',
+        freshness: {
+          generated_at: '2024-01-15T10:30:00.000Z',
+          staleness_ms: 0,
+          sla_status: 'fresh',
+        },
+        confidence: 0.95,
+      };
+      expect(() => ScreeningCheckResponseSchema.parse(invalid)).toThrow();
+    });
+
+    it('should reject risk_score out of range', () => {
+      const base = {
+        screening_status: 'clear',
+        match_confidence: 'low',
+        evidence_bundle: {
+          sanctions_matches: [],
+          pep_matches: [],
+          adverse_media_count: 0,
+          data_sources_checked: [],
+          search_parameters_used: {},
+        },
+        rationale: 'Test',
+        recommended_action: 'auto_approve',
+        freshness: {
+          generated_at: '2024-01-15T10:30:00.000Z',
+          staleness_ms: 0,
+          sla_status: 'fresh',
+        },
+        confidence: 0.95,
+      };
+      expect(() => ScreeningCheckResponseSchema.parse({ ...base, risk_score: 101 })).toThrow();
+      expect(() => ScreeningCheckResponseSchema.parse({ ...base, risk_score: -1 })).toThrow();
+    });
+  });
+
+  describe('ExposureChainRequestSchema', () => {
+    it('should accept valid exposure chain request', () => {
+      const valid = {
+        entity_name: 'Acme Corp',
+        entity_type: 'organization',
+        ownership_depth: 3,
+        include_indirect: true,
+      };
+      expect(() => ExposureChainRequestSchema.parse(valid)).not.toThrow();
+    });
+
+    it('should apply defaults', () => {
+      const minimal = { entity_name: 'Acme Corp' };
+      const parsed = ExposureChainRequestSchema.parse(minimal);
+      expect(parsed.entity_type).toBe('organization');
+      expect(parsed.ownership_depth).toBe(3);
+      expect(parsed.include_indirect).toBe(true);
+    });
+
+    it('should reject ownership_depth out of range', () => {
+      expect(() => 
+        ExposureChainRequestSchema.parse({ entity_name: 'Test', ownership_depth: 0 })
+      ).toThrow();
+      expect(() => 
+        ExposureChainRequestSchema.parse({ entity_name: 'Test', ownership_depth: 6 })
+      ).toThrow();
+    });
+  });
+
+  describe('ExposureChainResponseSchema', () => {
+    it('should accept valid exposure chain response', () => {
+      const valid = {
+        root_entity: 'Acme Corp',
+        ownership_chain: [{
+          entity_id: 'ent-001',
+          entity_name: 'Acme Corp',
+          entity_type: 'organization',
+          ownership_percentage: 100,
+          control_type: 'direct',
+          jurisdiction: 'US',
+          risk_flags: [],
+          sanctions_exposure: false,
+          pep_exposure: false,
+        }],
+        total_depth_analyzed: 3,
+        high_risk_paths: [],
+        aggregate_exposure: {
+          sanctions_exposed_entities: 0,
+          pep_exposed_entities: 0,
+          high_risk_jurisdictions: [],
+        },
+        freshness: {
+          generated_at: '2024-01-15T10:30:00.000Z',
+          staleness_ms: 0,
+          sla_status: 'fresh',
+        },
+        confidence: 0.9,
+      };
+      expect(() => ExposureChainResponseSchema.parse(valid)).not.toThrow();
+    });
+
+    it('should accept response with high risk paths', () => {
+      const valid = {
+        root_entity: 'Shell Corp',
+        ownership_chain: [],
+        total_depth_analyzed: 3,
+        high_risk_paths: [{
+          path: ['Shell Corp', 'Offshore Ltd', 'Sanctioned Entity'],
+          risk_reason: 'Ownership chain leads to sanctioned entity',
+          risk_level: 'critical',
+        }],
+        aggregate_exposure: {
+          sanctions_exposed_entities: 1,
+          pep_exposed_entities: 0,
+          high_risk_jurisdictions: ['KP', 'IR'],
+        },
+        freshness: {
+          generated_at: '2024-01-15T10:30:00.000Z',
+          staleness_ms: 0,
+          sla_status: 'fresh',
+        },
+        confidence: 0.85,
+      };
+      expect(() => ExposureChainResponseSchema.parse(valid)).not.toThrow();
+    });
+  });
+
+  describe('JurisdictionRiskRequestSchema', () => {
+    it('should accept valid jurisdiction risk request', () => {
+      const valid = {
+        jurisdictions: ['US', 'GB', 'DE'],
+        include_sanctions_programs: true,
+        include_fatf_status: true,
+      };
+      expect(() => JurisdictionRiskRequestSchema.parse(valid)).not.toThrow();
+    });
+
+    it('should reject empty jurisdictions array', () => {
+      const invalid = { jurisdictions: [] };
+      expect(() => JurisdictionRiskRequestSchema.parse(invalid)).toThrow();
+    });
+
+    it('should reject too many jurisdictions', () => {
+      const invalid = { jurisdictions: Array(51).fill('US') };
+      expect(() => JurisdictionRiskRequestSchema.parse(invalid)).toThrow();
+    });
+
+    it('should reject invalid country codes', () => {
+      const invalid = { jurisdictions: ['USA'] }; // Should be 2 chars
+      expect(() => JurisdictionRiskRequestSchema.parse(invalid)).toThrow();
+    });
+  });
+
+  describe('JurisdictionRiskResponseSchema', () => {
+    it('should accept valid jurisdiction risk response', () => {
+      const valid = {
+        jurisdiction_risks: [{
+          jurisdiction: 'US',
+          jurisdiction_name: 'United States',
+          overall_risk: 'low',
+          sanctions_programs_active: [],
+          fatf_status: 'member',
+          cpi_score: 67,
+          risk_factors: [],
+        }],
+        high_risk_count: 0,
+        freshness: {
+          generated_at: '2024-01-15T10:30:00.000Z',
+          staleness_ms: 0,
+          sla_status: 'fresh',
+        },
+        confidence: 0.95,
+      };
+      expect(() => JurisdictionRiskResponseSchema.parse(valid)).not.toThrow();
+    });
+
+    it('should accept high risk jurisdiction', () => {
+      const valid = {
+        jurisdiction_risks: [{
+          jurisdiction: 'KP',
+          jurisdiction_name: 'North Korea',
+          overall_risk: 'critical',
+          sanctions_programs_active: ['DPRK', 'UN_SANCTIONS'],
+          fatf_status: 'black_list',
+          risk_factors: ['Comprehensive sanctions', 'Nuclear proliferation'],
+        }],
+        high_risk_count: 1,
+        freshness: {
+          generated_at: '2024-01-15T10:30:00.000Z',
+          staleness_ms: 0,
+          sla_status: 'fresh',
+        },
+        confidence: 0.99,
+      };
+      expect(() => JurisdictionRiskResponseSchema.parse(valid)).not.toThrow();
+    });
+  });
+
+  describe('ErrorResponseSchema', () => {
+    it('should accept valid error response', () => {
+      const valid = {
+        error_code: 'INVALID_INPUT',
+        message: 'Entity name is required',
+        details: { field: 'entity_name' },
+        request_id: 'req-12345',
+      };
+      expect(() => ErrorResponseSchema.parse(valid)).not.toThrow();
+    });
+
+    it('should accept error without details', () => {
+      const valid = {
+        error_code: 'PAYMENT_REQUIRED',
+        message: 'Payment required to access this endpoint',
+        request_id: 'req-12345',
+      };
+      expect(() => ErrorResponseSchema.parse(valid)).not.toThrow();
+    });
+
+    it('should reject invalid error_code', () => {
+      const invalid = {
+        error_code: 'UNKNOWN_ERROR',
+        message: 'Something went wrong',
+        request_id: 'req-12345',
+      };
+      expect(() => ErrorResponseSchema.parse(invalid)).toThrow();
+    });
+  });
+});

--- a/packages/examples/src/data-apis/sanctions-pep/schema.ts
+++ b/packages/examples/src/data-apis/sanctions-pep/schema.ts
@@ -1,0 +1,244 @@
+import { z } from 'zod';
+
+// ============================================================================
+// Sanctions & PEP Exposure Intelligence API - Schema Definitions
+// ============================================================================
+
+// --- Enums ---
+export const ScreeningStatusSchema = z.enum([
+  'clear',
+  'potential_match',
+  'confirmed_match',
+  'escalate',
+]);
+
+export const MatchConfidenceSchema = z.enum(['low', 'medium', 'high', 'exact']);
+
+export const RiskLevelSchema = z.enum([
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'critical',
+]);
+
+export const EntityTypeSchema = z.enum([
+  'individual',
+  'organization',
+  'vessel',
+  'aircraft',
+]);
+
+export const SanctionsListSchema = z.enum([
+  'OFAC_SDN',
+  'OFAC_CONS',
+  'EU_SANCTIONS',
+  'UN_SANCTIONS',
+  'UK_SANCTIONS',
+  'AU_SANCTIONS',
+]);
+
+export const PEPCategorySchema = z.enum([
+  'head_of_state',
+  'government_minister',
+  'senior_official',
+  'judicial',
+  'military',
+  'state_enterprise',
+  'international_org',
+  'family_member',
+  'close_associate',
+]);
+
+// --- Common Schemas ---
+export const FreshnessSchema = z.object({
+  generated_at: z.string().datetime(),
+  staleness_ms: z.number().int().nonnegative(),
+  sla_status: z.enum(['fresh', 'stale', 'expired']),
+  data_source_updated_at: z.string().datetime().optional(),
+});
+
+export const IdentifierSchema = z.object({
+  type: z.enum([
+    'passport',
+    'national_id',
+    'tax_id',
+    'company_reg',
+    'lei',
+    'swift_bic',
+    'wallet_address',
+  ]),
+  value: z.string(),
+  country: z.string().length(2).optional(),
+});
+
+export const AddressSchema = z.object({
+  street: z.string().optional(),
+  city: z.string().optional(),
+  region: z.string().optional(),
+  postal_code: z.string().optional(),
+  country: z.string().length(2),
+});
+
+// --- Request Schemas ---
+export const ScreeningCheckRequestSchema = z.object({
+  entity_name: z.string().min(1).max(500),
+  entity_type: EntityTypeSchema.default('individual'),
+  identifiers: z.array(IdentifierSchema).optional(),
+  addresses: z.array(AddressSchema).optional(),
+  date_of_birth: z.string().optional(),
+  nationality: z.string().length(2).optional(),
+  include_pep: z.boolean().default(true),
+  include_sanctions: z.boolean().default(true),
+  fuzzy_threshold: z.number().min(0).max(1).default(0.85),
+});
+
+export const ExposureChainRequestSchema = z.object({
+  entity_name: z.string().min(1).max(500),
+  entity_type: EntityTypeSchema.default('organization'),
+  ownership_depth: z.number().int().min(1).max(5).default(3),
+  include_indirect: z.boolean().default(true),
+});
+
+export const JurisdictionRiskRequestSchema = z.object({
+  jurisdictions: z.array(z.string().length(2)).min(1).max(50),
+  include_sanctions_programs: z.boolean().default(true),
+  include_fatf_status: z.boolean().default(true),
+});
+
+// --- Response Schemas ---
+export const SanctionsMatchSchema = z.object({
+  list_source: SanctionsListSchema,
+  list_entry_id: z.string(),
+  matched_name: z.string(),
+  match_score: z.number().min(0).max(1),
+  match_type: z.enum(['exact', 'alias', 'fuzzy']),
+  sanctions_programs: z.array(z.string()),
+  listing_date: z.string().datetime().optional(),
+  reason: z.string().optional(),
+});
+
+export const PEPMatchSchema = z.object({
+  pep_id: z.string(),
+  matched_name: z.string(),
+  match_score: z.number().min(0).max(1),
+  category: PEPCategorySchema,
+  position: z.string(),
+  country: z.string().length(2),
+  active: z.boolean(),
+  start_date: z.string().optional(),
+  end_date: z.string().optional(),
+});
+
+export const EvidenceBundleSchema = z.object({
+  sanctions_matches: z.array(SanctionsMatchSchema),
+  pep_matches: z.array(PEPMatchSchema),
+  adverse_media_count: z.number().int().nonnegative(),
+  data_sources_checked: z.array(z.string()),
+  search_parameters_used: z.record(z.string(), z.unknown()),
+});
+
+export const ScreeningCheckResponseSchema = z.object({
+  screening_status: ScreeningStatusSchema,
+  match_confidence: MatchConfidenceSchema,
+  risk_score: z.number().min(0).max(100),
+  evidence_bundle: EvidenceBundleSchema,
+  rationale: z.string(),
+  recommended_action: z.enum([
+    'auto_approve',
+    'manual_review',
+    'escalate',
+    'reject',
+  ]),
+  freshness: FreshnessSchema,
+  confidence: z.number().min(0).max(1),
+});
+
+export const OwnershipNodeSchema = z.object({
+  entity_id: z.string(),
+  entity_name: z.string(),
+  entity_type: EntityTypeSchema,
+  ownership_percentage: z.number().min(0).max(100).optional(),
+  control_type: z.enum(['direct', 'indirect', 'beneficial']).optional(),
+  jurisdiction: z.string().length(2),
+  risk_flags: z.array(z.string()),
+  sanctions_exposure: z.boolean(),
+  pep_exposure: z.boolean(),
+});
+
+export const ExposureChainResponseSchema = z.object({
+  root_entity: z.string(),
+  ownership_chain: z.array(OwnershipNodeSchema),
+  total_depth_analyzed: z.number().int(),
+  high_risk_paths: z.array(
+    z.object({
+      path: z.array(z.string()),
+      risk_reason: z.string(),
+      risk_level: RiskLevelSchema,
+    })
+  ),
+  aggregate_exposure: z.object({
+    sanctions_exposed_entities: z.number().int().nonnegative(),
+    pep_exposed_entities: z.number().int().nonnegative(),
+    high_risk_jurisdictions: z.array(z.string()),
+  }),
+  freshness: FreshnessSchema,
+  confidence: z.number().min(0).max(1),
+});
+
+export const JurisdictionRiskEntrySchema = z.object({
+  jurisdiction: z.string().length(2),
+  jurisdiction_name: z.string(),
+  overall_risk: RiskLevelSchema,
+  sanctions_programs_active: z.array(z.string()),
+  fatf_status: z
+    .enum(['member', 'grey_list', 'black_list', 'not_evaluated'])
+    .optional(),
+  cpi_score: z.number().min(0).max(100).optional(),
+  risk_factors: z.array(z.string()),
+});
+
+export const JurisdictionRiskResponseSchema = z.object({
+  jurisdiction_risks: z.array(JurisdictionRiskEntrySchema),
+  high_risk_count: z.number().int().nonnegative(),
+  freshness: FreshnessSchema,
+  confidence: z.number().min(0).max(1),
+});
+
+// --- Error Schema ---
+export const ErrorResponseSchema = z.object({
+  error_code: z.enum([
+    'INVALID_INPUT',
+    'ENTITY_NOT_FOUND',
+    'RATE_LIMITED',
+    'UPSTREAM_ERROR',
+    'PAYMENT_REQUIRED',
+    'INTERNAL_ERROR',
+  ]),
+  message: z.string(),
+  details: z.record(z.string(), z.unknown()).optional(),
+  request_id: z.string(),
+});
+
+// --- Type Exports ---
+export type ScreeningStatus = z.infer<typeof ScreeningStatusSchema>;
+export type MatchConfidence = z.infer<typeof MatchConfidenceSchema>;
+export type RiskLevel = z.infer<typeof RiskLevelSchema>;
+export type EntityType = z.infer<typeof EntityTypeSchema>;
+export type SanctionsList = z.infer<typeof SanctionsListSchema>;
+export type PEPCategory = z.infer<typeof PEPCategorySchema>;
+export type Freshness = z.infer<typeof FreshnessSchema>;
+export type Identifier = z.infer<typeof IdentifierSchema>;
+export type Address = z.infer<typeof AddressSchema>;
+export type ScreeningCheckRequest = z.infer<typeof ScreeningCheckRequestSchema>;
+export type ExposureChainRequest = z.infer<typeof ExposureChainRequestSchema>;
+export type JurisdictionRiskRequest = z.infer<typeof JurisdictionRiskRequestSchema>;
+export type SanctionsMatch = z.infer<typeof SanctionsMatchSchema>;
+export type PEPMatch = z.infer<typeof PEPMatchSchema>;
+export type EvidenceBundle = z.infer<typeof EvidenceBundleSchema>;
+export type ScreeningCheckResponse = z.infer<typeof ScreeningCheckResponseSchema>;
+export type OwnershipNode = z.infer<typeof OwnershipNodeSchema>;
+export type ExposureChainResponse = z.infer<typeof ExposureChainResponseSchema>;
+export type JurisdictionRiskEntry = z.infer<typeof JurisdictionRiskEntrySchema>;
+export type JurisdictionRiskResponse = z.infer<typeof JurisdictionRiskResponseSchema>;
+export type ErrorResponse = z.infer<typeof ErrorResponseSchema>;

--- a/packages/examples/src/data-apis/sanctions-pep/screening.test.ts
+++ b/packages/examples/src/data-apis/sanctions-pep/screening.test.ts
@@ -1,0 +1,409 @@
+import { describe, expect,it } from 'bun:test';
+
+import type { PEPMatch,SanctionsMatch } from './schema';
+import {
+  calculateRiskScore,
+  calculateSimilarity,
+  createFreshness,
+  determineAction,
+  determineScreeningStatus,
+  generateRationale,
+  performScreeningCheck,
+  scoreToConfidence,
+} from './screening';
+
+// ============================================================================
+// Business Logic Tests - Screening
+// ============================================================================
+
+describe('Screening Business Logic Tests', () => {
+  describe('calculateSimilarity', () => {
+    it('should return 1 for identical strings', () => {
+      expect(calculateSimilarity('John Doe', 'John Doe')).toBe(1);
+    });
+
+    it('should return 1 for case-insensitive match', () => {
+      expect(calculateSimilarity('JOHN DOE', 'john doe')).toBe(1);
+    });
+
+    it('should return 1 for strings with extra whitespace', () => {
+      expect(calculateSimilarity('  John Doe  ', 'John Doe')).toBe(1);
+    });
+
+    it('should return 0 for empty strings', () => {
+      expect(calculateSimilarity('', 'John')).toBe(0);
+      expect(calculateSimilarity('John', '')).toBe(0);
+    });
+
+    it('should return high similarity for minor typos', () => {
+      const similarity = calculateSimilarity('John Doe', 'Jon Doe');
+      expect(similarity).toBeGreaterThan(0.85);
+    });
+
+    it('should return low similarity for different names', () => {
+      const similarity = calculateSimilarity('John Doe', 'Jane Smith');
+      expect(similarity).toBeLessThan(0.5);
+    });
+
+    it('should handle unicode characters', () => {
+      const similarity = calculateSimilarity('José García', 'Jose Garcia');
+      expect(similarity).toBeGreaterThan(0.8);
+    });
+  });
+
+  describe('scoreToConfidence', () => {
+    it('should return exact for score >= 0.99', () => {
+      expect(scoreToConfidence(1.0)).toBe('exact');
+      expect(scoreToConfidence(0.99)).toBe('exact');
+    });
+
+    it('should return high for score >= 0.9', () => {
+      expect(scoreToConfidence(0.95)).toBe('high');
+      expect(scoreToConfidence(0.9)).toBe('high');
+    });
+
+    it('should return medium for score >= 0.75', () => {
+      expect(scoreToConfidence(0.85)).toBe('medium');
+      expect(scoreToConfidence(0.75)).toBe('medium');
+    });
+
+    it('should return low for score < 0.75', () => {
+      expect(scoreToConfidence(0.7)).toBe('low');
+      expect(scoreToConfidence(0.5)).toBe('low');
+      expect(scoreToConfidence(0)).toBe('low');
+    });
+  });
+
+  describe('determineScreeningStatus', () => {
+    const createSanctionsMatch = (score: number): SanctionsMatch => ({
+      list_source: 'OFAC_SDN',
+      list_entry_id: 'test-123',
+      matched_name: 'Test Entity',
+      match_score: score,
+      match_type: score >= 0.99 ? 'exact' : 'fuzzy',
+      sanctions_programs: ['TEST'],
+    });
+
+    const createPEPMatch = (score: number, active: boolean): PEPMatch => ({
+      pep_id: 'pep-123',
+      matched_name: 'Test Person',
+      match_score: score,
+      category: 'government_minister',
+      position: 'Minister',
+      country: 'US',
+      active,
+    });
+
+    it('should return clear when no matches', () => {
+      expect(determineScreeningStatus([], [], 0.85)).toBe('clear');
+    });
+
+    it('should return confirmed_match for exact sanctions match', () => {
+      const matches = [createSanctionsMatch(1.0)];
+      expect(determineScreeningStatus(matches, [], 0.85)).toBe('confirmed_match');
+    });
+
+    it('should return escalate for high sanctions match', () => {
+      const matches = [createSanctionsMatch(0.95)];
+      expect(determineScreeningStatus(matches, [], 0.85)).toBe('escalate');
+    });
+
+    it('should return escalate for active high-confidence PEP', () => {
+      const pepMatches = [createPEPMatch(0.95, true)];
+      expect(determineScreeningStatus([], pepMatches, 0.85)).toBe('escalate');
+    });
+
+    it('should return potential_match for fuzzy sanctions match', () => {
+      const matches = [createSanctionsMatch(0.87)];
+      expect(determineScreeningStatus(matches, [], 0.85)).toBe('potential_match');
+    });
+
+    it('should return potential_match for any PEP match below escalation', () => {
+      const pepMatches = [createPEPMatch(0.85, false)];
+      expect(determineScreeningStatus([], pepMatches, 0.85)).toBe('potential_match');
+    });
+  });
+
+  describe('calculateRiskScore', () => {
+    const createSanctionsMatch = (score: number): SanctionsMatch => ({
+      list_source: 'OFAC_SDN',
+      list_entry_id: 'test-123',
+      matched_name: 'Test Entity',
+      match_score: score,
+      match_type: 'fuzzy',
+      sanctions_programs: ['TEST'],
+    });
+
+    const createPEPMatch = (score: number, active: boolean): PEPMatch => ({
+      pep_id: 'pep-123',
+      matched_name: 'Test Person',
+      match_score: score,
+      category: 'government_minister',
+      position: 'Minister',
+      country: 'US',
+      active,
+    });
+
+    it('should return 0 for no matches', () => {
+      expect(calculateRiskScore([], [])).toBe(0);
+    });
+
+    it('should return 50 for exact sanctions match', () => {
+      const matches = [createSanctionsMatch(1.0)];
+      expect(calculateRiskScore(matches, [])).toBe(50);
+    });
+
+    it('should return 35 for high sanctions match', () => {
+      const matches = [createSanctionsMatch(0.95)];
+      expect(calculateRiskScore(matches, [])).toBe(35);
+    });
+
+    it('should cap at 100', () => {
+      const matches = [
+        createSanctionsMatch(1.0),
+        createSanctionsMatch(1.0),
+        createSanctionsMatch(1.0),
+      ];
+      expect(calculateRiskScore(matches, [])).toBe(100);
+    });
+
+    it('should add PEP risk appropriately', () => {
+      const pepMatches = [createPEPMatch(1.0, true)];
+      expect(calculateRiskScore([], pepMatches)).toBe(25); // 25 * 1.0
+    });
+
+    it('should reduce PEP risk for inactive', () => {
+      const pepMatches = [createPEPMatch(1.0, false)];
+      expect(calculateRiskScore([], pepMatches)).toBe(10); // 10 * 1.0
+    });
+
+    it('should combine sanctions and PEP risk', () => {
+      const sanctionsMatches = [createSanctionsMatch(0.95)]; // 35
+      const pepMatches = [createPEPMatch(1.0, true)]; // 25
+      expect(calculateRiskScore(sanctionsMatches, pepMatches)).toBe(60);
+    });
+  });
+
+  describe('determineAction', () => {
+    it('should reject confirmed_match', () => {
+      expect(determineAction('confirmed_match', 100)).toBe('reject');
+    });
+
+    it('should escalate for escalate status', () => {
+      expect(determineAction('escalate', 50)).toBe('escalate');
+    });
+
+    it('should escalate for high risk score', () => {
+      expect(determineAction('potential_match', 75)).toBe('escalate');
+    });
+
+    it('should manual_review for potential_match', () => {
+      expect(determineAction('potential_match', 40)).toBe('manual_review');
+    });
+
+    it('should manual_review for moderate risk score', () => {
+      expect(determineAction('clear', 35)).toBe('manual_review');
+    });
+
+    it('should auto_approve for clear with low risk', () => {
+      expect(determineAction('clear', 10)).toBe('auto_approve');
+    });
+  });
+
+  describe('generateRationale', () => {
+    const createSanctionsMatch = (name: string, score: number): SanctionsMatch => ({
+      list_source: 'OFAC_SDN',
+      list_entry_id: 'test-123',
+      matched_name: name,
+      match_score: score,
+      match_type: 'fuzzy',
+      sanctions_programs: ['TEST'],
+    });
+
+    const createPEPMatch = (active: boolean): PEPMatch => ({
+      pep_id: 'pep-123',
+      matched_name: 'Test Person',
+      match_score: 0.9,
+      category: 'government_minister',
+      position: 'Minister',
+      country: 'US',
+      active,
+    });
+
+    it('should indicate no matches for clear status', () => {
+      const rationale = generateRationale('clear', [], [], 0);
+      expect(rationale).toContain('No sanctions or PEP matches found');
+    });
+
+    it('should describe sanctions matches', () => {
+      const matches = [createSanctionsMatch('Bad Actor', 0.95)];
+      const rationale = generateRationale('potential_match', matches, [], 35);
+      expect(rationale).toContain('1 sanctions match');
+      expect(rationale).toContain('Bad Actor');
+      expect(rationale).toContain('OFAC_SDN');
+      expect(rationale).toContain('95%');
+    });
+
+    it('should describe PEP matches', () => {
+      const pepMatches = [createPEPMatch(true), createPEPMatch(false)];
+      const rationale = generateRationale('potential_match', [], pepMatches, 30);
+      expect(rationale).toContain('2 PEP match');
+      expect(rationale).toContain('1 currently active');
+    });
+
+    it('should include risk score', () => {
+      const rationale = generateRationale('clear', [], [], 15);
+      expect(rationale).toContain('risk score: 15/100');
+    });
+  });
+
+  describe('createFreshness', () => {
+    it('should create fresh status for recent data', () => {
+      const recentDate = new Date(Date.now() - 1000); // 1 second ago
+      const freshness = createFreshness(recentDate);
+      expect(freshness.sla_status).toBe('fresh');
+      expect(freshness.staleness_ms).toBeLessThan(3600000);
+    });
+
+    it('should create stale status for older data', () => {
+      const oldDate = new Date(Date.now() - 7200000); // 2 hours ago
+      const freshness = createFreshness(oldDate);
+      expect(freshness.sla_status).toBe('stale');
+    });
+
+    it('should create expired status for very old data', () => {
+      const veryOldDate = new Date(Date.now() - 172800000); // 2 days ago
+      const freshness = createFreshness(veryOldDate);
+      expect(freshness.sla_status).toBe('expired');
+    });
+
+    it('should include valid ISO timestamps', () => {
+      const freshness = createFreshness();
+      expect(() => new Date(freshness.generated_at)).not.toThrow();
+      expect(freshness.data_source_updated_at).toBeDefined();
+    });
+  });
+
+  describe('performScreeningCheck', () => {
+    const sanctionsDb = [
+      { name: 'Bad Actor', aliases: ['B. Actor', 'BadActor'], list: 'OFAC_SDN', programs: ['IRAN'], id: 'sdn-001' },
+      { name: 'Evil Corp', aliases: [], list: 'EU_SANCTIONS', programs: ['RUSSIA'], id: 'eu-001' },
+    ];
+
+    const pepDb = [
+      { name: 'John Minister', category: 'government_minister', position: 'Finance Minister', country: 'US', active: true, id: 'pep-001' },
+      { name: 'Jane Former', category: 'senior_official', position: 'Former Director', country: 'GB', active: false, id: 'pep-002' },
+    ];
+
+    it('should return clear for unknown entity', () => {
+      const result = performScreeningCheck(
+        { entity_name: 'Innocent Person' },
+        sanctionsDb,
+        pepDb
+      );
+      expect(result.screening_status).toBe('clear');
+      expect(result.recommended_action).toBe('auto_approve');
+      expect(result.evidence_bundle.sanctions_matches).toHaveLength(0);
+      expect(result.evidence_bundle.pep_matches).toHaveLength(0);
+    });
+
+    it('should find exact sanctions match', () => {
+      const result = performScreeningCheck(
+        { entity_name: 'Bad Actor' },
+        sanctionsDb,
+        pepDb
+      );
+      expect(result.screening_status).toBe('confirmed_match');
+      expect(result.recommended_action).toBe('reject');
+      expect(result.evidence_bundle.sanctions_matches).toHaveLength(1);
+      expect(result.evidence_bundle.sanctions_matches[0].matched_name).toBe('Bad Actor');
+    });
+
+    it('should find alias match', () => {
+      const result = performScreeningCheck(
+        { entity_name: 'B. Actor' },
+        sanctionsDb,
+        pepDb
+      );
+      expect(result.screening_status).toBe('confirmed_match');
+      expect(result.evidence_bundle.sanctions_matches[0].matched_name).toBe('B. Actor');
+    });
+
+    it('should find PEP match', () => {
+      const result = performScreeningCheck(
+        { entity_name: 'John Minister' },
+        sanctionsDb,
+        pepDb
+      );
+      expect(result.evidence_bundle.pep_matches).toHaveLength(1);
+      expect(result.evidence_bundle.pep_matches[0].active).toBe(true);
+    });
+
+    it('should respect include_sanctions=false', () => {
+      const result = performScreeningCheck(
+        { entity_name: 'Bad Actor', include_sanctions: false },
+        sanctionsDb,
+        pepDb
+      );
+      expect(result.evidence_bundle.sanctions_matches).toHaveLength(0);
+    });
+
+    it('should respect include_pep=false', () => {
+      const result = performScreeningCheck(
+        { entity_name: 'John Minister', include_pep: false },
+        sanctionsDb,
+        pepDb
+      );
+      expect(result.evidence_bundle.pep_matches).toHaveLength(0);
+    });
+
+    it('should respect fuzzy_threshold', () => {
+      // With high threshold, fuzzy match should not trigger
+      const strictResult = performScreeningCheck(
+        { entity_name: 'Bad Actr', fuzzy_threshold: 0.99 },
+        sanctionsDb,
+        pepDb
+      );
+      expect(strictResult.screening_status).toBe('clear');
+
+      // With lower threshold, fuzzy match should trigger
+      const lenientResult = performScreeningCheck(
+        { entity_name: 'Bad Actr', fuzzy_threshold: 0.8 },
+        sanctionsDb,
+        pepDb
+      );
+      expect(lenientResult.screening_status).not.toBe('clear');
+    });
+
+    it('should include freshness metadata', () => {
+      const result = performScreeningCheck(
+        { entity_name: 'Test' },
+        sanctionsDb,
+        pepDb
+      );
+      expect(result.freshness).toBeDefined();
+      expect(result.freshness.generated_at).toBeDefined();
+      expect(result.freshness.sla_status).toBeDefined();
+    });
+
+    it('should include confidence score', () => {
+      const result = performScreeningCheck(
+        { entity_name: 'Test' },
+        sanctionsDb,
+        pepDb
+      );
+      expect(result.confidence).toBeGreaterThanOrEqual(0);
+      expect(result.confidence).toBeLessThanOrEqual(1);
+    });
+
+    it('should record search parameters', () => {
+      const result = performScreeningCheck(
+        { entity_name: 'Test Entity', fuzzy_threshold: 0.9 },
+        sanctionsDb,
+        pepDb
+      );
+      expect(result.evidence_bundle.search_parameters_used.entity_name).toBe('Test Entity');
+      expect(result.evidence_bundle.search_parameters_used.fuzzy_threshold).toBe(0.9);
+    });
+  });
+});

--- a/packages/examples/src/data-apis/sanctions-pep/screening.ts
+++ b/packages/examples/src/data-apis/sanctions-pep/screening.ts
@@ -1,0 +1,259 @@
+import type {
+  Freshness,
+  MatchConfidence,
+  PEPMatch,
+  SanctionsMatch,
+  ScreeningCheckRequest,
+  ScreeningCheckResponse,
+  ScreeningStatus,
+} from './schema';
+
+// ============================================================================
+// Screening Business Logic
+// ============================================================================
+
+/**
+ * Calculate string similarity using Levenshtein distance
+ */
+export function calculateSimilarity(str1: string, str2: string): number {
+  const s1 = str1.toLowerCase().trim();
+  const s2 = str2.toLowerCase().trim();
+  
+  if (s1 === s2) return 1;
+  if (s1.length === 0 || s2.length === 0) return 0;
+
+  const matrix: number[][] = [];
+  for (let i = 0; i <= s1.length; i++) {
+    matrix[i] = [i];
+  }
+  for (let j = 0; j <= s2.length; j++) {
+    matrix[0][j] = j;
+  }
+
+  for (let i = 1; i <= s1.length; i++) {
+    for (let j = 1; j <= s2.length; j++) {
+      const cost = s1[i - 1] === s2[j - 1] ? 0 : 1;
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1,
+        matrix[i][j - 1] + 1,
+        matrix[i - 1][j - 1] + cost
+      );
+    }
+  }
+
+  const maxLen = Math.max(s1.length, s2.length);
+  return 1 - matrix[s1.length][s2.length] / maxLen;
+}
+
+/**
+ * Determine match confidence from score
+ */
+export function scoreToConfidence(score: number): MatchConfidence {
+  if (score >= 0.99) return 'exact';
+  if (score >= 0.9) return 'high';
+  if (score >= 0.75) return 'medium';
+  return 'low';
+}
+
+/**
+ * Determine screening status from matches
+ */
+export function determineScreeningStatus(
+  sanctionsMatches: SanctionsMatch[],
+  pepMatches: PEPMatch[],
+  threshold: number
+): ScreeningStatus {
+  const hasExactSanctions = sanctionsMatches.some(m => m.match_score >= 0.99);
+  const hasHighSanctions = sanctionsMatches.some(m => m.match_score >= 0.9);
+  const hasPotentialSanctions = sanctionsMatches.some(m => m.match_score >= threshold);
+  
+  const hasActivePEP = pepMatches.some(m => m.active && m.match_score >= 0.9);
+
+  if (hasExactSanctions) return 'confirmed_match';
+  if (hasHighSanctions || hasActivePEP) return 'escalate';
+  if (hasPotentialSanctions || pepMatches.length > 0) return 'potential_match';
+  return 'clear';
+}
+
+/**
+ * Calculate risk score (0-100)
+ */
+export function calculateRiskScore(
+  sanctionsMatches: SanctionsMatch[],
+  pepMatches: PEPMatch[]
+): number {
+  let score = 0;
+
+  // Sanctions contribute heavily
+  for (const match of sanctionsMatches) {
+    if (match.match_score >= 0.99) score += 50;
+    else if (match.match_score >= 0.9) score += 35;
+    else if (match.match_score >= 0.75) score += 20;
+    else score += 10;
+  }
+
+  // PEP matches contribute moderately
+  for (const match of pepMatches) {
+    const baseScore = match.active ? 25 : 10;
+    score += baseScore * match.match_score;
+  }
+
+  return Math.min(100, Math.round(score));
+}
+
+/**
+ * Determine recommended action
+ */
+export function determineAction(
+  status: ScreeningStatus,
+  riskScore: number
+): 'auto_approve' | 'manual_review' | 'escalate' | 'reject' {
+  if (status === 'confirmed_match') return 'reject';
+  if (status === 'escalate' || riskScore >= 70) return 'escalate';
+  if (status === 'potential_match' || riskScore >= 30) return 'manual_review';
+  return 'auto_approve';
+}
+
+/**
+ * Generate rationale text
+ */
+export function generateRationale(
+  status: ScreeningStatus,
+  sanctionsMatches: SanctionsMatch[],
+  pepMatches: PEPMatch[],
+  riskScore: number
+): string {
+  const parts: string[] = [];
+
+  if (status === 'clear') {
+    parts.push('No sanctions or PEP matches found.');
+  } else {
+    if (sanctionsMatches.length > 0) {
+      const bestMatch = sanctionsMatches.reduce((a, b) => 
+        a.match_score > b.match_score ? a : b
+      );
+      parts.push(
+        `Found ${sanctionsMatches.length} sanctions match(es). ` +
+        `Best match: "${bestMatch.matched_name}" on ${bestMatch.list_source} ` +
+        `(${Math.round(bestMatch.match_score * 100)}% confidence).`
+      );
+    }
+
+    if (pepMatches.length > 0) {
+      const activePEPs = pepMatches.filter(m => m.active);
+      parts.push(
+        `Found ${pepMatches.length} PEP match(es), ${activePEPs.length} currently active.`
+      );
+    }
+  }
+
+  parts.push(`Overall risk score: ${riskScore}/100.`);
+  return parts.join(' ');
+}
+
+/**
+ * Create freshness metadata
+ */
+export function createFreshness(dataSourceUpdatedAt?: Date): Freshness {
+  const now = new Date();
+  const sourceTime = dataSourceUpdatedAt || new Date(now.getTime() - 3600000); // 1 hour ago default
+  const stalenessMs = now.getTime() - sourceTime.getTime();
+
+  let slaStatus: 'fresh' | 'stale' | 'expired';
+  if (stalenessMs < 3600000) slaStatus = 'fresh'; // < 1 hour
+  else if (stalenessMs < 86400000) slaStatus = 'stale'; // < 24 hours
+  else slaStatus = 'expired';
+
+  return {
+    generated_at: now.toISOString(),
+    staleness_ms: stalenessMs,
+    sla_status: slaStatus,
+    data_source_updated_at: sourceTime.toISOString(),
+  };
+}
+
+/**
+ * Main screening check function
+ */
+export function performScreeningCheck(
+  request: ScreeningCheckRequest,
+  sanctionsDatabase: Array<{ name: string; aliases: string[]; list: string; programs: string[]; id: string }>,
+  pepDatabase: Array<{ name: string; category: string; position: string; country: string; active: boolean; id: string }>
+): ScreeningCheckResponse {
+  const sanctionsMatches: SanctionsMatch[] = [];
+  const pepMatches: PEPMatch[] = [];
+  const threshold = request.fuzzy_threshold ?? 0.85;
+
+  // Check sanctions
+  if (request.include_sanctions !== false) {
+    for (const entry of sanctionsDatabase) {
+      const namesToCheck = [entry.name, ...entry.aliases];
+      for (const name of namesToCheck) {
+        const score = calculateSimilarity(request.entity_name, name);
+        if (score >= threshold) {
+          sanctionsMatches.push({
+            list_source: entry.list as any,
+            list_entry_id: entry.id,
+            matched_name: name,
+            match_score: score,
+            match_type: score >= 0.99 ? 'exact' : score >= 0.9 ? 'alias' : 'fuzzy',
+            sanctions_programs: entry.programs,
+          });
+          break; // One match per entry
+        }
+      }
+    }
+  }
+
+  // Check PEP
+  if (request.include_pep !== false) {
+    for (const entry of pepDatabase) {
+      const score = calculateSimilarity(request.entity_name, entry.name);
+      if (score >= threshold) {
+        pepMatches.push({
+          pep_id: entry.id,
+          matched_name: entry.name,
+          match_score: score,
+          category: entry.category as any,
+          position: entry.position,
+          country: entry.country,
+          active: entry.active,
+        });
+      }
+    }
+  }
+
+  const status = determineScreeningStatus(sanctionsMatches, pepMatches, threshold);
+  const riskScore = calculateRiskScore(sanctionsMatches, pepMatches);
+  const confidence = sanctionsMatches.length + pepMatches.length > 0
+    ? Math.max(...[...sanctionsMatches, ...pepMatches].map(m => m.match_score))
+    : 0.95; // High confidence in clear result
+
+  return {
+    screening_status: status,
+    match_confidence: scoreToConfidence(
+      sanctionsMatches.length > 0 
+        ? Math.max(...sanctionsMatches.map(m => m.match_score))
+        : pepMatches.length > 0
+          ? Math.max(...pepMatches.map(m => m.match_score))
+          : 0
+    ),
+    risk_score: riskScore,
+    evidence_bundle: {
+      sanctions_matches: sanctionsMatches,
+      pep_matches: pepMatches,
+      adverse_media_count: 0,
+      data_sources_checked: ['OFAC_SDN', 'EU_SANCTIONS', 'UN_SANCTIONS', 'PEP_DATABASE'],
+      search_parameters_used: {
+        entity_name: request.entity_name,
+        fuzzy_threshold: threshold,
+        include_sanctions: request.include_sanctions,
+        include_pep: request.include_pep,
+      },
+    },
+    rationale: generateRationale(status, sanctionsMatches, pepMatches, riskScore),
+    recommended_action: determineAction(status, riskScore),
+    freshness: createFreshness(),
+    confidence,
+  };
+}


### PR DESCRIPTION
## Summary
Implements TDD PRD for issue #185 - Sanctions & PEP Exposure Intelligence API.

## API Endpoints (x402 paid)
| Endpoint | Price | Description |
|----------|-------|-------------|
| `POST /entrypoints/screening-check/invoke` | $0.50 | Screen entity against sanctions lists and PEP databases |
| `POST /entrypoints/exposure-chain/invoke` | $2.00 | Analyze ownership chain for sanctions/PEP exposure |
| `POST /entrypoints/jurisdiction-risk/invoke` | $0.25 | Get risk assessment for jurisdictions |

## Features
- ✅ Zod-validated request/response schemas with strict typing
- ✅ Fuzzy name matching with configurable threshold (Levenshtein distance)
- ✅ Sanctions list screening (OFAC_SDN, EU_SANCTIONS, UN_SANCTIONS, UK_SANCTIONS, AU_SANCTIONS)
- ✅ PEP database checks with category classification (head_of_state, government_minister, etc.)
- ✅ Ownership chain analysis with risk path detection
- ✅ Jurisdiction risk assessment with FATF status and CPI scores
- ✅ Freshness metadata (generated_at, staleness_ms, sla_status)
- ✅ Confidence scoring for all responses
- ✅ Explainable rationale and recommended actions (auto_approve/manual_review/escalate/reject)

## Test Coverage (101 tests passing)
- **Contract tests**: Schema validation for all request/response types
- **Unit tests**: Similarity scoring, risk calculation, status determination
- **Integration tests**: Endpoint contracts, x402 payment requirements, error handling
- **Quality tests**: Freshness thresholds, confidence propagation

## Files Added
```
packages/examples/src/data-apis/sanctions-pep/
├── README.md           # Documentation
├── schema.ts           # Zod schemas for all types
├── schema.test.ts      # Contract tests (32 tests)
├── screening.ts        # Business logic
├── screening.test.ts   # Unit tests (48 tests)
├── agent.ts            # Hono server with x402 payments
└── agent.test.ts       # Integration tests (21 tests)
```

## Running
```bash
# Run tests
bun test packages/examples/src/data-apis/sanctions-pep/

# Start server
PORT=3002 bun run packages/examples/src/data-apis/sanctions-pep/agent.ts
```

Closes #185