### PR TITLE
chore: standardize MIT license declarations

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Daydreams AI
+Copyright (c) 2025-2026 Daydreams AI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lucid-docs/package.json
+++ b/lucid-docs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "lucid-docs",
+  "license": "MIT",
   "private": true,
   "sideEffects": false,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@lucid-agents/root",
+  "license": "MIT",
   "workspaces": {
     "packages": [
       "packages/*",

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lucid-agents/a2a",
   "version": "0.6.2",
+  "license": "MIT",
   "description": "Agent-to-Agent (A2A) protocol support for Lucid agents",
   "repository": {
     "type": "git",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lucid-agents/analytics",
   "version": "0.3.2",
+  "license": "MIT",
   "description": "Analytics and reporting for payment tracking data",
   "repository": {
     "type": "git",

--- a/packages/ap2/package.json
+++ b/packages/ap2/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lucid-agents/ap2",
   "version": "0.4.2",
+  "license": "MIT",
   "description": "AP2 (Agent Payments Protocol) extension for Lucid agents",
   "repository": {
     "type": "git",

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lucid-agents/api-sdk",
   "version": "2.5.0",
+  "license": "MIT",
   "description": "TypeScript SDK for the Lucid Agents Runtime API (auto-generated from OpenAPI)",
   "repository": {
     "type": "git",

--- a/packages/cli/adapters/express/package.json
+++ b/packages/cli/adapters/express/package.json
@@ -1,6 +1,7 @@
 {
   "name": "{{PACKAGE_NAME}}",
   "version": "0.0.1",
+  "license": "MIT",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/adapters/hono/package.json
+++ b/packages/cli/adapters/hono/package.json
@@ -1,6 +1,7 @@
 {
   "name": "{{PACKAGE_NAME}}",
   "version": "0.0.1",
+  "license": "MIT",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/adapters/next/package.json
+++ b/packages/cli/adapters/next/package.json
@@ -1,6 +1,7 @@
 {
   "name": "{{PACKAGE_NAME}}",
   "version": "0.0.1",
+  "license": "MIT",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/adapters/tanstack/headless/package.json
+++ b/packages/cli/adapters/tanstack/headless/package.json
@@ -1,6 +1,7 @@
 {
   "name": "{{PACKAGE_NAME}}",
   "version": "0.0.1",
+  "license": "MIT",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/adapters/tanstack/ui/package.json
+++ b/packages/cli/adapters/tanstack/ui/package.json
@@ -1,6 +1,7 @@
 {
   "name": "{{PACKAGE_NAME}}",
   "version": "0.0.1",
+  "license": "MIT",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lucid-agents/core",
   "version": "2.5.0",
+  "license": "MIT",
   "description": "Build typed agent HTTP apps",
   "repository": {
     "type": "git",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lucid-agents/eslint-config",
   "version": "1.0.0",
+  "license": "MIT",
   "description": "Shared ESLint configuration for Lucid Agents monorepo",
   "main": "index.js",
   "private": true,

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lucid-agents/examples",
   "version": "0.3.6",
+  "license": "MIT",
   "description": "Example implementations for lucid-agents framework",
   "type": "module",
   "private": true,

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lucid-agents/express",
   "version": "0.5.6",
+  "license": "MIT",
   "description": "Express adapter for Lucid agent runtime",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lucid-agents/hono",
   "version": "0.9.6",
+  "license": "MIT",
   "description": "Hono adapter for Lucid agent runtime",
   "repository": {
     "type": "git",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lucid-agents/http",
   "version": "1.10.2",
+  "license": "MIT",
   "description": "HTTP extension for agent runtime",
   "repository": {
     "type": "git",

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lucid-agents/identity",
   "version": "2.5.0",
+  "license": "MIT",
   "description": "ERC-8004 identity helpers for Lucid agent kit surfaces",
   "repository": {
     "type": "git",

--- a/packages/payments/package.json
+++ b/packages/payments/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lucid-agents/payments",
   "version": "2.5.0",
+  "license": "MIT",
   "description": "Payment logic for bidirectional agent-to-agent payments",
   "repository": {
     "type": "git",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lucid-agents/prettier-config",
   "version": "1.0.0",
+  "license": "MIT",
   "description": "Shared Prettier configuration for Lucid Agents monorepo",
   "main": "index.js",
   "private": true,

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lucid-agents/scheduler",
   "version": "0.2.2",
+  "license": "MIT",
   "description": "Pull-style scheduler for hiring agents and invoking them on a schedule with bound wallets",
   "repository": {
     "type": "git",

--- a/packages/tanstack/package.json
+++ b/packages/tanstack/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lucid-agents/tanstack",
   "version": "0.7.4",
+  "license": "MIT",
   "description": "TanStack Start adapter for Lucid agent runtime",
   "repository": {
     "type": "git",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lucid-agents/types",
   "version": "1.7.0",
+  "license": "MIT",
   "description": "Shared types for lucid-agents framework",
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lucid-agents/wallet",
   "version": "0.6.2",
+  "license": "MIT",
   "description": "Wallet connectors and helpers for Lucid agents",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Updated LICENSE copyright year to "2025-2026"
- Added `"license": "MIT"` to all 24 package.json files missing it

🤖 Generated with [Claude Code](https://claude.com/claude-code)