### PR TITLE
feat: add @lucid-agents/identity-solana package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -273,6 +273,25 @@
         "typescript": "^5.9.2",
       },
     },
+    "packages/identity-solana": {
+      "name": "@lucid-agents/identity-solana",
+      "version": "0.1.0",
+      "dependencies": {
+        "8004-solana": "^0.7.9",
+        "@lucid-agents/types": "workspace:*",
+      },
+      "devDependencies": {
+        "@lucid-agents/eslint-config": "workspace:*",
+        "@lucid-agents/prettier-config": "workspace:*",
+        "@solana/web3.js": "^1.98.0",
+        "@types/node": "^22.0.0",
+        "tsup": "^8.5.0",
+        "typescript": "^5.9.2",
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.98.0",
+      },
+    },
     "packages/payments": {
       "name": "@lucid-agents/payments",
       "version": "2.5.0",
@@ -373,6 +392,8 @@
     "zod": "^4.1.12",
   },
   "packages": {
+    "8004-solana": ["8004-solana@0.7.9", "", { "dependencies": { "@coral-xyz/borsh": "^0.32.1", "@noble/hashes": "^2.0.1", "@solana/web3.js": "^1.95.0", "borsh": "^0.7.0", "bs58": "^6.0.0", "tweetnacl": "^1.0.3" } }, "sha512-7qSldH9Af89Vpq7NuE2AqN0lW283xCSqR2t2e5kYYgvEGCCwEZhS/DR0cUI4KX0iEsYBlTfmXva9A9O6P44YVw=="],
+
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.78.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w=="],
@@ -498,6 +519,8 @@
     "@coinbase/cdp-sdk": ["@coinbase/cdp-sdk@1.40.0", "", { "dependencies": { "@solana-program/system": "^0.8.0", "@solana-program/token": "^0.6.0", "@solana/kit": "^3.0.3", "@solana/web3.js": "^1.98.1", "abitype": "1.0.6", "axios": "^1.12.2", "axios-retry": "^4.5.0", "jose": "^6.0.8", "md5": "^2.3.0", "uncrypto": "^0.1.3", "viem": "^2.21.26", "zod": "^3.24.4" } }, "sha512-N3hVqjcNh4yD4oJRX2jzC3fGfYJLELqQ77OtBbW/wjhyExHqBXYLqWAVSB9ZK+L5/0WjOBjl0WCpy4WF/3dZqA=="],
 
     "@coinbase/wallet-sdk": ["@coinbase/wallet-sdk@4.3.0", "", { "dependencies": { "@noble/hashes": "^1.4.0", "clsx": "^1.2.1", "eventemitter3": "^5.0.1", "preact": "^10.24.2" } }, "sha512-T3+SNmiCw4HzDm4we9wCHCxlP0pqCiwKe4sOwPH3YAK2KSKjxPRydKu6UQJrdONFVLG7ujXvbd/6ZqmvJb8rkw=="],
+
+    "@coral-xyz/borsh": ["@coral-xyz/borsh@0.32.1", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.69.0" } }, "sha512-pWsqkkZ+psLlupMkgu5rDok7baDQLWKqyDsb76gUNArbVB783mF3ZOleKMHVXZczl5JuxnVVfO1+XDVvR17C3A=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -710,6 +733,8 @@
     "@lucid-agents/http": ["@lucid-agents/http@workspace:packages/http"],
 
     "@lucid-agents/identity": ["@lucid-agents/identity@workspace:packages/identity"],
+
+    "@lucid-agents/identity-solana": ["@lucid-agents/identity-solana@workspace:packages/identity-solana"],
 
     "@lucid-agents/payments": ["@lucid-agents/payments@workspace:packages/payments"],
 
@@ -1488,6 +1513,8 @@
     "bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
+    "buffer-layout": ["buffer-layout@1.2.2", "", {}, "sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA=="],
 
     "bufferutil": ["bufferutil@4.0.9", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw=="],
 
@@ -2897,6 +2924,8 @@
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
+    "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
+
     "twoslash": ["twoslash@0.3.4", "", { "dependencies": { "@typescript/vfs": "^1.6.1", "twoslash-protocol": "0.3.4" }, "peerDependencies": { "typescript": "^5.5.0" } }, "sha512-RtJURJlGRxrkJmTcZMjpr7jdYly1rfgpujJr1sBM9ch7SKVht/SjFk23IOAyvwT1NLCk+SJiMrvW4rIAUM2Wug=="],
 
     "twoslash-protocol": ["twoslash-protocol@0.3.4", "", {}, "sha512-HHd7lzZNLUvjPzG/IE6js502gEzLC1x7HaO1up/f72d8G8ScWAs9Yfa97igelQRDl5h9tGcdFsRp+lNVre1EeQ=="],
@@ -3065,6 +3094,10 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "8004-solana/@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
+
+    "8004-solana/bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
+
     "@babel/core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@babel/core/json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
@@ -3120,6 +3153,8 @@
     "@hey-api/openapi-ts/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "@lucid-agents/examples/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "@lucid-agents/identity-solana/@types/node": ["@types/node@22.19.13", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
@@ -3505,6 +3540,8 @@
 
     "youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
+    "8004-solana/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
+
     "@base-org/account/ox/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "@base-org/account/ox/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
@@ -3544,6 +3581,8 @@
     "@coinbase/cdp-sdk/@solana/kit/@solana/transaction-messages": ["@solana/transaction-messages@3.0.3", "", { "dependencies": { "@solana/addresses": "3.0.3", "@solana/codecs-core": "3.0.3", "@solana/codecs-data-structures": "3.0.3", "@solana/codecs-numbers": "3.0.3", "@solana/errors": "3.0.3", "@solana/functional": "3.0.3", "@solana/instructions": "3.0.3", "@solana/nominal-types": "3.0.3", "@solana/rpc-types": "3.0.3" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-s+6NWRnBhnnjFWV4x2tzBzoWa6e5LiIxIvJlWwVQBFkc8fMGY04w7jkFh0PM08t/QFKeXBEWkyBDa/TFYdkWug=="],
 
     "@coinbase/cdp-sdk/@solana/kit/@solana/transactions": ["@solana/transactions@3.0.3", "", { "dependencies": { "@solana/addresses": "3.0.3", "@solana/codecs-core": "3.0.3", "@solana/codecs-data-structures": "3.0.3", "@solana/codecs-numbers": "3.0.3", "@solana/codecs-strings": "3.0.3", "@solana/errors": "3.0.3", "@solana/functional": "3.0.3", "@solana/instructions": "3.0.3", "@solana/keys": "3.0.3", "@solana/nominal-types": "3.0.3", "@solana/rpc-types": "3.0.3", "@solana/transaction-messages": "3.0.3" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-iMX+n9j4ON7H1nKlWEbMqMOpKYC6yVGxKKmWHT1KdLRG7v+03I4DnDeFoI+Zmw56FA+7Bbne8jwwX60Q1vk/MQ=="],
+
+    "@lucid-agents/identity-solana/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -181,6 +181,7 @@
         "@lucid-agents/hono": "workspace:*",
         "@lucid-agents/http": "workspace:*",
         "@lucid-agents/identity": "workspace:*",
+        "@lucid-agents/identity-solana": "workspace:*",
         "@lucid-agents/payments": "workspace:*",
         "@lucid-agents/scheduler": "workspace:*",
         "@lucid-agents/types": "workspace:*",
@@ -3152,7 +3153,7 @@
 
     "@hey-api/openapi-ts/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
-    "@lucid-agents/examples/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+    "@lucid-agents/examples/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "@lucid-agents/identity-solana/@types/node": ["@types/node@22.19.13", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw=="],
 

--- a/packages/examples/__tests__/solana-identity.test.ts
+++ b/packages/examples/__tests__/solana-identity.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 import {
+  createSolanaAgentIdentity,
   identitySolana,
   identitySolanaFromEnv,
-  createSolanaAgentIdentity,
   mapTrustTierToConfig,
 } from '@lucid-agents/identity-solana';
 
@@ -43,14 +43,21 @@ describe('solana-identity example: createSolanaAgentIdentity', () => {
     expect(identity.clients?.reputation).toBeDefined();
   });
 
+  it('short-circuits when options.trust is pre-supplied', async () => {
+    const trust = { trustModels: ['feedback'] as string[] };
+    const identity = await createSolanaAgentIdentity({
+      trust,
+      cluster: 'devnet',
+      env: {},
+    });
+    expect(identity.trust).toBe(trust);
+    expect(identity.status).toContain('Pre-resolved');
+  });
+
   it('maps TrustTier to TrustConfig correctly', () => {
-    const trust = mapTrustTierToConfig(
-      3, // Gold
-      BigInt(100),
-      'devnet',
-      undefined,
-      ['feedback']
-    );
+    const trust = mapTrustTierToConfig(BigInt(100), 'devnet', undefined, [
+      'feedback',
+    ]);
     expect(trust.registrations?.[0].agentId).toBe('100');
     expect(trust.registrations?.[0].agentRegistry).toContain('solana:devnet');
     expect(trust.trustModels).toContain('feedback');

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -23,6 +23,7 @@
     "@lucid-agents/hono": "workspace:*",
     "@lucid-agents/http": "workspace:*",
     "@lucid-agents/identity": "workspace:*",
+    "@lucid-agents/identity-solana": "workspace:*",
     "@lucid-agents/payments": "workspace:*",
     "@lucid-agents/scheduler": "workspace:*",
     "@lucid-agents/types": "workspace:*",

--- a/packages/examples/src/solana-identity.ts
+++ b/packages/examples/src/solana-identity.ts
@@ -13,11 +13,22 @@
 import { createAgent } from '@lucid-agents/core';
 import { createAgentApp } from '@lucid-agents/hono';
 import { http } from '@lucid-agents/http';
-import { identitySolana, identitySolanaFromEnv } from '@lucid-agents/identity-solana';
+import {
+  createSolanaAgentIdentity,
+  identitySolana,
+  identitySolanaFromEnv,
+} from '@lucid-agents/identity-solana';
 import { payments, paymentsFromEnv } from '@lucid-agents/payments';
 import { z } from 'zod';
 
 async function main() {
+  // Fail fast: SOLANA_PRIVATE_KEY is required for on-chain registration
+  if (!process.env.SOLANA_PRIVATE_KEY) {
+    throw new Error(
+      'SOLANA_PRIVATE_KEY is required. Set it to a JSON array of numbers, e.g. [1,2,...,64].'
+    );
+  }
+
   // Build agent with Solana identity
   const agent = await createAgent({
     name: 'solana-identity-example',
@@ -37,7 +48,7 @@ async function main() {
           SOLANA_CLUSTER: process.env.SOLANA_CLUSTER ?? 'devnet',
           AGENT_DOMAIN: process.env.AGENT_DOMAIN ?? 'solana-agent.example.com',
           REGISTER_IDENTITY: 'true',
-          SOLANA_PRIVATE_KEY: process.env.SOLANA_PRIVATE_KEY ?? '',
+          SOLANA_PRIVATE_KEY: process.env.SOLANA_PRIVATE_KEY,
         }),
       })
     )
@@ -46,10 +57,16 @@ async function main() {
   const { app, addEntrypoint } = await createAgentApp(agent);
 
   // Paid endpoint — analyze a creator's distribution strategy
+  // After completing the task, submit reputation feedback to the requesting agent.
   addEntrypoint({
     key: 'analyze-distribution',
     description: 'Analyze a creator distribution strategy for $0.01 USDC',
-    input: z.object({ creatorHandle: z.string(), platform: z.string() }),
+    input: z.object({
+      creatorHandle: z.string(),
+      platform: z.string(),
+      /** Optional: caller's Solana address to receive positive feedback after task */
+      callerAddress: z.string().optional(),
+    }),
     output: z.object({
       summary: z.string(),
       signals: z.array(z.string()),
@@ -57,14 +74,40 @@ async function main() {
     }),
     price: '0.01',
     async handler({ input }) {
-      // Minimal implementation for example purposes
-      return {
-        output: {
-          summary: `Distribution analysis for @${input.creatorHandle} on ${input.platform}`,
-          signals: ['Shipping velocity: high', 'Narrative spread: building'],
-          recommendation: 'Continue current cadence. Diversify to Farcaster.',
-        },
+      const result = {
+        summary: `Distribution analysis for @${input.creatorHandle} on ${input.platform}`,
+        signals: ['Shipping velocity: high', 'Narrative spread: building'],
+        recommendation: 'Continue current cadence. Diversify to Farcaster.',
       };
+
+      // Demonstration: give reputation feedback to the caller after task completion.
+      // In production, resolve callerAddress from the payment proof or session context.
+      if (input.callerAddress) {
+        try {
+          const { clients } = await createSolanaAgentIdentity(
+            identitySolanaFromEnv({
+              SOLANA_CLUSTER: process.env.SOLANA_CLUSTER ?? 'devnet',
+              SOLANA_PRIVATE_KEY: process.env.SOLANA_PRIVATE_KEY!,
+              AGENT_DOMAIN:
+                process.env.AGENT_DOMAIN ?? 'solana-agent.example.com',
+            })
+          );
+          await clients?.reputation.giveFeedback({
+            targetAddress: input.callerAddress,
+            score: 5,
+            comment:
+              'Task completed successfully via analyze-distribution entrypoint',
+          });
+          console.log(
+            `[solana-identity] Reputation feedback sent to ${input.callerAddress}`
+          );
+        } catch (err) {
+          // Non-fatal: log and continue; reputation is best-effort
+          console.warn(`[solana-identity] Reputation feedback failed: ${err}`);
+        }
+      }
+
+      return { output: result };
     },
   });
 
@@ -86,7 +129,9 @@ async function main() {
 
   const port = parseInt(process.env.PORT ?? '3099');
   console.log(`[solana-identity] Agent running on port ${port}`);
-  console.log(`[solana-identity] Entrypoints: analyze-distribution ($0.01), health (free)`);
+  console.log(
+    `[solana-identity] Entrypoints: analyze-distribution ($0.01), health (free)`
+  );
 
   return { app, port };
 }

--- a/packages/examples/src/solana-identity.ts
+++ b/packages/examples/src/solana-identity.ts
@@ -1,0 +1,102 @@
+/**
+ * Solana Identity Example
+ *
+ * Demonstrates:
+ * 1. Registering an agent on devnet using @lucid-agents/identity-solana
+ * 2. Serving a paid x402 endpoint
+ * 3. Giving reputation feedback after task completion
+ *
+ * Usage:
+ *   SOLANA_PRIVATE_KEY='[1,2,...,64]' AGENT_DOMAIN=my-agent.example.com bun src/solana-identity.ts
+ */
+
+import { createAgent } from '@lucid-agents/core';
+import { createAgentApp } from '@lucid-agents/hono';
+import { http } from '@lucid-agents/http';
+import { identitySolana, identitySolanaFromEnv } from '@lucid-agents/identity-solana';
+import { payments, paymentsFromEnv } from '@lucid-agents/payments';
+import { z } from 'zod';
+
+async function main() {
+  // Build agent with Solana identity
+  const agent = await createAgent({
+    name: 'solana-identity-example',
+    version: '1.0.0',
+    description: 'Example agent registered on 8004-Solana with paid endpoints',
+  })
+    .use(http())
+    .use(
+      payments({
+        config: paymentsFromEnv(),
+      })
+    )
+    .use(
+      identitySolana({
+        config: identitySolanaFromEnv({
+          // Override: use devnet for this example
+          SOLANA_CLUSTER: process.env.SOLANA_CLUSTER ?? 'devnet',
+          AGENT_DOMAIN: process.env.AGENT_DOMAIN ?? 'solana-agent.example.com',
+          REGISTER_IDENTITY: 'true',
+          SOLANA_PRIVATE_KEY: process.env.SOLANA_PRIVATE_KEY ?? '',
+        }),
+      })
+    )
+    .build();
+
+  const { app, addEntrypoint } = await createAgentApp(agent);
+
+  // Paid endpoint — analyze a creator's distribution strategy
+  addEntrypoint({
+    key: 'analyze-distribution',
+    description: 'Analyze a creator distribution strategy for $0.01 USDC',
+    input: z.object({ creatorHandle: z.string(), platform: z.string() }),
+    output: z.object({
+      summary: z.string(),
+      signals: z.array(z.string()),
+      recommendation: z.string(),
+    }),
+    price: '0.01',
+    async handler({ input }) {
+      // Minimal implementation for example purposes
+      return {
+        output: {
+          summary: `Distribution analysis for @${input.creatorHandle} on ${input.platform}`,
+          signals: ['Shipping velocity: high', 'Narrative spread: building'],
+          recommendation: 'Continue current cadence. Diversify to Farcaster.',
+        },
+      };
+    },
+  });
+
+  // Free health endpoint
+  addEntrypoint({
+    key: 'health',
+    description: 'Health check (free)',
+    input: z.object({}),
+    output: z.object({ status: z.string(), identity: z.string() }),
+    async handler() {
+      return {
+        output: {
+          status: 'ok',
+          identity: 'solana:8004',
+        },
+      };
+    },
+  });
+
+  const port = parseInt(process.env.PORT ?? '3099');
+  console.log(`[solana-identity] Agent running on port ${port}`);
+  console.log(`[solana-identity] Entrypoints: analyze-distribution ($0.01), health (free)`);
+
+  return { app, port };
+}
+
+// Export for use as module
+export { main };
+
+// Run if executed directly
+if (import.meta.main) {
+  main().then(({ app, port }) => {
+    Bun.serve({ port, fetch: app.fetch });
+  });
+}

--- a/packages/examples/tests/solana-identity.test.ts
+++ b/packages/examples/tests/solana-identity.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  identitySolana,
+  identitySolanaFromEnv,
+  createSolanaAgentIdentity,
+  mapTrustTierToConfig,
+} from '@lucid-agents/identity-solana';
+
+describe('solana-identity example: identitySolana extension', () => {
+  it('creates extension with name identity-solana', () => {
+    const ext = identitySolana();
+    expect(ext.name).toBe('identity-solana');
+  });
+
+  it('identitySolanaFromEnv with devnet cluster', () => {
+    const config = identitySolanaFromEnv({ SOLANA_CLUSTER: 'devnet' });
+    expect(config.cluster).toBe('devnet');
+  });
+
+  it('identitySolanaFromEnv without private key returns no key', () => {
+    const config = identitySolanaFromEnv({});
+    expect(config.privateKey).toBeUndefined();
+  });
+});
+
+describe('solana-identity example: createSolanaAgentIdentity', () => {
+  it('returns no-identity when no key and autoRegister=false', async () => {
+    const identity = await createSolanaAgentIdentity({
+      autoRegister: false,
+      cluster: 'devnet',
+      env: {},
+    });
+    expect(identity.status).toContain('No 8004-Solana');
+    expect(identity.clients).toBeDefined();
+  });
+
+  it('includes registry clients always', async () => {
+    const identity = await createSolanaAgentIdentity({
+      autoRegister: false,
+      env: {},
+    });
+    expect(identity.clients?.identity).toBeDefined();
+    expect(identity.clients?.reputation).toBeDefined();
+  });
+
+  it('maps TrustTier to TrustConfig correctly', () => {
+    const trust = mapTrustTierToConfig(
+      3,       // Gold
+      BigInt(100),
+      'devnet',
+      undefined,
+      ['feedback']
+    );
+    expect(trust.registrations?.[0].agentId).toBe('100');
+    expect(trust.registrations?.[0].agentRegistry).toContain('solana:devnet');
+    expect(trust.trustModels).toContain('feedback');
+  });
+});

--- a/packages/examples/tests/solana-identity.test.ts
+++ b/packages/examples/tests/solana-identity.test.ts
@@ -45,7 +45,7 @@ describe('solana-identity example: createSolanaAgentIdentity', () => {
 
   it('maps TrustTier to TrustConfig correctly', () => {
     const trust = mapTrustTierToConfig(
-      3,       // Gold
+      3, // Gold
       BigInt(100),
       'devnet',
       undefined,

--- a/packages/identity-solana/.eslintrc.cjs
+++ b/packages/identity-solana/.eslintrc.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  extends: ['@lucid-agents/eslint-config'],
+  env: {
+    node: true,
+    es2022: true,
+  },
+  rules: {},
+};

--- a/packages/identity-solana/.prettierignore
+++ b/packages/identity-solana/.prettierignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+*.tsbuildinfo

--- a/packages/identity-solana/README.md
+++ b/packages/identity-solana/README.md
@@ -13,7 +13,10 @@ bun add @lucid-agents/identity-solana @solana/web3.js 8004-solana
 ```ts
 import { createAgent } from '@lucid-agents/core';
 import { http } from '@lucid-agents/http';
-import { identitySolana, identitySolanaFromEnv } from '@lucid-agents/identity-solana';
+import {
+  identitySolana,
+  identitySolanaFromEnv,
+} from '@lucid-agents/identity-solana';
 
 const agent = await createAgent({ name: 'my-agent', version: '1.0.0' })
   .use(http())
@@ -23,31 +26,36 @@ const agent = await createAgent({ name: 'my-agent', version: '1.0.0' })
 
 ## Environment Variables
 
-| Variable | Description | Required |
-|---|---|---|
-| `SOLANA_PRIVATE_KEY` | JSON array of numbers (Uint8Array) — e.g. `[1,2,3,...]` | For registration |
-| `SOLANA_CLUSTER` | `mainnet-beta` \| `devnet` \| `testnet` (default: `mainnet-beta`) | No |
-| `SOLANA_RPC_URL` | Custom RPC endpoint | No |
-| `AGENT_DOMAIN` | Agent domain for identity registration | Recommended |
-| `REGISTER_IDENTITY` | `true`/`false` — auto-register on startup | No (default: `true`) |
-| `PINATA_JWT` | Pinata JWT for IPFS metadata upload | No |
-| `ATOM_ENABLED` | Enable ATOM protocol support | No |
+| Variable             | Description                                                                     | Required             |
+| -------------------- | ------------------------------------------------------------------------------- | -------------------- |
+| `SOLANA_PRIVATE_KEY` | JSON array of numbers (Uint8Array) — e.g. `[1,2,3,...]`                         | For registration     |
+| `SOLANA_CLUSTER`     | `mainnet-beta` \| `devnet` \| `testnet` \| `localnet` (default: `mainnet-beta`) | No                   |
+| `SOLANA_RPC_URL`     | Custom RPC endpoint                                                             | No                   |
+| `AGENT_DOMAIN`       | Agent domain for identity registration                                          | Recommended          |
+| `REGISTER_IDENTITY`  | `true`/`false` — auto-register on startup                                       | No (default: `true`) |
+| `PINATA_JWT`         | Pinata JWT for IPFS metadata upload                                             | No                   |
+| `ATOM_ENABLED`       | Enable ATOM protocol support                                                    | No                   |
 
 ## Manual Configuration
 
 ```ts
+import { createAgent } from '@lucid-agents/core';
 import { identitySolana } from '@lucid-agents/identity-solana';
 
 const agent = await createAgent({ name: 'my-agent', version: '1.0.0' })
-  .use(identitySolana({
-    config: {
-      privateKey: new Uint8Array([/* your 64-byte keypair */]),
-      cluster: 'devnet',
-      domain: 'my-agent.example.com',
-      autoRegister: true,
-      trustModels: ['feedback', 'inference-validation'],
-    },
-  }))
+  .use(
+    identitySolana({
+      config: {
+        privateKey: new Uint8Array([
+          /* your 64-byte keypair */
+        ]),
+        cluster: 'devnet',
+        domain: 'my-agent.example.com',
+        autoRegister: true,
+        trustModels: ['feedback', 'inference-validation'],
+      },
+    })
+  )
   .build();
 ```
 
@@ -88,25 +96,31 @@ if (identity.clients) {
   });
 
   // Get agent record
-  const record = await identity.clients.identity.getAgentByOwner('wallet-address');
+  const record =
+    await identity.clients.identity.getAgentByOwner('wallet-address');
 }
 ```
 
 ## API Reference
 
 ### `identitySolana(options?)`
+
 Extension for Lucid SDK. Accepts `config?: SolanaIdentityConfig`.
 
 ### `identitySolanaFromEnv(env?)`
+
 Creates `SolanaIdentityConfig` from environment variables.
 
 ### `createSolanaAgentIdentity(options)`
+
 Core function — registers agent on 8004-Solana, returns `SolanaAgentIdentity` with `trust`, `record`, and `clients`.
 
 ### `createAgentCardWithSolanaIdentity(card, trustConfig)`
+
 Merges Solana trust into an A2A Agent Card (immutable).
 
 ### `SolanaRegistryClients`
+
 ```ts
 type SolanaRegistryClients = {
   identity: SolanaIdentityRegistryClient;
@@ -116,10 +130,10 @@ type SolanaRegistryClients = {
 
 ## Differences from @lucid-agents/identity (EVM)
 
-| Feature | EVM | Solana |
-|---|---|---|
-| Registry | ERC-8004 on Ethereum/Base | 8004-Solana program |
-| Key format | `0x…` hex private key | JSON array `[1,2,3,…]` |
-| Chain config | `chainId` + `rpcUrl` | `cluster` + `rpcUrl` |
-| Peer deps | `viem` | `@solana/web3.js` |
-| Extension name | `identity` | `identity-solana` |
+| Feature        | EVM                       | Solana                 |
+| -------------- | ------------------------- | ---------------------- |
+| Registry       | ERC-8004 on Ethereum/Base | 8004-Solana program    |
+| Key format     | `0x…` hex private key     | JSON array `[1,2,3,…]` |
+| Chain config   | `chainId` + `rpcUrl`      | `cluster` + `rpcUrl`   |
+| Peer deps      | `viem`                    | `@solana/web3.js`      |
+| Extension name | `identity`                | `identity-solana`      |

--- a/packages/identity-solana/README.md
+++ b/packages/identity-solana/README.md
@@ -1,0 +1,125 @@
+# @lucid-agents/identity-solana
+
+8004-Solana identity helpers for the Lucid agent SDK. Mirrors `@lucid-agents/identity` (EVM/ERC-8004) for Solana — same Extension API, different chain.
+
+## Installation
+
+```bash
+bun add @lucid-agents/identity-solana @solana/web3.js 8004-solana
+```
+
+## Quick Start
+
+```ts
+import { createAgent } from '@lucid-agents/core';
+import { http } from '@lucid-agents/http';
+import { identitySolana, identitySolanaFromEnv } from '@lucid-agents/identity-solana';
+
+const agent = await createAgent({ name: 'my-agent', version: '1.0.0' })
+  .use(http())
+  .use(identitySolana({ config: identitySolanaFromEnv() }))
+  .build();
+```
+
+## Environment Variables
+
+| Variable | Description | Required |
+|---|---|---|
+| `SOLANA_PRIVATE_KEY` | JSON array of numbers (Uint8Array) — e.g. `[1,2,3,...]` | For registration |
+| `SOLANA_CLUSTER` | `mainnet-beta` \| `devnet` \| `testnet` (default: `mainnet-beta`) | No |
+| `SOLANA_RPC_URL` | Custom RPC endpoint | No |
+| `AGENT_DOMAIN` | Agent domain for identity registration | Recommended |
+| `REGISTER_IDENTITY` | `true`/`false` — auto-register on startup | No (default: `true`) |
+| `PINATA_JWT` | Pinata JWT for IPFS metadata upload | No |
+| `ATOM_ENABLED` | Enable ATOM protocol support | No |
+
+## Manual Configuration
+
+```ts
+import { identitySolana } from '@lucid-agents/identity-solana';
+
+const agent = await createAgent({ name: 'my-agent', version: '1.0.0' })
+  .use(identitySolana({
+    config: {
+      privateKey: new Uint8Array([/* your 64-byte keypair */]),
+      cluster: 'devnet',
+      domain: 'my-agent.example.com',
+      autoRegister: true,
+      trustModels: ['feedback', 'inference-validation'],
+    },
+  }))
+  .build();
+```
+
+## Browser Wallet Support (skipSend)
+
+For browser wallets where signing must be deferred:
+
+```ts
+import { createSolanaAgentIdentity } from '@lucid-agents/identity-solana';
+
+const identity = await createSolanaAgentIdentity({
+  domain: 'my-agent.example.com',
+  registration: { skipSend: true },
+});
+
+if (identity.unsignedTransaction) {
+  // Sign and broadcast with user's browser wallet
+  const signedTx = await wallet.signTransaction(identity.unsignedTransaction);
+  await connection.sendRawTransaction(signedTx.serialize());
+}
+```
+
+## Registry Clients
+
+After identity is created, use the registry clients:
+
+```ts
+const identity = await createSolanaAgentIdentity({ autoRegister: true });
+
+if (identity.clients) {
+  // Give feedback to another agent
+  await identity.clients.reputation.giveFeedback({
+    toAgentId: BigInt(42),
+    value: 90,
+    tag1: 'reliable',
+    tag2: 'fast',
+    endpoint: 'https://other-agent.example.com',
+  });
+
+  // Get agent record
+  const record = await identity.clients.identity.getAgentByOwner('wallet-address');
+}
+```
+
+## API Reference
+
+### `identitySolana(options?)`
+Extension for Lucid SDK. Accepts `config?: SolanaIdentityConfig`.
+
+### `identitySolanaFromEnv(env?)`
+Creates `SolanaIdentityConfig` from environment variables.
+
+### `createSolanaAgentIdentity(options)`
+Core function — registers agent on 8004-Solana, returns `SolanaAgentIdentity` with `trust`, `record`, and `clients`.
+
+### `createAgentCardWithSolanaIdentity(card, trustConfig)`
+Merges Solana trust into an A2A Agent Card (immutable).
+
+### `SolanaRegistryClients`
+```ts
+type SolanaRegistryClients = {
+  identity: SolanaIdentityRegistryClient;
+  reputation: SolanaReputationRegistryClient;
+};
+```
+
+## Differences from @lucid-agents/identity (EVM)
+
+| Feature | EVM | Solana |
+|---|---|---|
+| Registry | ERC-8004 on Ethereum/Base | 8004-Solana program |
+| Key format | `0x…` hex private key | JSON array `[1,2,3,…]` |
+| Chain config | `chainId` + `rpcUrl` | `cluster` + `rpcUrl` |
+| Peer deps | `viem` | `@solana/web3.js` |
+| Extension name | `identity` | `identity-solana` |

--- a/packages/identity-solana/package.json
+++ b/packages/identity-solana/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@lucid-agents/identity-solana",
+  "version": "0.1.0",
+  "description": "8004-Solana identity helpers for Lucid agent kit surfaces",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/daydreamsai/lucid-agents",
+    "directory": "packages/identity-solana"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "clean": "rm -rf dist",
+    "test": "bun test",
+    "lint": "eslint src --ext .ts",
+    "lint:fix": "eslint src --ext .ts --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "type-check": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@lucid-agents/types": "workspace:*",
+    "8004-solana": "^0.7.9"
+  },
+  "peerDependencies": {
+    "@solana/web3.js": "^1.98.0"
+  },
+  "peerDependenciesMeta": {
+    "@solana/web3.js": {
+      "optional": false
+    }
+  },
+  "devDependencies": {
+    "@solana/web3.js": "^1.98.0",
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.2",
+    "@lucid-agents/eslint-config": "workspace:*",
+    "@lucid-agents/prettier-config": "workspace:*",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/packages/identity-solana/src/__tests__/env.test.ts
+++ b/packages/identity-solana/src/__tests__/env.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect,it } from 'bun:test';
+
+import { identitySolanaFromEnv } from '../env';
+
+const makeKey = () => JSON.stringify(Array.from({ length: 64 }, (_, i) => i));
+
+describe('identitySolanaFromEnv', () => {
+  it('returns empty config when no env vars set', () => {
+    const config = identitySolanaFromEnv({});
+    expect(config.privateKey).toBeUndefined();
+    expect(config.cluster).toBeUndefined();
+    expect(config.domain).toBeUndefined();
+  });
+
+  it('parses SOLANA_PRIVATE_KEY', () => {
+    const config = identitySolanaFromEnv({
+      SOLANA_PRIVATE_KEY: makeKey(),
+    });
+    expect(config.privateKey).toBeInstanceOf(Uint8Array);
+    expect(config.privateKey?.length).toBe(64);
+  });
+
+  it('passes SOLANA_CLUSTER', () => {
+    const config = identitySolanaFromEnv({ SOLANA_CLUSTER: 'devnet' });
+    expect(config.cluster).toBe('devnet');
+  });
+
+  it('passes SOLANA_RPC_URL', () => {
+    const config = identitySolanaFromEnv({
+      SOLANA_RPC_URL: 'https://custom.rpc.example.com',
+    });
+    expect(config.rpcUrl).toBe('https://custom.rpc.example.com');
+  });
+
+  it('passes AGENT_DOMAIN', () => {
+    const config = identitySolanaFromEnv({ AGENT_DOMAIN: 'agent.example.com' });
+    expect(config.domain).toBe('agent.example.com');
+  });
+
+  it('parses REGISTER_IDENTITY=true', () => {
+    const config = identitySolanaFromEnv({ REGISTER_IDENTITY: 'true' });
+    expect(config.autoRegister).toBe(true);
+  });
+
+  it('parses REGISTER_IDENTITY=false', () => {
+    const config = identitySolanaFromEnv({ REGISTER_IDENTITY: 'false' });
+    expect(config.autoRegister).toBe(false);
+  });
+
+  it('does not set autoRegister when REGISTER_IDENTITY absent', () => {
+    const config = identitySolanaFromEnv({});
+    expect(config.autoRegister).toBeUndefined();
+  });
+
+  it('attaches env reference for downstream use', () => {
+    const env = { SOLANA_CLUSTER: 'devnet' };
+    const config = identitySolanaFromEnv(env);
+    expect(config.env).toBe(env);
+  });
+});

--- a/packages/identity-solana/src/__tests__/env.test.ts
+++ b/packages/identity-solana/src/__tests__/env.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect,it } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 
 import { identitySolanaFromEnv } from '../env';
 

--- a/packages/identity-solana/src/__tests__/extension.test.ts
+++ b/packages/identity-solana/src/__tests__/extension.test.ts
@@ -1,18 +1,26 @@
-import { describe, expect,it } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 
 import { identitySolana } from '../extension';
 
-const makeRuntime = () => ({
-  wallets: {},
-  entrypoints: { snapshot: () => [] },
-} as any);
+const makeRuntime = () =>
+  ({
+    wallets: {},
+    entrypoints: { snapshot: () => [] },
+  }) as any;
 
-const makeCard = () => ({
-  name: 'test-agent',
-  version: '1.0.0',
-  entrypoints: [],
-  capabilities: {},
-} as any);
+const makeBuildCtx = () =>
+  ({
+    meta: { name: 'test-agent', version: '1.0.0' },
+    runtime: {},
+  }) as any;
+
+const makeCard = () =>
+  ({
+    name: 'test-agent',
+    version: '1.0.0',
+    entrypoints: [],
+    capabilities: {},
+  }) as any;
 
 describe('identitySolana extension', () => {
   describe('contract: .use() attaches correctly', () => {
@@ -32,7 +40,7 @@ describe('identitySolana extension', () => {
   describe('build()', () => {
     it('returns empty object when no config provided', () => {
       const ext = identitySolana();
-      const result = ext.build();
+      const result = ext.build(makeBuildCtx());
       expect(result.trust).toBeUndefined();
       expect(result.identity).toBeUndefined();
     });
@@ -40,7 +48,7 @@ describe('identitySolana extension', () => {
     it('returns trust from config when pre-supplied', () => {
       const trust = { trustModels: ['feedback'] as string[] };
       const ext = identitySolana({ config: { trust } });
-      const result = ext.build();
+      const result = ext.build(makeBuildCtx());
       expect(result.trust).toBe(trust);
     });
 
@@ -50,7 +58,7 @@ describe('identitySolana extension', () => {
           registration: { name: 'Test Agent', skipSend: false },
         },
       });
-      const result = ext.build();
+      const result = ext.build(makeBuildCtx());
       expect(result.identity?.registration?.name).toBe('Test Agent');
     });
   });

--- a/packages/identity-solana/src/__tests__/extension.test.ts
+++ b/packages/identity-solana/src/__tests__/extension.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect,it } from 'bun:test';
+
+import { identitySolana } from '../extension';
+
+const makeRuntime = () => ({
+  wallets: {},
+  entrypoints: { snapshot: () => [] },
+} as any);
+
+const makeCard = () => ({
+  name: 'test-agent',
+  version: '1.0.0',
+  entrypoints: [],
+  capabilities: {},
+} as any);
+
+describe('identitySolana extension', () => {
+  describe('contract: .use() attaches correctly', () => {
+    it('returns an extension object with name identity-solana', () => {
+      const ext = identitySolana();
+      expect(ext.name).toBe('identity-solana');
+    });
+
+    it('has build, onBuild, onManifestBuild lifecycle methods', () => {
+      const ext = identitySolana();
+      expect(typeof ext.build).toBe('function');
+      expect(typeof ext.onBuild).toBe('function');
+      expect(typeof ext.onManifestBuild).toBe('function');
+    });
+  });
+
+  describe('build()', () => {
+    it('returns empty object when no config provided', () => {
+      const ext = identitySolana();
+      const result = ext.build();
+      expect(result.trust).toBeUndefined();
+      expect(result.identity).toBeUndefined();
+    });
+
+    it('returns trust from config when pre-supplied', () => {
+      const trust = { trustModels: ['feedback'] as string[] };
+      const ext = identitySolana({ config: { trust } });
+      const result = ext.build();
+      expect(result.trust).toBe(trust);
+    });
+
+    it('returns identity when registration config provided', () => {
+      const ext = identitySolana({
+        config: {
+          registration: { name: 'Test Agent', skipSend: false },
+        },
+      });
+      const result = ext.build();
+      expect(result.identity?.registration?.name).toBe('Test Agent');
+    });
+  });
+
+  describe('onBuild()', () => {
+    it('skips registration when trust already provided', async () => {
+      const trust = { trustModels: ['feedback'] as string[] };
+      const ext = identitySolana({ config: { trust } });
+      // onBuild should not error; trust is already set
+      await expect(ext.onBuild!(makeRuntime())).resolves.toBeUndefined();
+    });
+
+    it('does not throw when no config provided', async () => {
+      const ext = identitySolana();
+      await expect(ext.onBuild!(makeRuntime())).resolves.toBeUndefined();
+    });
+  });
+
+  describe('onManifestBuild()', () => {
+    it('returns original card when no trust configured', () => {
+      const ext = identitySolana();
+      const card = makeCard();
+      const result = ext.onManifestBuild!(card, makeRuntime());
+      // No trust = card returned unchanged (structurally equal)
+      expect(result.name).toBe(card.name);
+    });
+
+    it('merges trust into card when trust config present', () => {
+      const trust = {
+        trustModels: ['feedback', 'inference-validation'] as string[],
+        registrations: [{ agentId: '42', agentRegistry: 'solana:devnet:8004' }],
+      };
+      const ext = identitySolana({ config: { trust } });
+      const card = makeCard();
+      const result = ext.onManifestBuild!(card, makeRuntime());
+      expect(result.trustModels).toContain('feedback');
+      expect(result.registrations?.length).toBe(1);
+    });
+
+    it('does not mutate original card', () => {
+      const trust = { trustModels: ['feedback'] as string[] };
+      const ext = identitySolana({ config: { trust } });
+      const card = makeCard();
+      ext.onManifestBuild!(card, makeRuntime());
+      expect(card.trustModels).toBeUndefined();
+    });
+  });
+});

--- a/packages/identity-solana/src/__tests__/identity-registry.test.ts
+++ b/packages/identity-solana/src/__tests__/identity-registry.test.ts
@@ -2,21 +2,31 @@ import { describe, expect, it, mock } from 'bun:test';
 
 import { createSolanaIdentityRegistryClient } from '../registries/identity';
 
-/** Build a mock SolanaSDK */
+/** Build a mock SolanaSDK matching the methods actually used in the registry client */
 function makeMockSdk(overrides: Record<string, unknown> = {}) {
   return {
-    getAgent: mock(async () => null),
-    getAgentsByOwner: mock(async () => []),
-    registerAgent: mock(async () => ({ agentId: BigInt(42), signature: 'sig123' })),
+    // getAgentByAgentId is used for getAgent(agentId)
+    getAgentByAgentId: mock(async () => null),
+    // getAgentByWallet is used for getAgentByOwner(walletAddress)
+    getAgentByWallet: mock(async () => null),
+    // registerAgent is used for on-chain registration
+    registerAgent: mock(async () => ({ agentId: '42', signature: 'sig123' })),
     getCluster: mock(() => 'devnet'),
     ...overrides,
   } as any;
 }
 
+const INDEXED_AGENT = {
+  agent_id: 5,
+  owner: 'OwnerAddress111111111111111111111111111111',
+  agent_uri: 'https://agent.example.com/.well-known/agent.json',
+  asset: 'AssetAddress11111111111111111111111111111111',
+};
+
 describe('createSolanaIdentityRegistryClient', () => {
   describe('getAgent', () => {
     it('returns null when agent not found', async () => {
-      const sdk = makeMockSdk({ getAgent: mock(async () => null) });
+      const sdk = makeMockSdk({ getAgentByAgentId: mock(async () => null) });
       const client = createSolanaIdentityRegistryClient(sdk);
       const result = await client.getAgent(1n);
       expect(result).toBeNull();
@@ -24,21 +34,21 @@ describe('createSolanaIdentityRegistryClient', () => {
 
     it('returns agent record when found', async () => {
       const sdk = makeMockSdk({
-        getAgent: mock(async () => ({
-          agentId: BigInt(5),
-          owner: { toString: () => '0xABC' },
-          uri: 'https://agent.example.com',
-        })),
+        getAgentByAgentId: mock(async () => INDEXED_AGENT),
       });
       const client = createSolanaIdentityRegistryClient(sdk);
-      const result = await client.getAgent(5n);
-      expect(result?.agentId).toBeDefined();
+      const result = await client.getAgent(5);
+      expect(result?.agentId).toBe(5);
+      expect(result?.owner).toBe(INDEXED_AGENT.owner);
+      expect(result?.uri).toBe(INDEXED_AGENT.agent_uri);
       expect(result?.cluster).toBe('devnet');
     });
 
     it('returns null on SDK error', async () => {
       const sdk = makeMockSdk({
-        getAgent: mock(async () => { throw new Error('network error'); }),
+        getAgentByAgentId: mock(async () => {
+          throw new Error('network error');
+        }),
       });
       const client = createSolanaIdentityRegistryClient(sdk);
       const result = await client.getAgent(1n);
@@ -47,22 +57,22 @@ describe('createSolanaIdentityRegistryClient', () => {
   });
 
   describe('getAgentByOwner', () => {
-    it('returns null when no agents for owner', async () => {
-      const sdk = makeMockSdk({ getAgentsByOwner: mock(async () => []) });
+    it('returns null when wallet not found', async () => {
+      const sdk = makeMockSdk({ getAgentByWallet: mock(async () => null) });
       const client = createSolanaIdentityRegistryClient(sdk);
       const result = await client.getAgentByOwner('ABC123');
       expect(result).toBeNull();
     });
 
-    it('returns first agent for owner', async () => {
+    it('returns agent record for wallet owner', async () => {
       const sdk = makeMockSdk({
-        getAgentsByOwner: mock(async () => [
-          { agentId: BigInt(7), owner: { toString: () => 'OWNER' }, uri: 'https://x.com' },
-        ]),
+        getAgentByWallet: mock(async () => INDEXED_AGENT),
       });
       const client = createSolanaIdentityRegistryClient(sdk);
-      const result = await client.getAgentByOwner('OWNER');
-      expect(result?.agentId).toBeDefined();
+      const result = await client.getAgentByOwner(INDEXED_AGENT.owner);
+      expect(result?.agentId).toBe(5);
+      expect(result?.owner).toBe(INDEXED_AGENT.owner);
+      expect(result?.uri).toBe(INDEXED_AGENT.agent_uri);
     });
   });
 
@@ -78,12 +88,28 @@ describe('createSolanaIdentityRegistryClient', () => {
       expect(sdk.registerAgent).toHaveBeenCalled();
     });
 
+    it('uses custom agentURI when provided', async () => {
+      const sdk = makeMockSdk();
+      const client = createSolanaIdentityRegistryClient(sdk);
+      await client.registerAgent({
+        domain: 'agent.example.com',
+        agentURI: 'https://custom.example.com/agent.json',
+      });
+      expect(sdk.registerAgent).toHaveBeenCalledWith(
+        'https://custom.example.com/agent.json'
+      );
+    });
+
     it('handles already-exists error gracefully', async () => {
       const sdk = makeMockSdk({
-        registerAgent: mock(async () => { throw new Error('agent already exists'); }),
+        registerAgent: mock(async () => {
+          throw new Error('agent already exists');
+        }),
       });
       const client = createSolanaIdentityRegistryClient(sdk);
-      const result = await client.registerAgent({ domain: 'agent.example.com' });
+      const result = await client.registerAgent({
+        domain: 'agent.example.com',
+      });
       expect(result.alreadyExists).toBe(true);
       expect(result.didRegister).toBe(false);
     });

--- a/packages/identity-solana/src/__tests__/identity-registry.test.ts
+++ b/packages/identity-solana/src/__tests__/identity-registry.test.ts
@@ -1,3 +1,4 @@
+import { SolanaSDK } from '8004-solana';
 import { describe, expect, it, mock } from 'bun:test';
 
 import { createSolanaIdentityRegistryClient } from '../registries/identity';
@@ -24,6 +25,16 @@ function makeMockSdk(overrides: Partial<MockSolanaSDK> = {}): MockSolanaSDK {
   };
 }
 
+/**
+ * Typed factory: wraps the single unavoidable cast in one place so individual
+ * tests never need `as any`.
+ */
+function createClientFromMock(sdk: MockSolanaSDK) {
+  return createSolanaIdentityRegistryClient(
+    sdk as unknown as InstanceType<typeof SolanaSDK>
+  );
+}
+
 const INDEXED_AGENT = {
   agent_id: 5,
   owner: 'OwnerAddress111111111111111111111111111111',
@@ -43,7 +54,7 @@ describe('createSolanaIdentityRegistryClient', () => {
   describe('getAgent', () => {
     it('returns null when agent not found', async () => {
       const sdk = makeMockSdk({ getAgentByAgentId: mock(async () => null) });
-      const client = createSolanaIdentityRegistryClient(sdk as any);
+      const client = createClientFromMock(sdk);
       const result = await client.getAgent(1n);
       expect(result).toBeNull();
     });
@@ -52,7 +63,7 @@ describe('createSolanaIdentityRegistryClient', () => {
       const sdk = makeMockSdk({
         getAgentByAgentId: mock(async () => INDEXED_AGENT),
       });
-      const client = createSolanaIdentityRegistryClient(sdk as any);
+      const client = createClientFromMock(sdk);
       const result = await client.getAgent(5);
       expect(result?.agentId).toBe(5);
       expect(result?.owner).toBe(INDEXED_AGENT.owner);
@@ -66,7 +77,7 @@ describe('createSolanaIdentityRegistryClient', () => {
           throw new Error('network error');
         }),
       });
-      const client = createSolanaIdentityRegistryClient(sdk as any);
+      const client = createClientFromMock(sdk);
       await expect(client.getAgent(1n)).rejects.toThrow(
         'getAgent: failed to fetch agent'
       );
@@ -76,7 +87,7 @@ describe('createSolanaIdentityRegistryClient', () => {
   describe('getAgentByOwner', () => {
     it('returns null when wallet not found', async () => {
       const sdk = makeMockSdk({ getAgentByWallet: mock(async () => null) });
-      const client = createSolanaIdentityRegistryClient(sdk as any);
+      const client = createClientFromMock(sdk);
       const result = await client.getAgentByOwner('ABC123');
       expect(result).toBeNull();
     });
@@ -85,7 +96,7 @@ describe('createSolanaIdentityRegistryClient', () => {
       const sdk = makeMockSdk({
         getAgentByWallet: mock(async () => INDEXED_AGENT),
       });
-      const client = createSolanaIdentityRegistryClient(sdk as any);
+      const client = createClientFromMock(sdk);
       const result = await client.getAgentByOwner(INDEXED_AGENT.owner);
       expect(result?.agentId).toBe(5);
       expect(result?.owner).toBe(INDEXED_AGENT.owner);
@@ -98,7 +109,7 @@ describe('createSolanaIdentityRegistryClient', () => {
           throw new Error('network error');
         }),
       });
-      const client = createSolanaIdentityRegistryClient(sdk as any);
+      const client = createClientFromMock(sdk);
       await expect(client.getAgentByOwner('ABC123')).rejects.toThrow(
         'getAgentByOwner: failed to fetch agent'
       );
@@ -108,7 +119,7 @@ describe('createSolanaIdentityRegistryClient', () => {
   describe('registerAgent', () => {
     it('calls sdk.registerAgent with tokenUri', async () => {
       const sdk = makeMockSdk();
-      const client = createSolanaIdentityRegistryClient(sdk as any);
+      const client = createClientFromMock(sdk);
       const result = await client.registerAgent({
         domain: 'agent.example.com',
         name: 'Test Agent',
@@ -119,7 +130,7 @@ describe('createSolanaIdentityRegistryClient', () => {
 
     it('uses custom agentURI when provided', async () => {
       const sdk = makeMockSdk();
-      const client = createSolanaIdentityRegistryClient(sdk as any);
+      const client = createClientFromMock(sdk);
       await client.registerAgent({
         domain: 'agent.example.com',
         agentURI: 'https://custom.example.com/agent.json',
@@ -135,7 +146,7 @@ describe('createSolanaIdentityRegistryClient', () => {
           throw new Error('agent already exists');
         }),
       });
-      const client = createSolanaIdentityRegistryClient(sdk as any);
+      const client = createClientFromMock(sdk);
       const result = await client.registerAgent({
         domain: 'agent.example.com',
       });
@@ -149,7 +160,7 @@ describe('createSolanaIdentityRegistryClient', () => {
       const sdk = makeMockSdk({
         registerAgent: mock(async () => FAKE_PREPARED_TX),
       });
-      const client = createSolanaIdentityRegistryClient(sdk as any);
+      const client = createClientFromMock(sdk);
       const result = await client.registerAgent({
         domain: 'agent.example.com',
         skipSend: true,

--- a/packages/identity-solana/src/__tests__/identity-registry.test.ts
+++ b/packages/identity-solana/src/__tests__/identity-registry.test.ts
@@ -44,15 +44,16 @@ describe('createSolanaIdentityRegistryClient', () => {
       expect(result?.cluster).toBe('devnet');
     });
 
-    it('returns null on SDK error', async () => {
+    it('rethrows SDK errors so callers distinguish outages from missing agents', async () => {
       const sdk = makeMockSdk({
         getAgentByAgentId: mock(async () => {
           throw new Error('network error');
         }),
       });
       const client = createSolanaIdentityRegistryClient(sdk);
-      const result = await client.getAgent(1n);
-      expect(result).toBeNull();
+      await expect(client.getAgent(1n)).rejects.toThrow(
+        'getAgent: failed to fetch agent'
+      );
     });
   });
 

--- a/packages/identity-solana/src/__tests__/identity-registry.test.ts
+++ b/packages/identity-solana/src/__tests__/identity-registry.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+import { createSolanaIdentityRegistryClient } from '../registries/identity';
+
+/** Build a mock SolanaSDK */
+function makeMockSdk(overrides: Record<string, unknown> = {}) {
+  return {
+    getAgent: mock(async () => null),
+    getAgentsByOwner: mock(async () => []),
+    registerAgent: mock(async () => ({ agentId: BigInt(42), signature: 'sig123' })),
+    getCluster: mock(() => 'devnet'),
+    ...overrides,
+  } as any;
+}
+
+describe('createSolanaIdentityRegistryClient', () => {
+  describe('getAgent', () => {
+    it('returns null when agent not found', async () => {
+      const sdk = makeMockSdk({ getAgent: mock(async () => null) });
+      const client = createSolanaIdentityRegistryClient(sdk);
+      const result = await client.getAgent(1n);
+      expect(result).toBeNull();
+    });
+
+    it('returns agent record when found', async () => {
+      const sdk = makeMockSdk({
+        getAgent: mock(async () => ({
+          agentId: BigInt(5),
+          owner: { toString: () => '0xABC' },
+          uri: 'https://agent.example.com',
+        })),
+      });
+      const client = createSolanaIdentityRegistryClient(sdk);
+      const result = await client.getAgent(5n);
+      expect(result?.agentId).toBeDefined();
+      expect(result?.cluster).toBe('devnet');
+    });
+
+    it('returns null on SDK error', async () => {
+      const sdk = makeMockSdk({
+        getAgent: mock(async () => { throw new Error('network error'); }),
+      });
+      const client = createSolanaIdentityRegistryClient(sdk);
+      const result = await client.getAgent(1n);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getAgentByOwner', () => {
+    it('returns null when no agents for owner', async () => {
+      const sdk = makeMockSdk({ getAgentsByOwner: mock(async () => []) });
+      const client = createSolanaIdentityRegistryClient(sdk);
+      const result = await client.getAgentByOwner('ABC123');
+      expect(result).toBeNull();
+    });
+
+    it('returns first agent for owner', async () => {
+      const sdk = makeMockSdk({
+        getAgentsByOwner: mock(async () => [
+          { agentId: BigInt(7), owner: { toString: () => 'OWNER' }, uri: 'https://x.com' },
+        ]),
+      });
+      const client = createSolanaIdentityRegistryClient(sdk);
+      const result = await client.getAgentByOwner('OWNER');
+      expect(result?.agentId).toBeDefined();
+    });
+  });
+
+  describe('registerAgent', () => {
+    it('calls sdk.registerAgent with tokenUri', async () => {
+      const sdk = makeMockSdk();
+      const client = createSolanaIdentityRegistryClient(sdk);
+      const result = await client.registerAgent({
+        domain: 'agent.example.com',
+        name: 'Test Agent',
+      });
+      expect(result.didRegister).toBe(true);
+      expect(sdk.registerAgent).toHaveBeenCalled();
+    });
+
+    it('handles already-exists error gracefully', async () => {
+      const sdk = makeMockSdk({
+        registerAgent: mock(async () => { throw new Error('agent already exists'); }),
+      });
+      const client = createSolanaIdentityRegistryClient(sdk);
+      const result = await client.registerAgent({ domain: 'agent.example.com' });
+      expect(result.alreadyExists).toBe(true);
+      expect(result.didRegister).toBe(false);
+    });
+
+    it('returns unsignedTransaction when skipSend=true', async () => {
+      const sdk = makeMockSdk();
+      const client = createSolanaIdentityRegistryClient(sdk);
+      const result = await client.registerAgent({
+        domain: 'agent.example.com',
+        skipSend: true,
+      });
+      expect(result.didRegister).toBe(false);
+      expect(result.unsignedTransaction).toBeInstanceOf(Uint8Array);
+    });
+  });
+});

--- a/packages/identity-solana/src/__tests__/identity-registry.test.ts
+++ b/packages/identity-solana/src/__tests__/identity-registry.test.ts
@@ -2,8 +2,16 @@ import { describe, expect, it, mock } from 'bun:test';
 
 import { createSolanaIdentityRegistryClient } from '../registries/identity';
 
+/** Typed shape for the subset of SolanaSDK methods used by the identity registry client */
+type MockSolanaSDK = {
+  getAgentByAgentId: ReturnType<typeof mock>;
+  getAgentByWallet: ReturnType<typeof mock>;
+  registerAgent: ReturnType<typeof mock>;
+  getCluster: ReturnType<typeof mock>;
+};
+
 /** Build a mock SolanaSDK matching the methods actually used in the registry client */
-function makeMockSdk(overrides: Record<string, unknown> = {}) {
+function makeMockSdk(overrides: Partial<MockSolanaSDK> = {}): MockSolanaSDK {
   return {
     // getAgentByAgentId is used for getAgent(agentId)
     getAgentByAgentId: mock(async () => null),
@@ -13,7 +21,7 @@ function makeMockSdk(overrides: Record<string, unknown> = {}) {
     registerAgent: mock(async () => ({ agentId: '42', signature: 'sig123' })),
     getCluster: mock(() => 'devnet'),
     ...overrides,
-  } as any;
+  };
 }
 
 const INDEXED_AGENT = {
@@ -23,11 +31,19 @@ const INDEXED_AGENT = {
   asset: 'AssetAddress11111111111111111111111111111111',
 };
 
+// A valid PreparedTransaction-shaped response for skipSend flows
+const FAKE_PREPARED_TX = {
+  transaction: Buffer.from('fake-unsigned-tx-bytes').toString('base64'),
+  blockhash: 'FakeBlocKHash1111111111111111111111111111111',
+  lastValidBlockHeight: 999,
+  signer: 'SignerPubkey11111111111111111111111111111111',
+};
+
 describe('createSolanaIdentityRegistryClient', () => {
   describe('getAgent', () => {
     it('returns null when agent not found', async () => {
       const sdk = makeMockSdk({ getAgentByAgentId: mock(async () => null) });
-      const client = createSolanaIdentityRegistryClient(sdk);
+      const client = createSolanaIdentityRegistryClient(sdk as any);
       const result = await client.getAgent(1n);
       expect(result).toBeNull();
     });
@@ -36,7 +52,7 @@ describe('createSolanaIdentityRegistryClient', () => {
       const sdk = makeMockSdk({
         getAgentByAgentId: mock(async () => INDEXED_AGENT),
       });
-      const client = createSolanaIdentityRegistryClient(sdk);
+      const client = createSolanaIdentityRegistryClient(sdk as any);
       const result = await client.getAgent(5);
       expect(result?.agentId).toBe(5);
       expect(result?.owner).toBe(INDEXED_AGENT.owner);
@@ -50,7 +66,7 @@ describe('createSolanaIdentityRegistryClient', () => {
           throw new Error('network error');
         }),
       });
-      const client = createSolanaIdentityRegistryClient(sdk);
+      const client = createSolanaIdentityRegistryClient(sdk as any);
       await expect(client.getAgent(1n)).rejects.toThrow(
         'getAgent: failed to fetch agent'
       );
@@ -60,7 +76,7 @@ describe('createSolanaIdentityRegistryClient', () => {
   describe('getAgentByOwner', () => {
     it('returns null when wallet not found', async () => {
       const sdk = makeMockSdk({ getAgentByWallet: mock(async () => null) });
-      const client = createSolanaIdentityRegistryClient(sdk);
+      const client = createSolanaIdentityRegistryClient(sdk as any);
       const result = await client.getAgentByOwner('ABC123');
       expect(result).toBeNull();
     });
@@ -69,18 +85,30 @@ describe('createSolanaIdentityRegistryClient', () => {
       const sdk = makeMockSdk({
         getAgentByWallet: mock(async () => INDEXED_AGENT),
       });
-      const client = createSolanaIdentityRegistryClient(sdk);
+      const client = createSolanaIdentityRegistryClient(sdk as any);
       const result = await client.getAgentByOwner(INDEXED_AGENT.owner);
       expect(result?.agentId).toBe(5);
       expect(result?.owner).toBe(INDEXED_AGENT.owner);
       expect(result?.uri).toBe(INDEXED_AGENT.agent_uri);
+    });
+
+    it('rethrows SDK errors for getAgentByOwner', async () => {
+      const sdk = makeMockSdk({
+        getAgentByWallet: mock(async () => {
+          throw new Error('network error');
+        }),
+      });
+      const client = createSolanaIdentityRegistryClient(sdk as any);
+      await expect(client.getAgentByOwner('ABC123')).rejects.toThrow(
+        'getAgentByOwner: failed to fetch agent'
+      );
     });
   });
 
   describe('registerAgent', () => {
     it('calls sdk.registerAgent with tokenUri', async () => {
       const sdk = makeMockSdk();
-      const client = createSolanaIdentityRegistryClient(sdk);
+      const client = createSolanaIdentityRegistryClient(sdk as any);
       const result = await client.registerAgent({
         domain: 'agent.example.com',
         name: 'Test Agent',
@@ -91,7 +119,7 @@ describe('createSolanaIdentityRegistryClient', () => {
 
     it('uses custom agentURI when provided', async () => {
       const sdk = makeMockSdk();
-      const client = createSolanaIdentityRegistryClient(sdk);
+      const client = createSolanaIdentityRegistryClient(sdk as any);
       await client.registerAgent({
         domain: 'agent.example.com',
         agentURI: 'https://custom.example.com/agent.json',
@@ -107,7 +135,7 @@ describe('createSolanaIdentityRegistryClient', () => {
           throw new Error('agent already exists');
         }),
       });
-      const client = createSolanaIdentityRegistryClient(sdk);
+      const client = createSolanaIdentityRegistryClient(sdk as any);
       const result = await client.registerAgent({
         domain: 'agent.example.com',
       });
@@ -115,15 +143,20 @@ describe('createSolanaIdentityRegistryClient', () => {
       expect(result.didRegister).toBe(false);
     });
 
-    it('returns unsignedTransaction when skipSend=true', async () => {
-      const sdk = makeMockSdk();
-      const client = createSolanaIdentityRegistryClient(sdk);
+    it('returns non-empty unsignedTransaction when skipSend=true', async () => {
+      // Mock must return PreparedTransaction shape ({transaction: base64}) so the
+      // registry client can decode it into a real Uint8Array.
+      const sdk = makeMockSdk({
+        registerAgent: mock(async () => FAKE_PREPARED_TX),
+      });
+      const client = createSolanaIdentityRegistryClient(sdk as any);
       const result = await client.registerAgent({
         domain: 'agent.example.com',
         skipSend: true,
       });
       expect(result.didRegister).toBe(false);
       expect(result.unsignedTransaction).toBeInstanceOf(Uint8Array);
+      expect(result.unsignedTransaction?.length).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/identity-solana/src/__tests__/init.test.ts
+++ b/packages/identity-solana/src/__tests__/init.test.ts
@@ -10,7 +10,9 @@ import {
 
 describe('mapTrustTierToConfig', () => {
   it('builds TrustConfig with registrations when agentId provided', () => {
-    const cfg = mapTrustTierToConfig(3, BigInt(99), 'devnet', undefined, ['feedback']);
+    const cfg = mapTrustTierToConfig(3, BigInt(99), 'devnet', undefined, [
+      'feedback',
+    ]);
     expect(cfg.registrations).toHaveLength(1);
     expect(cfg.registrations?.[0].agentId).toBe('99');
     expect(cfg.registrations?.[0].agentRegistry).toContain('solana');
@@ -32,7 +34,11 @@ describe('mapTrustTierToConfig', () => {
 
   it('includes feedbackDataUri when provided', () => {
     const cfg = mapTrustTierToConfig(
-      1, 1n, 'devnet', 'https://agent.example.com/feedback', ['feedback']
+      1,
+      1n,
+      'devnet',
+      'https://agent.example.com/feedback',
+      ['feedback']
     );
     expect(cfg.feedbackDataUri).toBe('https://agent.example.com/feedback');
   });

--- a/packages/identity-solana/src/__tests__/init.test.ts
+++ b/packages/identity-solana/src/__tests__/init.test.ts
@@ -10,7 +10,7 @@ import {
 
 describe('mapTrustTierToConfig', () => {
   it('builds TrustConfig with registrations when agentId provided', () => {
-    const cfg = mapTrustTierToConfig(3, BigInt(99), 'devnet', undefined, [
+    const cfg = mapTrustTierToConfig(BigInt(99), 'devnet', undefined, [
       'feedback',
     ]);
     expect(cfg.registrations).toHaveLength(1);
@@ -19,12 +19,12 @@ describe('mapTrustTierToConfig', () => {
   });
 
   it('builds TrustConfig with empty registrations when no agentId', () => {
-    const cfg = mapTrustTierToConfig(undefined, undefined, 'devnet');
+    const cfg = mapTrustTierToConfig(undefined, 'devnet');
     expect(cfg.registrations).toHaveLength(0);
   });
 
   it('includes trustModels', () => {
-    const cfg = mapTrustTierToConfig(1, 1n, 'mainnet-beta', undefined, [
+    const cfg = mapTrustTierToConfig(1n, 'mainnet-beta', undefined, [
       'feedback',
       'inference-validation',
     ]);
@@ -34,7 +34,6 @@ describe('mapTrustTierToConfig', () => {
 
   it('includes feedbackDataUri when provided', () => {
     const cfg = mapTrustTierToConfig(
-      1,
       1n,
       'devnet',
       'https://agent.example.com/feedback',
@@ -104,5 +103,37 @@ describe('createSolanaAgentIdentity', () => {
       env: { AGENT_DOMAIN: 'agent.example.com' },
     });
     expect(result.domain).toBe('agent.example.com');
+  });
+});
+
+// ── options.trust short-circuit ───────────────────────────────────────────────
+
+describe('createSolanaAgentIdentity: options.trust short-circuit', () => {
+  it('returns pre-resolved TrustConfig without touching the chain', async () => {
+    const trust = { trustModels: ['feedback'] as string[], registrations: [] };
+    const result = await createSolanaAgentIdentity({
+      trust,
+      cluster: 'devnet',
+      env: {},
+    });
+    expect(result.trust).toBe(trust);
+    expect(result.status).toContain('Pre-resolved');
+    // Should not have registry clients (skipped chain interaction)
+    expect(result.clients).toBeUndefined();
+  });
+});
+
+// ── domain fail-fast ──────────────────────────────────────────────────────────
+
+describe('createSolanaAgentIdentity: domain fail-fast', () => {
+  it('throws when autoRegister=true, privateKey provided, but domain missing', async () => {
+    await expect(
+      createSolanaAgentIdentity({
+        privateKey: new Uint8Array(64),
+        autoRegister: true,
+        cluster: 'devnet',
+        env: {},
+      })
+    ).rejects.toThrow('Missing required domain for auto-registration');
   });
 });

--- a/packages/identity-solana/src/__tests__/init.test.ts
+++ b/packages/identity-solana/src/__tests__/init.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  createSolanaAgentIdentity,
+  getSolanaTrustConfig,
+  mapTrustTierToConfig,
+} from '../init';
+
+// ── mapTrustTierToConfig ─────────────────────────────────────────────────────
+
+describe('mapTrustTierToConfig', () => {
+  it('builds TrustConfig with registrations when agentId provided', () => {
+    const cfg = mapTrustTierToConfig(3, BigInt(99), 'devnet', undefined, ['feedback']);
+    expect(cfg.registrations).toHaveLength(1);
+    expect(cfg.registrations?.[0].agentId).toBe('99');
+    expect(cfg.registrations?.[0].agentRegistry).toContain('solana');
+  });
+
+  it('builds TrustConfig with empty registrations when no agentId', () => {
+    const cfg = mapTrustTierToConfig(undefined, undefined, 'devnet');
+    expect(cfg.registrations).toHaveLength(0);
+  });
+
+  it('includes trustModels', () => {
+    const cfg = mapTrustTierToConfig(1, 1n, 'mainnet-beta', undefined, [
+      'feedback',
+      'inference-validation',
+    ]);
+    expect(cfg.trustModels).toContain('feedback');
+    expect(cfg.trustModels).toContain('inference-validation');
+  });
+
+  it('includes feedbackDataUri when provided', () => {
+    const cfg = mapTrustTierToConfig(
+      1, 1n, 'devnet', 'https://agent.example.com/feedback', ['feedback']
+    );
+    expect(cfg.feedbackDataUri).toBe('https://agent.example.com/feedback');
+  });
+});
+
+// ── getSolanaTrustConfig ──────────────────────────────────────────────────────
+
+describe('getSolanaTrustConfig', () => {
+  it('returns trust from identity result', () => {
+    const trust = { trustModels: ['feedback'] as string[] };
+    const identity = { status: 'ok', trust };
+    expect(getSolanaTrustConfig(identity)).toBe(trust);
+  });
+
+  it('returns undefined when no trust', () => {
+    expect(getSolanaTrustConfig({ status: 'no trust' })).toBeUndefined();
+  });
+});
+
+// ── createSolanaAgentIdentity (mocked SDK) ────────────────────────────────────
+
+describe('createSolanaAgentIdentity', () => {
+  it('returns no-identity status when no private key and autoRegister=false', async () => {
+    const result = await createSolanaAgentIdentity({
+      autoRegister: false,
+      cluster: 'devnet',
+      env: {},
+    });
+    expect(result.status).toContain('No 8004-Solana identity');
+    expect(result.trust).toBeUndefined();
+  });
+
+  it('returns no-identity status when no private key (default autoRegister=true)', async () => {
+    const result = await createSolanaAgentIdentity({
+      cluster: 'devnet',
+      env: {},
+    });
+    expect(result.status).toContain('No 8004-Solana identity');
+  });
+
+  it('includes clients in result', async () => {
+    const result = await createSolanaAgentIdentity({
+      autoRegister: false,
+      cluster: 'devnet',
+      env: {},
+    });
+    expect(result.clients).toBeDefined();
+    expect(result.clients?.identity).toBeDefined();
+    expect(result.clients?.reputation).toBeDefined();
+  });
+
+  it('respects cluster from env', async () => {
+    const result = await createSolanaAgentIdentity({
+      autoRegister: false,
+      env: { SOLANA_CLUSTER: 'testnet' },
+    });
+    expect(result.status).toBeDefined();
+  });
+
+  it('respects domain from env', async () => {
+    const result = await createSolanaAgentIdentity({
+      autoRegister: false,
+      env: { AGENT_DOMAIN: 'agent.example.com' },
+    });
+    expect(result.domain).toBe('agent.example.com');
+  });
+});

--- a/packages/identity-solana/src/__tests__/manifest.test.ts
+++ b/packages/identity-solana/src/__tests__/manifest.test.ts
@@ -1,14 +1,15 @@
 import type { TrustConfig } from '@lucid-agents/types/identity';
-import { describe, expect,it } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 
 import { createAgentCardWithSolanaIdentity } from '../manifest';
 
-const makeCard = () => ({
-  name: 'test-agent',
-  version: '1.0.0',
-  entrypoints: [],
-  capabilities: {},
-} as any);
+const makeCard = () =>
+  ({
+    name: 'test-agent',
+    version: '1.0.0',
+    entrypoints: [],
+    capabilities: {},
+  }) as any;
 
 describe('createAgentCardWithSolanaIdentity', () => {
   it('returns a new card object (immutable)', () => {
@@ -20,7 +21,9 @@ describe('createAgentCardWithSolanaIdentity', () => {
 
   it('adds trustModels to card', () => {
     const card = makeCard();
-    const trust: TrustConfig = { trustModels: ['feedback', 'inference-validation'] };
+    const trust: TrustConfig = {
+      trustModels: ['feedback', 'inference-validation'],
+    };
     const result = createAgentCardWithSolanaIdentity(card, trust);
     expect(result.trustModels).toEqual(['feedback', 'inference-validation']);
   });

--- a/packages/identity-solana/src/__tests__/manifest.test.ts
+++ b/packages/identity-solana/src/__tests__/manifest.test.ts
@@ -1,0 +1,68 @@
+import type { TrustConfig } from '@lucid-agents/types/identity';
+import { describe, expect,it } from 'bun:test';
+
+import { createAgentCardWithSolanaIdentity } from '../manifest';
+
+const makeCard = () => ({
+  name: 'test-agent',
+  version: '1.0.0',
+  entrypoints: [],
+  capabilities: {},
+} as any);
+
+describe('createAgentCardWithSolanaIdentity', () => {
+  it('returns a new card object (immutable)', () => {
+    const card = makeCard();
+    const trust: TrustConfig = { trustModels: ['feedback'] };
+    const result = createAgentCardWithSolanaIdentity(card, trust);
+    expect(result).not.toBe(card);
+  });
+
+  it('adds trustModels to card', () => {
+    const card = makeCard();
+    const trust: TrustConfig = { trustModels: ['feedback', 'inference-validation'] };
+    const result = createAgentCardWithSolanaIdentity(card, trust);
+    expect(result.trustModels).toEqual(['feedback', 'inference-validation']);
+  });
+
+  it('deduplicates trustModels', () => {
+    const card = makeCard();
+    const trust: TrustConfig = { trustModels: ['feedback', 'feedback'] };
+    const result = createAgentCardWithSolanaIdentity(card, trust);
+    expect(result.trustModels?.length).toBe(1);
+  });
+
+  it('adds registrations to card', () => {
+    const card = makeCard();
+    const trust: TrustConfig = {
+      registrations: [
+        { agentId: '123', agentRegistry: 'solana:devnet:8004-solana' },
+      ],
+    };
+    const result = createAgentCardWithSolanaIdentity(card, trust);
+    expect(result.registrations?.length).toBe(1);
+    expect(result.registrations?.[0].agentId).toBe('123');
+  });
+
+  it('adds FeedbackDataURI when provided', () => {
+    const card = makeCard();
+    const trust: TrustConfig = {
+      feedbackDataUri: 'https://agent.example.com/feedback',
+    };
+    const result = createAgentCardWithSolanaIdentity(card, trust);
+    expect(result.FeedbackDataURI).toBe('https://agent.example.com/feedback');
+  });
+
+  it('preserves existing card fields', () => {
+    const card = { ...makeCard(), customField: 'preserved' } as any;
+    const result = createAgentCardWithSolanaIdentity(card, {});
+    expect((result as any).customField).toBe('preserved');
+  });
+
+  it('does not mutate the original card', () => {
+    const card = makeCard();
+    const trust: TrustConfig = { trustModels: ['feedback'] };
+    createAgentCardWithSolanaIdentity(card, trust);
+    expect(card.trustModels).toBeUndefined();
+  });
+});

--- a/packages/identity-solana/src/__tests__/reputation-registry.test.ts
+++ b/packages/identity-solana/src/__tests__/reputation-registry.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+import { createSolanaReputationRegistryClient } from '../registries/reputation';
+
+function makeMockSdk(overrides: Record<string, unknown> = {}) {
+  return {
+    getReputationSummary: mock(async () => ({ score: 85, feedbackCount: 12 })),
+    getTrustTier: mock(async () => 3), // Gold
+    giveFeedback: mock(async () => ({ signature: 'feedsig123' })),
+    revokeFeedback: mock(async () => ({ signature: 'revokesig456' })),
+    ...overrides,
+  } as any;
+}
+
+describe('createSolanaReputationRegistryClient', () => {
+  describe('getSummary', () => {
+    it('returns summary with score and tier', async () => {
+      const sdk = makeMockSdk();
+      const client = createSolanaReputationRegistryClient(sdk);
+      const result = await client.getSummary(1n);
+      expect(result?.score).toBe(85);
+      expect(result?.feedbackCount).toBe(12);
+      expect(result?.tier).toBe('3'); // Gold tier value
+    });
+
+    it('returns null when no summary found', async () => {
+      const sdk = makeMockSdk({
+        getReputationSummary: mock(async () => null),
+      });
+      const client = createSolanaReputationRegistryClient(sdk);
+      const result = await client.getSummary(999n);
+      expect(result).toBeNull();
+    });
+
+    it('returns null on SDK error', async () => {
+      const sdk = makeMockSdk({
+        getReputationSummary: mock(async () => { throw new Error('not found'); }),
+      });
+      const client = createSolanaReputationRegistryClient(sdk);
+      const result = await client.getSummary(1n);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('giveFeedback', () => {
+    it('calls sdk.giveFeedback and returns signature', async () => {
+      const sdk = makeMockSdk();
+      const client = createSolanaReputationRegistryClient(sdk);
+      const result = await client.giveFeedback({
+        toAgentId: 42n,
+        value: 90,
+        tag1: 'reliable',
+        tag2: 'fast',
+        endpoint: 'https://agent.example.com',
+      });
+      expect(result.signature).toBe('feedsig123');
+      expect(sdk.giveFeedback).toHaveBeenCalled();
+    });
+
+    it('handles feedback with defaults', async () => {
+      const sdk = makeMockSdk();
+      const client = createSolanaReputationRegistryClient(sdk);
+      await expect(
+        client.giveFeedback({ toAgentId: 1n, value: 70 })
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('revokeFeedback', () => {
+    it('calls sdk.revokeFeedback and returns signature', async () => {
+      const sdk = makeMockSdk();
+      const client = createSolanaReputationRegistryClient(sdk);
+      const result = await client.revokeFeedback('feedback-id-123');
+      expect(result.signature).toBe('revokesig456');
+      expect(sdk.revokeFeedback).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/identity-solana/src/__tests__/reputation-registry.test.ts
+++ b/packages/identity-solana/src/__tests__/reputation-registry.test.ts
@@ -38,15 +38,16 @@ describe('createSolanaReputationRegistryClient', () => {
       expect(result).toBeNull();
     });
 
-    it('returns null on SDK error', async () => {
+    it('rethrows SDK errors so callers distinguish outages from missing data', async () => {
       const sdk = makeMockSdk({
         getAgentReputationFromIndexer: mock(async () => {
           throw new Error('network error');
         }),
       });
       const client = createSolanaReputationRegistryClient(sdk);
-      const result = await client.getSummary(ASSET_ADDR);
-      expect(result).toBeNull();
+      await expect(client.getSummary(ASSET_ADDR)).rejects.toThrow(
+        'getSummary: failed to fetch reputation'
+      );
     });
 
     it('handles null avg_score gracefully', async () => {

--- a/packages/identity-solana/src/__tests__/reputation-registry.test.ts
+++ b/packages/identity-solana/src/__tests__/reputation-registry.test.ts
@@ -125,3 +125,31 @@ describe('createSolanaReputationRegistryClient', () => {
     });
   });
 });
+
+describe('giveFeedback (input validation)', () => {
+  it('throws for score > 100', async () => {
+    const sdk = makeMockSdk();
+    const client = createSolanaReputationRegistryClient(sdk);
+    await expect(
+      client.giveFeedback({ targetAddress: ASSET_ADDR, score: 101 })
+    ).rejects.toThrow('invalid score 101');
+  });
+
+  it('throws for negative score', async () => {
+    const sdk = makeMockSdk();
+    const client = createSolanaReputationRegistryClient(sdk);
+    await expect(
+      client.giveFeedback({ targetAddress: ASSET_ADDR, score: -1 })
+    ).rejects.toThrow('invalid score -1');
+  });
+});
+
+describe('revokeFeedback (input validation)', () => {
+  it('throws for negative feedbackIndex', async () => {
+    const sdk = makeMockSdk();
+    const client = createSolanaReputationRegistryClient(sdk);
+    await expect(
+      client.revokeFeedback({ assetAddress: ASSET_ADDR, feedbackIndex: -1 })
+    ).rejects.toThrow('invalid feedbackIndex');
+  });
+});

--- a/packages/identity-solana/src/__tests__/reputation-registry.test.ts
+++ b/packages/identity-solana/src/__tests__/reputation-registry.test.ts
@@ -4,41 +4,63 @@ import { createSolanaReputationRegistryClient } from '../registries/reputation';
 
 function makeMockSdk(overrides: Record<string, unknown> = {}) {
   return {
-    getReputationSummary: mock(async () => ({ score: 85, feedbackCount: 12 })),
-    getTrustTier: mock(async () => 3), // Gold
+    getAgentReputationFromIndexer: mock(async () => ({
+      avg_score: 85,
+      trust_tier: 3,
+      feedback_count: 12,
+    })),
     giveFeedback: mock(async () => ({ signature: 'feedsig123' })),
     revokeFeedback: mock(async () => ({ signature: 'revokesig456' })),
     ...overrides,
   } as any;
 }
 
+const ASSET_ADDR = 'AgentAsset11111111111111111111111111111111';
+
 describe('createSolanaReputationRegistryClient', () => {
   describe('getSummary', () => {
     it('returns summary with score and tier', async () => {
       const sdk = makeMockSdk();
       const client = createSolanaReputationRegistryClient(sdk);
-      const result = await client.getSummary(1n);
+      const result = await client.getSummary(ASSET_ADDR);
       expect(result?.score).toBe(85);
       expect(result?.feedbackCount).toBe(12);
-      expect(result?.tier).toBe('3'); // Gold tier value
+      expect(result?.tier).toBe('3'); // Gold tier index
+      expect(result?.assetAddress).toBe(ASSET_ADDR);
     });
 
-    it('returns null when no summary found', async () => {
+    it('returns null when indexer returns null', async () => {
       const sdk = makeMockSdk({
-        getReputationSummary: mock(async () => null),
+        getAgentReputationFromIndexer: mock(async () => null),
       });
       const client = createSolanaReputationRegistryClient(sdk);
-      const result = await client.getSummary(999n);
+      const result = await client.getSummary(ASSET_ADDR);
       expect(result).toBeNull();
     });
 
     it('returns null on SDK error', async () => {
       const sdk = makeMockSdk({
-        getReputationSummary: mock(async () => { throw new Error('not found'); }),
+        getAgentReputationFromIndexer: mock(async () => {
+          throw new Error('network error');
+        }),
       });
       const client = createSolanaReputationRegistryClient(sdk);
-      const result = await client.getSummary(1n);
+      const result = await client.getSummary(ASSET_ADDR);
       expect(result).toBeNull();
+    });
+
+    it('handles null avg_score gracefully', async () => {
+      const sdk = makeMockSdk({
+        getAgentReputationFromIndexer: mock(async () => ({
+          avg_score: null,
+          trust_tier: 0,
+          feedback_count: 0,
+        })),
+      });
+      const client = createSolanaReputationRegistryClient(sdk);
+      const result = await client.getSummary(ASSET_ADDR);
+      expect(result?.score).toBeNull();
+      expect(result?.feedbackCount).toBe(0);
     });
   });
 
@@ -47,22 +69,35 @@ describe('createSolanaReputationRegistryClient', () => {
       const sdk = makeMockSdk();
       const client = createSolanaReputationRegistryClient(sdk);
       const result = await client.giveFeedback({
-        toAgentId: 42n,
-        value: 90,
+        targetAddress: ASSET_ADDR,
+        score: 90,
         tag1: 'reliable',
         tag2: 'fast',
-        endpoint: 'https://agent.example.com',
+        comment: 'Completed task successfully',
       });
       expect(result.signature).toBe('feedsig123');
-      expect(sdk.giveFeedback).toHaveBeenCalled();
+      expect(sdk.giveFeedback).toHaveBeenCalledWith(
+        ASSET_ADDR,
+        expect.objectContaining({ value: 90 })
+      );
     });
 
-    it('handles feedback with defaults', async () => {
+    it('handles feedback with minimal options', async () => {
       const sdk = makeMockSdk();
       const client = createSolanaReputationRegistryClient(sdk);
-      await expect(
-        client.giveFeedback({ toAgentId: 1n, value: 70 })
-      ).resolves.toBeDefined();
+      const result = await client.giveFeedback({
+        targetAddress: ASSET_ADDR,
+        score: 70,
+      });
+      expect(result.signature).toBe('feedsig123');
+    });
+
+    it('omits metricUri when comment is absent', async () => {
+      const sdk = makeMockSdk();
+      const client = createSolanaReputationRegistryClient(sdk);
+      await client.giveFeedback({ targetAddress: ASSET_ADDR, score: 50 });
+      const call = (sdk.giveFeedback as ReturnType<typeof mock>).mock.calls[0];
+      expect(call[1]).not.toHaveProperty('metricUri');
     });
   });
 
@@ -70,9 +105,22 @@ describe('createSolanaReputationRegistryClient', () => {
     it('calls sdk.revokeFeedback and returns signature', async () => {
       const sdk = makeMockSdk();
       const client = createSolanaReputationRegistryClient(sdk);
-      const result = await client.revokeFeedback('feedback-id-123');
+      const result = await client.revokeFeedback({
+        assetAddress: ASSET_ADDR,
+        feedbackIndex: 0,
+      });
       expect(result.signature).toBe('revokesig456');
-      expect(sdk.revokeFeedback).toHaveBeenCalled();
+      expect(sdk.revokeFeedback).toHaveBeenCalledWith(ASSET_ADDR, 0);
+    });
+
+    it('supports bigint feedback index', async () => {
+      const sdk = makeMockSdk();
+      const client = createSolanaReputationRegistryClient(sdk);
+      const result = await client.revokeFeedback({
+        assetAddress: ASSET_ADDR,
+        feedbackIndex: 3n,
+      });
+      expect(result.signature).toBe('revokesig456');
     });
   });
 });

--- a/packages/identity-solana/src/__tests__/validation.test.ts
+++ b/packages/identity-solana/src/__tests__/validation.test.ts
@@ -5,6 +5,7 @@ import {
   parseBoolean,
   parseSolanaPrivateKey,
   resolveAutoRegister,
+  validateSolanaIdentityConfig,
 } from '../validation';
 
 describe('parseBoolean', () => {
@@ -76,5 +77,72 @@ describe('hasRegistrationCapability', () => {
 
   it('returns false when no privateKey', () => {
     expect(hasRegistrationCapability({})).toBe(false);
+  });
+});
+
+describe('parseSolanaPrivateKey (element range validation)', () => {
+  it('rejects arrays with values > 255', () => {
+    const bad = JSON.stringify([0, 256, 1]);
+    expect(parseSolanaPrivateKey(bad)).toBeNull();
+  });
+
+  it('rejects arrays with negative values', () => {
+    const bad = JSON.stringify([0, -1, 128]);
+    expect(parseSolanaPrivateKey(bad)).toBeNull();
+  });
+
+  it('rejects arrays with non-integer values', () => {
+    const bad = JSON.stringify([0, 1.5, 128]);
+    expect(parseSolanaPrivateKey(bad)).toBeNull();
+  });
+
+  it('accepts a valid 64-byte key array', () => {
+    const valid = JSON.stringify(Array.from({ length: 64 }, (_, i) => i % 256));
+    const result = parseSolanaPrivateKey(valid);
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result?.length).toBe(64);
+  });
+});
+
+describe('resolveAutoRegister (presence not truthiness)', () => {
+  it('honours REGISTER_IDENTITY=false in env even when value is falsy string', () => {
+    expect(resolveAutoRegister({}, { REGISTER_IDENTITY: 'false' })).toBe(false);
+  });
+
+  it('honours empty string REGISTER_IDENTITY as false', () => {
+    // Empty string is falsy but present — parseBoolean("", default=true) → true
+    // because empty string returns defaultValue; presence check ensures we read it.
+    expect(resolveAutoRegister({}, { REGISTER_IDENTITY: '' })).toBe(true);
+  });
+});
+
+describe('validateSolanaIdentityConfig', () => {
+  it('throws when domain is provided but no private key', () => {
+    expect(() =>
+      validateSolanaIdentityConfig({ domain: 'agent.example.com' }, {})
+    ).toThrow('SOLANA_PRIVATE_KEY is required');
+  });
+
+  it('does not throw when domain and private key both provided', () => {
+    expect(() =>
+      validateSolanaIdentityConfig(
+        { domain: 'agent.example.com', privateKey: new Uint8Array(64) },
+        {}
+      )
+    ).not.toThrow();
+  });
+
+  it('does not throw when domain absent and no private key', () => {
+    expect(() => validateSolanaIdentityConfig({}, {})).not.toThrow();
+  });
+
+  it('does not throw when private key in env', () => {
+    const validKey = JSON.stringify(Array.from({ length: 64 }, () => 1));
+    expect(() =>
+      validateSolanaIdentityConfig(
+        { domain: 'agent.example.com' },
+        { SOLANA_PRIVATE_KEY: validKey }
+      )
+    ).not.toThrow();
   });
 });

--- a/packages/identity-solana/src/__tests__/validation.test.ts
+++ b/packages/identity-solana/src/__tests__/validation.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect,it } from 'bun:test';
+
+import {
+  hasRegistrationCapability,
+  parseBoolean,
+  parseSolanaPrivateKey,
+  resolveAutoRegister,
+} from '../validation';
+
+describe('parseBoolean', () => {
+  it('returns true for "true"', () => {
+    expect(parseBoolean('true')).toBe(true);
+  });
+
+  it('returns true for "1"', () => {
+    expect(parseBoolean('1')).toBe(true);
+  });
+
+  it('returns false for "false"', () => {
+    expect(parseBoolean('false')).toBe(false);
+  });
+
+  it('returns default when undefined', () => {
+    expect(parseBoolean(undefined, true)).toBe(true);
+    expect(parseBoolean(undefined, false)).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(parseBoolean('')).toBe(false);
+  });
+});
+
+describe('parseSolanaPrivateKey', () => {
+  it('parses valid JSON array', () => {
+    const arr = Array.from({ length: 64 }, (_, i) => i);
+    const result = parseSolanaPrivateKey(JSON.stringify(arr));
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result?.length).toBe(64);
+  });
+
+  it('returns null for undefined', () => {
+    expect(parseSolanaPrivateKey(undefined)).toBeNull();
+  });
+
+  it('returns null for invalid JSON', () => {
+    expect(parseSolanaPrivateKey('not-json')).toBeNull();
+  });
+
+  it('returns null for non-array JSON', () => {
+    expect(parseSolanaPrivateKey('{"key": "val"}')).toBeNull();
+  });
+});
+
+describe('resolveAutoRegister', () => {
+  it('uses options.autoRegister when set', () => {
+    expect(resolveAutoRegister({ autoRegister: false })).toBe(false);
+    expect(resolveAutoRegister({ autoRegister: true })).toBe(true);
+  });
+
+  it('uses env REGISTER_IDENTITY when options not set', () => {
+    expect(resolveAutoRegister({}, { REGISTER_IDENTITY: 'false' })).toBe(false);
+    expect(resolveAutoRegister({}, { REGISTER_IDENTITY: 'true' })).toBe(true);
+  });
+
+  it('defaults to true when nothing set', () => {
+    expect(resolveAutoRegister({})).toBe(true);
+  });
+});
+
+describe('hasRegistrationCapability', () => {
+  it('returns true when privateKey is present', () => {
+    expect(
+      hasRegistrationCapability({ privateKey: new Uint8Array(64) })
+    ).toBe(true);
+  });
+
+  it('returns false when no privateKey', () => {
+    expect(hasRegistrationCapability({})).toBe(false);
+  });
+});

--- a/packages/identity-solana/src/__tests__/validation.test.ts
+++ b/packages/identity-solana/src/__tests__/validation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect,it } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 
 import {
   hasRegistrationCapability,
@@ -69,9 +69,9 @@ describe('resolveAutoRegister', () => {
 
 describe('hasRegistrationCapability', () => {
   it('returns true when privateKey is present', () => {
-    expect(
-      hasRegistrationCapability({ privateKey: new Uint8Array(64) })
-    ).toBe(true);
+    expect(hasRegistrationCapability({ privateKey: new Uint8Array(64) })).toBe(
+      true
+    );
   });
 
   it('returns false when no privateKey', () => {

--- a/packages/identity-solana/src/__tests__/validation.test.ts
+++ b/packages/identity-solana/src/__tests__/validation.test.ts
@@ -81,20 +81,19 @@ describe('hasRegistrationCapability', () => {
 });
 
 describe('parseSolanaPrivateKey (element range validation)', () => {
-  it('rejects arrays with values > 255', () => {
-    const bad = JSON.stringify([0, 256, 1]);
-    expect(parseSolanaPrivateKey(bad)).toBeNull();
-  });
+  const invalidCases: [string, unknown[]][] = [
+    ['value > 255', [0, 256, 1]],
+    ['negative value', [0, -1, 128]],
+    ['non-integer (float)', [0, 1.5, 128]],
+    ['non-numeric (string element)', [0, 'x', 128]],
+    ['Infinity', [0, Infinity, 1]],
+  ];
 
-  it('rejects arrays with negative values', () => {
-    const bad = JSON.stringify([0, -1, 128]);
-    expect(parseSolanaPrivateKey(bad)).toBeNull();
-  });
-
-  it('rejects arrays with non-integer values', () => {
-    const bad = JSON.stringify([0, 1.5, 128]);
-    expect(parseSolanaPrivateKey(bad)).toBeNull();
-  });
+  for (const [desc, arr] of invalidCases) {
+    it(`rejects array with ${desc}`, () => {
+      expect(parseSolanaPrivateKey(JSON.stringify(arr))).toBeNull();
+    });
+  }
 
   it('accepts a valid 64-byte key array', () => {
     const valid = JSON.stringify(Array.from({ length: 64 }, (_, i) => i % 256));
@@ -109,9 +108,9 @@ describe('resolveAutoRegister (presence not truthiness)', () => {
     expect(resolveAutoRegister({}, { REGISTER_IDENTITY: 'false' })).toBe(false);
   });
 
-  it('honours empty string REGISTER_IDENTITY as false', () => {
-    // Empty string is falsy but present — parseBoolean("", default=true) → true
-    // because empty string returns defaultValue; presence check ensures we read it.
+  it('treats empty string REGISTER_IDENTITY as true (parseBoolean falls back to default)', () => {
+    // Empty string is present in env (presence check passes) but parseBoolean("", default=true)
+    // returns the default value of true because empty string is treated as unset by parseBoolean.
     expect(resolveAutoRegister({}, { REGISTER_IDENTITY: '' })).toBe(true);
   });
 });

--- a/packages/identity-solana/src/__tests__/validation.test.ts
+++ b/packages/identity-solana/src/__tests__/validation.test.ts
@@ -89,11 +89,9 @@ describe('parseSolanaPrivateKey (element range validation)', () => {
     ['Infinity', [0, Infinity, 1]],
   ];
 
-  for (const [desc, arr] of invalidCases) {
-    it(`rejects array with ${desc}`, () => {
-      expect(parseSolanaPrivateKey(JSON.stringify(arr))).toBeNull();
-    });
-  }
+  it.each(invalidCases)('rejects array with %s', (_desc, arr) => {
+    expect(parseSolanaPrivateKey(JSON.stringify(arr))).toBeNull();
+  });
 
   it('accepts a valid 64-byte key array', () => {
     const valid = JSON.stringify(Array.from({ length: 64 }, (_, i) => i % 256));

--- a/packages/identity-solana/src/config.ts
+++ b/packages/identity-solana/src/config.ts
@@ -1,0 +1,37 @@
+/**
+ * Solana cluster and RPC configuration for 8004-Solana identity.
+ */
+
+export type SolanaCluster = 'mainnet-beta' | 'devnet' | 'testnet' | 'localnet';
+
+export const CLUSTER_RPC_URLS: Record<SolanaCluster, string> = {
+  'mainnet-beta': 'https://api.mainnet-beta.solana.com',
+  devnet: 'https://api.devnet.solana.com',
+  testnet: 'https://api.testnet.solana.com',
+  localnet: 'http://127.0.0.1:8899',
+};
+
+export const SOLANA_REGISTRATION_TYPE_V1 =
+  'https://8004-solana.io/registry#registration-v1' as const;
+
+/**
+ * Resolve RPC URL from cluster name or explicit override.
+ */
+export function resolveRpcUrl(
+  cluster: SolanaCluster = 'mainnet-beta',
+  rpcUrlOverride?: string
+): string {
+  if (rpcUrlOverride) return rpcUrlOverride;
+  return CLUSTER_RPC_URLS[cluster] ?? CLUSTER_RPC_URLS['mainnet-beta'];
+}
+
+/**
+ * Parse cluster from string, defaulting to mainnet-beta.
+ */
+export function parseCluster(raw: string | undefined): SolanaCluster {
+  const valid: SolanaCluster[] = ['mainnet-beta', 'devnet', 'testnet', 'localnet'];
+  if (raw && valid.includes(raw as SolanaCluster)) {
+    return raw as SolanaCluster;
+  }
+  return 'mainnet-beta';
+}

--- a/packages/identity-solana/src/config.ts
+++ b/packages/identity-solana/src/config.ts
@@ -26,12 +26,23 @@ export function resolveRpcUrl(
 }
 
 /**
- * Parse cluster from string, defaulting to mainnet-beta.
+ * Parse cluster from string, defaulting to mainnet-beta when unset.
+ * Throws a descriptive error when a value is provided but not a valid SolanaCluster.
  */
 export function parseCluster(raw: string | undefined): SolanaCluster {
-  const valid: SolanaCluster[] = ['mainnet-beta', 'devnet', 'testnet', 'localnet'];
-  if (raw && valid.includes(raw as SolanaCluster)) {
+  const valid: SolanaCluster[] = [
+    'mainnet-beta',
+    'devnet',
+    'testnet',
+    'localnet',
+  ];
+  if (raw === undefined) {
+    return 'mainnet-beta';
+  }
+  if (valid.includes(raw as SolanaCluster)) {
     return raw as SolanaCluster;
   }
-  return 'mainnet-beta';
+  throw new Error(
+    `parseCluster: invalid SOLANA_CLUSTER value "${raw}". Allowed values: ${valid.join(', ')}.`
+  );
 }

--- a/packages/identity-solana/src/env.ts
+++ b/packages/identity-solana/src/env.ts
@@ -6,7 +6,12 @@
 import type { CreateSolanaAgentIdentityOptions } from './init';
 import { parseBoolean, parseSolanaPrivateKey } from './validation';
 
-export type SolanaIdentityConfig = CreateSolanaAgentIdentityOptions;
+export type SolanaIdentityConfig = CreateSolanaAgentIdentityOptions & {
+  /** Pinata JWT for IPFS metadata upload (optional). */
+  _pinataJwt?: string;
+  /** Whether ATOM protocol support is enabled (optional). */
+  _atomEnabled?: boolean;
+};
 
 /**
  * Build a SolanaIdentityConfig from environment variables.
@@ -25,17 +30,35 @@ export function identitySolanaFromEnv(
     ? process.env
     : {}
 ): SolanaIdentityConfig {
-  const privateKey = parseSolanaPrivateKey(env.SOLANA_PRIVATE_KEY);
+  let privateKey: Uint8Array | undefined;
+  if (env.SOLANA_PRIVATE_KEY !== undefined && env.SOLANA_PRIVATE_KEY !== '') {
+    try {
+      privateKey = parseSolanaPrivateKey(env.SOLANA_PRIVATE_KEY);
+      if (!privateKey) {
+        throw new Error(
+          'parseSolanaPrivateKey returned undefined for a non-empty value'
+        );
+      }
+    } catch (err) {
+      throw new Error(
+        `env.ts: SOLANA_PRIVATE_KEY is set but could not be parsed. ` +
+          `Ensure it is a JSON array of numbers (e.g. [1,2,...,64]). ` +
+          `Original error: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
   const cluster = env.SOLANA_CLUSTER;
   const rpcUrl = env.SOLANA_RPC_URL;
   const domain = env.AGENT_DOMAIN;
-  const autoRegister = env.REGISTER_IDENTITY !== undefined
-    ? parseBoolean(env.REGISTER_IDENTITY, true)
-    : undefined;
+  const autoRegister =
+    env.REGISTER_IDENTITY !== undefined
+      ? parseBoolean(env.REGISTER_IDENTITY, true)
+      : undefined;
   const pinataJwt = env.PINATA_JWT;
-  const atomEnabled = env.ATOM_ENABLED !== undefined
-    ? parseBoolean(env.ATOM_ENABLED, false)
-    : undefined;
+  const atomEnabled =
+    env.ATOM_ENABLED !== undefined
+      ? parseBoolean(env.ATOM_ENABLED, false)
+      : undefined;
 
   const config: SolanaIdentityConfig = {
     env,
@@ -44,11 +67,9 @@ export function identitySolanaFromEnv(
     ...(rpcUrl ? { rpcUrl } : {}),
     ...(domain ? { domain } : {}),
     ...(autoRegister !== undefined ? { autoRegister } : {}),
+    _pinataJwt: pinataJwt,
+    _atomEnabled: atomEnabled,
   };
-
-  // Attach extra fields for downstream use (PINATA_JWT, ATOM_ENABLED)
-  (config as any)._pinataJwt = pinataJwt;
-  (config as any)._atomEnabled = atomEnabled;
 
   return config;
 }

--- a/packages/identity-solana/src/env.ts
+++ b/packages/identity-solana/src/env.ts
@@ -1,0 +1,54 @@
+/**
+ * Create SolanaIdentityConfig from environment variables.
+ * Mirrors identityFromEnv() from @lucid-agents/identity.
+ */
+
+import type { CreateSolanaAgentIdentityOptions } from './init';
+import { parseBoolean, parseSolanaPrivateKey } from './validation';
+
+export type SolanaIdentityConfig = CreateSolanaAgentIdentityOptions;
+
+/**
+ * Build a SolanaIdentityConfig from environment variables.
+ *
+ * @example
+ * ```ts
+ * import { identitySolana, identitySolanaFromEnv } from '@lucid-agents/identity-solana';
+ *
+ * const agent = await createAgent({ name: 'my-agent', version: '1.0.0' })
+ *   .use(identitySolana({ config: identitySolanaFromEnv() }))
+ *   .build();
+ * ```
+ */
+export function identitySolanaFromEnv(
+  env: Record<string, string | undefined> = typeof process !== 'undefined'
+    ? process.env
+    : {}
+): SolanaIdentityConfig {
+  const privateKey = parseSolanaPrivateKey(env.SOLANA_PRIVATE_KEY);
+  const cluster = env.SOLANA_CLUSTER;
+  const rpcUrl = env.SOLANA_RPC_URL;
+  const domain = env.AGENT_DOMAIN;
+  const autoRegister = env.REGISTER_IDENTITY !== undefined
+    ? parseBoolean(env.REGISTER_IDENTITY, true)
+    : undefined;
+  const pinataJwt = env.PINATA_JWT;
+  const atomEnabled = env.ATOM_ENABLED !== undefined
+    ? parseBoolean(env.ATOM_ENABLED, false)
+    : undefined;
+
+  const config: SolanaIdentityConfig = {
+    env,
+    ...(privateKey ? { privateKey } : {}),
+    ...(cluster ? { cluster } : {}),
+    ...(rpcUrl ? { rpcUrl } : {}),
+    ...(domain ? { domain } : {}),
+    ...(autoRegister !== undefined ? { autoRegister } : {}),
+  };
+
+  // Attach extra fields for downstream use (PINATA_JWT, ATOM_ENABLED)
+  (config as any)._pinataJwt = pinataJwt;
+  (config as any)._atomEnabled = atomEnabled;
+
+  return config;
+}

--- a/packages/identity-solana/src/extension.ts
+++ b/packages/identity-solana/src/extension.ts
@@ -55,7 +55,11 @@ export function identitySolana(options?: {
       if (trustConfig) return;
 
       // If identity config is present, auto-configure
-      if (config?.domain || config?.autoRegister !== undefined || config?.privateKey) {
+      if (
+        config?.domain ||
+        config?.autoRegister !== undefined ||
+        config?.privateKey
+      ) {
         const identityResult = await createSolanaAgentIdentity(config ?? {});
         trustConfig = getSolanaTrustConfig(identityResult);
       }

--- a/packages/identity-solana/src/extension.ts
+++ b/packages/identity-solana/src/extension.ts
@@ -1,0 +1,74 @@
+/**
+ * identitySolana() Extension for Lucid SDK.
+ * Mirrors identity() from @lucid-agents/identity but for Solana.
+ */
+
+import type { AgentCardWithEntrypoints } from '@lucid-agents/types/a2a';
+import type { AgentRuntime, Extension } from '@lucid-agents/types/core';
+import type { TrustConfig } from '@lucid-agents/types/identity';
+
+import type { SolanaIdentityConfig } from './env';
+import type { SolanaAgentRegistrationOptions } from './init';
+import { createSolanaAgentIdentity, getSolanaTrustConfig } from './init';
+import { createAgentCardWithSolanaIdentity } from './manifest';
+
+export type { SolanaIdentityConfig };
+
+/**
+ * identitySolana Extension — add 8004-Solana identity to a Lucid agent.
+ *
+ * @example
+ * ```ts
+ * import { createAgent } from '@lucid-agents/core';
+ * import { identitySolana, identitySolanaFromEnv } from '@lucid-agents/identity-solana';
+ *
+ * const agent = await createAgent({ name: 'my-agent', version: '1.0.0' })
+ *   .use(identitySolana({ config: identitySolanaFromEnv() }))
+ *   .build();
+ * ```
+ */
+export function identitySolana(options?: {
+  config?: SolanaIdentityConfig;
+}): Extension<{
+  trust?: TrustConfig;
+  identity?: { registration?: SolanaAgentRegistrationOptions };
+}> {
+  const config = options?.config;
+  let trustConfig: TrustConfig | undefined = config?.trust;
+
+  return {
+    name: 'identity-solana',
+
+    build(): {
+      trust?: TrustConfig;
+      identity?: { registration?: SolanaAgentRegistrationOptions };
+    } {
+      const registration = config?.registration;
+      return {
+        trust: trustConfig,
+        identity: registration ? { registration } : undefined,
+      };
+    },
+
+    async onBuild(_runtime: AgentRuntime): Promise<void> {
+      // If trust config is already provided, skip automatic setup
+      if (trustConfig) return;
+
+      // If identity config is present, auto-configure
+      if (config?.domain || config?.autoRegister !== undefined || config?.privateKey) {
+        const identityResult = await createSolanaAgentIdentity(config ?? {});
+        trustConfig = getSolanaTrustConfig(identityResult);
+      }
+    },
+
+    onManifestBuild(
+      card: AgentCardWithEntrypoints,
+      _runtime: AgentRuntime
+    ): AgentCardWithEntrypoints {
+      if (trustConfig) {
+        return createAgentCardWithSolanaIdentity(card, trustConfig);
+      }
+      return card;
+    },
+  };
+}

--- a/packages/identity-solana/src/index.ts
+++ b/packages/identity-solana/src/index.ts
@@ -1,0 +1,60 @@
+// Main extension
+export type { SolanaIdentityConfig } from './extension';
+export { identitySolana } from './extension';
+
+// Env helper
+export { identitySolanaFromEnv } from './env';
+
+// Core identity function
+export type {
+  CreateSolanaAgentIdentityOptions,
+  SolanaAgentIdentity,
+  SolanaAgentRegistrationOptions,
+  SolanaRegistryClients,
+} from './init';
+export {
+  createSdk,
+  createSolanaAgentIdentity,
+  getSolanaTrustConfig,
+  mapTrustTierToConfig,
+} from './init';
+
+// Manifest helper
+export { createAgentCardWithSolanaIdentity } from './manifest';
+
+// Registry clients
+export type {
+  RegisterAgentOptions,
+  RegisterAgentResult,
+  SolanaAgentRecord,
+  SolanaIdentityRegistryClient,
+} from './registries/identity';
+export {
+  createSolanaIdentityRegistryClient,
+} from './registries/identity';
+export type {
+  GiveFeedbackOptions,
+  SolanaReputationRegistryClient,
+  SolanaReputationSummary,
+} from './registries/reputation';
+export {
+  createSolanaReputationRegistryClient,
+} from './registries/reputation';
+
+// Config helpers
+export type { SolanaCluster } from './config';
+export {
+  CLUSTER_RPC_URLS,
+  parseCluster,
+  resolveRpcUrl,
+  SOLANA_REGISTRATION_TYPE_V1,
+} from './config';
+
+// Validation helpers
+export {
+  hasRegistrationCapability,
+  parseBoolean,
+  parseSolanaPrivateKey,
+  resolveAutoRegister,
+  validateSolanaIdentityConfig,
+} from './validation';

--- a/packages/identity-solana/src/index.ts
+++ b/packages/identity-solana/src/index.ts
@@ -29,17 +29,13 @@ export type {
   SolanaAgentRecord,
   SolanaIdentityRegistryClient,
 } from './registries/identity';
-export {
-  createSolanaIdentityRegistryClient,
-} from './registries/identity';
+export { createSolanaIdentityRegistryClient } from './registries/identity';
 export type {
   GiveFeedbackOptions,
   SolanaReputationRegistryClient,
   SolanaReputationSummary,
 } from './registries/reputation';
-export {
-  createSolanaReputationRegistryClient,
-} from './registries/reputation';
+export { createSolanaReputationRegistryClient } from './registries/reputation';
 
 // Config helpers
 export type { SolanaCluster } from './config';

--- a/packages/identity-solana/src/init.ts
+++ b/packages/identity-solana/src/init.ts
@@ -4,7 +4,6 @@
  */
 
 import type { TrustConfig } from '@lucid-agents/types/identity';
-// @ts-ignore — 8004-solana is a peer/dependency
 import { SolanaSDK } from '8004-solana';
 
 import { parseCluster, resolveRpcUrl } from './config';
@@ -17,7 +16,7 @@ import {
   createSolanaReputationRegistryClient,
   type SolanaReputationRegistryClient,
 } from './registries/reputation';
-import { resolveAutoRegister } from './validation';
+import { parseSolanaPrivateKey, resolveAutoRegister } from './validation';
 
 export type SolanaRegistryClients = {
   identity: SolanaIdentityRegistryClient;
@@ -36,7 +35,7 @@ export type SolanaAgentRegistrationOptions = {
 export type CreateSolanaAgentIdentityOptions = {
   /** Solana private key as Uint8Array */
   privateKey?: Uint8Array;
-  /** Cluster: mainnet-beta | devnet | testnet (default: mainnet-beta) */
+  /** Cluster: mainnet-beta | devnet | testnet | localnet (default: mainnet-beta) */
   cluster?: string;
   /** Optional RPC URL override */
   rpcUrl?: string;
@@ -48,7 +47,10 @@ export type CreateSolanaAgentIdentityOptions = {
   trustModels?: string[];
   /** Registration metadata */
   registration?: SolanaAgentRegistrationOptions;
-  /** Pre-resolved TrustConfig (bypasses auto-derivation from trustModels) */
+  /**
+   * Pre-resolved TrustConfig. When provided, bypasses auto-derivation from
+   * trustModels and registration state — used directly as the identity trust.
+   */
   trust?: TrustConfig;
   /** Custom env vars (defaults to process.env) */
   env?: Record<string, string | undefined>;
@@ -73,10 +75,11 @@ export type SolanaAgentIdentity = {
 };
 
 /**
- * Map a Solana TrustTier value to a Lucid TrustConfig.
+ * Map a Solana registration result to a Lucid TrustConfig.
+ * The tier value from on-chain reads is intentionally omitted here because
+ * fresh registrations have no tier yet — callers should query it separately.
  */
 export function mapTrustTierToConfig(
-  tier: number | string | undefined,
   agentId: string | bigint | number | null | undefined,
   cluster: string,
   feedbackDataUri?: string,
@@ -120,6 +123,16 @@ export function createSdk(options: {
 }
 
 /**
+ * Resolve the effective TrustConfig for a given set of options.
+ * If options.trust is provided it wins; otherwise derive from trustModels.
+ */
+export function getSolanaTrustConfig(
+  result: SolanaAgentIdentity
+): TrustConfig | undefined {
+  return result.trust;
+}
+
+/**
  * Create Solana agent identity with automatic registration.
  * Mirrors createAgentIdentity() from @lucid-agents/identity.
  */
@@ -127,6 +140,16 @@ export async function createSolanaAgentIdentity(
   options: CreateSolanaAgentIdentityOptions
 ): Promise<SolanaAgentIdentity> {
   const { env, logger, registration: regOpts } = options;
+
+  // Short-circuit: if a pre-resolved TrustConfig is supplied, use it directly
+  // without touching the chain at all.
+  if (options.trust) {
+    return {
+      status: 'Pre-resolved TrustConfig supplied — skipping on-chain lookup',
+      trust: options.trust,
+      domain: options.domain,
+    };
+  }
 
   // Resolve cluster + RPC
   const clusterRaw =
@@ -141,8 +164,8 @@ export async function createSolanaAgentIdentity(
       (typeof process !== 'undefined' ? process.env?.SOLANA_RPC_URL : undefined)
   );
 
-  // Resolve private key
-  const privateKey =
+  // Resolve private key — single source of truth via parseSolanaPrivateKey
+  const privateKey: Uint8Array | undefined =
     options.privateKey ??
     (() => {
       const raw =
@@ -150,12 +173,7 @@ export async function createSolanaAgentIdentity(
         (typeof process !== 'undefined'
           ? process.env?.SOLANA_PRIVATE_KEY
           : undefined);
-      if (!raw) return undefined;
-      try {
-        return new Uint8Array(JSON.parse(raw));
-      } catch {
-        return undefined;
-      }
+      return parseSolanaPrivateKey(raw) ?? undefined;
     })();
 
   // Resolve domain
@@ -181,11 +199,11 @@ export async function createSolanaAgentIdentity(
   let existing: SolanaAgentRecord | null = null;
   if (privateKey) {
     try {
-      const { PublicKey, Keypair } = await import('@solana/web3.js');
+      const { Keypair } = await import('@solana/web3.js');
       const kp = Keypair.fromSecretKey(privateKey);
       existing = await identityClient.getAgentByOwner(kp.publicKey.toString());
     } catch {
-      // Ignore — may not be registered yet
+      // Ignore — agent may not be registered yet
     }
   }
 
@@ -194,7 +212,6 @@ export async function createSolanaAgentIdentity(
       `[identity-solana] Found existing Solana agent ID: ${existing.agentId}`
     );
     const trust = mapTrustTierToConfig(
-      undefined,
       existing.agentId,
       cluster,
       undefined,
@@ -211,14 +228,22 @@ export async function createSolanaAgentIdentity(
     };
   }
 
-  // Register if requested
+  // Auto-register if requested
   if (autoRegister && privateKey) {
+    // Fail fast: writing placeholder domain on-chain is worse than an early error.
+    if (!domain) {
+      throw new Error(
+        '[identity-solana] Missing required domain for auto-registration. ' +
+          'Set the AGENT_DOMAIN environment variable or provide options.domain.'
+      );
+    }
+
     logger?.info?.(
       '[identity-solana] No existing registration found, registering...'
     );
     const skipSend = regOpts?.skipSend ?? false;
     const result = await identityClient.registerAgent({
-      domain: domain ?? 'unknown',
+      domain,
       name: regOpts?.name,
       description: regOpts?.description,
       image: regOpts?.image,
@@ -228,7 +253,6 @@ export async function createSolanaAgentIdentity(
 
     if (result.alreadyExists) {
       const trust = mapTrustTierToConfig(
-        undefined,
         result.agentId,
         cluster,
         undefined,
@@ -247,7 +271,17 @@ export async function createSolanaAgentIdentity(
       };
     }
 
-    if (skipSend && result.unsignedTransaction) {
+    if (skipSend) {
+      // Guard: the SDK must return a serialised unsigned transaction.
+      if (
+        !result.unsignedTransaction ||
+        result.unsignedTransaction.length === 0
+      ) {
+        throw new Error(
+          '[identity-solana] skipSend=true but SDK returned no unsigned transaction payload. ' +
+            'Ensure assetPubkey is provided and the SDK version supports PreparedTransaction.'
+        );
+      }
       return {
         status: 'Unsigned transaction ready for browser wallet signing',
         domain,
@@ -259,7 +293,6 @@ export async function createSolanaAgentIdentity(
     }
 
     const trust = mapTrustTierToConfig(
-      undefined,
       result.agentId,
       cluster,
       undefined,
@@ -279,7 +312,7 @@ export async function createSolanaAgentIdentity(
     };
   }
 
-  // No registration — return trust config with no on-chain record
+  // No registration — return without on-chain identity
   if (autoRegister && !privateKey) {
     logger?.warn?.(
       '[identity-solana] autoRegister=true but no SOLANA_PRIVATE_KEY. Cannot register.'
@@ -292,11 +325,4 @@ export async function createSolanaAgentIdentity(
     domain,
     clients,
   };
-}
-
-/** Extract TrustConfig from a SolanaAgentIdentity. */
-export function getSolanaTrustConfig(
-  result: SolanaAgentIdentity
-): TrustConfig | undefined {
-  return result.trust;
 }

--- a/packages/identity-solana/src/init.ts
+++ b/packages/identity-solana/src/init.ts
@@ -1,0 +1,263 @@
+/**
+ * Core initialization for Solana agent identity.
+ * Mirrors @lucid-agents/identity createAgentIdentity() for Solana.
+ */
+
+import type { TrustConfig } from '@lucid-agents/types/identity';
+// @ts-ignore — 8004-solana is a peer/dependency
+import { SolanaSDK } from '8004-solana';
+
+import { parseCluster, resolveRpcUrl } from './config';
+import {
+  createSolanaIdentityRegistryClient,
+  type SolanaAgentRecord,
+  type SolanaIdentityRegistryClient,
+} from './registries/identity';
+import {
+  createSolanaReputationRegistryClient,
+  type SolanaReputationRegistryClient,
+} from './registries/reputation';
+import { resolveAutoRegister } from './validation';
+
+export type SolanaRegistryClients = {
+  identity: SolanaIdentityRegistryClient;
+  reputation: SolanaReputationRegistryClient;
+};
+
+export type SolanaAgentRegistrationOptions = {
+  name?: string;
+  description?: string;
+  image?: string;
+  agentURI?: string;
+  /** Skip sending the on-chain tx — useful for browser wallets */
+  skipSend?: boolean;
+};
+
+export type CreateSolanaAgentIdentityOptions = {
+  /** Solana private key as Uint8Array */
+  privateKey?: Uint8Array;
+  /** Cluster: mainnet-beta | devnet | testnet (default: mainnet-beta) */
+  cluster?: string;
+  /** Optional RPC URL override */
+  rpcUrl?: string;
+  /** Agent domain (e.g., "agent.example.com") */
+  domain?: string;
+  /** Whether to auto-register if not found. Defaults to true. */
+  autoRegister?: boolean;
+  /** Trust models to advertise */
+  trustModels?: string[];
+  /** Registration metadata */
+  registration?: SolanaAgentRegistrationOptions;
+  /** Custom env vars (defaults to process.env) */
+  env?: Record<string, string | undefined>;
+  /** Logger */
+  logger?: { info?(msg: string): void; warn?(msg: string, err?: unknown): void };
+};
+
+export type SolanaAgentIdentity = {
+  status: string;
+  trust?: TrustConfig;
+  record?: SolanaAgentRecord;
+  domain?: string;
+  isNewRegistration?: boolean;
+  didRegister?: boolean;
+  transactionSignature?: string;
+  /** Set when skipSend=true for browser wallet signing */
+  unsignedTransaction?: Uint8Array;
+  clients?: SolanaRegistryClients;
+};
+
+/**
+ * Map a Solana TrustTier value to a Lucid TrustConfig.
+ */
+export function mapTrustTierToConfig(
+  tier: number | string | undefined,
+  agentId: bigint | number | undefined,
+  cluster: string,
+  feedbackDataUri?: string,
+  trustModels: string[] = ['feedback']
+): TrustConfig {
+  const registrations = agentId != null
+    ? [{
+        agentId: String(agentId),
+        agentRegistry: `solana:${cluster}:8004-solana`,
+      }]
+    : [];
+
+  return {
+    registrations,
+    trustModels,
+    feedbackDataUri,
+  };
+}
+
+/**
+ * Create a SolanaSDK instance from config options.
+ */
+export function createSdk(options: {
+  privateKey?: Uint8Array;
+  cluster: string;
+  rpcUrl: string;
+}): InstanceType<typeof SolanaSDK> {
+  const sdkOptions: Record<string, unknown> = {
+    cluster: options.cluster,
+    rpcUrl: options.rpcUrl,
+  };
+
+  if (options.privateKey) {
+    sdkOptions.keypair = options.privateKey;
+  }
+
+  return new SolanaSDK(sdkOptions);
+}
+
+/**
+ * Create Solana agent identity with automatic registration.
+ * Mirrors createAgentIdentity() from @lucid-agents/identity.
+ */
+export async function createSolanaAgentIdentity(
+  options: CreateSolanaAgentIdentityOptions
+): Promise<SolanaAgentIdentity> {
+  const { env, logger, registration: regOpts } = options;
+
+  // Resolve cluster + RPC
+  const clusterRaw =
+    options.cluster ??
+    env?.SOLANA_CLUSTER ??
+    (typeof process !== 'undefined' ? process.env?.SOLANA_CLUSTER : undefined);
+  const cluster = parseCluster(clusterRaw);
+  const rpcUrl = resolveRpcUrl(
+    cluster,
+    options.rpcUrl ??
+      env?.SOLANA_RPC_URL ??
+      (typeof process !== 'undefined' ? process.env?.SOLANA_RPC_URL : undefined)
+  );
+
+  // Resolve private key
+  const privateKey =
+    options.privateKey ??
+    (() => {
+      const raw =
+        env?.SOLANA_PRIVATE_KEY ??
+        (typeof process !== 'undefined' ? process.env?.SOLANA_PRIVATE_KEY : undefined);
+      if (!raw) return undefined;
+      try { return new Uint8Array(JSON.parse(raw)); } catch { return undefined; }
+    })();
+
+  // Resolve domain
+  const domain =
+    options.domain ??
+    env?.AGENT_DOMAIN ??
+    (typeof process !== 'undefined' ? process.env?.AGENT_DOMAIN : undefined);
+
+  const autoRegister = resolveAutoRegister(options, env);
+  const trustModels = options.trustModels ?? ['feedback'];
+
+  // Create SDK (read-only if no private key)
+  const sdk = createSdk({ privateKey, cluster, rpcUrl });
+
+  const identityClient = createSolanaIdentityRegistryClient(sdk);
+  const reputationClient = createSolanaReputationRegistryClient(sdk);
+  const clients: SolanaRegistryClients = {
+    identity: identityClient,
+    reputation: reputationClient,
+  };
+
+  // Check existing registration (by domain owner if possible)
+  let existing: SolanaAgentRecord | null = null;
+  if (privateKey) {
+    try {
+      const { PublicKey, Keypair } = await import('@solana/web3.js');
+      const kp = Keypair.fromSecretKey(privateKey);
+      existing = await identityClient.getAgentByOwner(kp.publicKey.toString());
+    } catch {
+      // Ignore — may not be registered yet
+    }
+  }
+
+  if (existing) {
+    logger?.info?.(`[identity-solana] Found existing Solana agent ID: ${existing.agentId}`);
+    const trust = mapTrustTierToConfig(undefined, existing.agentId, cluster, undefined, trustModels);
+    return {
+      status: 'Found existing registration in 8004-Solana registry',
+      trust,
+      record: existing,
+      domain,
+      isNewRegistration: false,
+      didRegister: false,
+      clients,
+    };
+  }
+
+  // Register if requested
+  if (autoRegister && privateKey) {
+    logger?.info?.('[identity-solana] No existing registration found, registering...');
+    const skipSend = regOpts?.skipSend ?? false;
+    const result = await identityClient.registerAgent({
+      domain: domain ?? 'unknown',
+      name: regOpts?.name,
+      description: regOpts?.description,
+      image: regOpts?.image,
+      agentURI: regOpts?.agentURI,
+      skipSend,
+    });
+
+    if (result.alreadyExists) {
+      const trust = mapTrustTierToConfig(undefined, result.agentId, cluster, undefined, trustModels);
+      return {
+        status: 'Found existing registration in 8004-Solana registry',
+        trust,
+        record: result.agentId ? { agentId: result.agentId, owner: '', uri: '', cluster } : undefined,
+        domain,
+        isNewRegistration: false,
+        didRegister: false,
+        clients,
+      };
+    }
+
+    if (skipSend && result.unsignedTransaction) {
+      return {
+        status: 'Unsigned transaction ready for browser wallet signing',
+        domain,
+        isNewRegistration: false,
+        didRegister: false,
+        unsignedTransaction: result.unsignedTransaction,
+        clients,
+      };
+    }
+
+    const trust = mapTrustTierToConfig(undefined, result.agentId, cluster, undefined, trustModels);
+    return {
+      status: 'Successfully registered agent in 8004-Solana registry',
+      trust,
+      record: result.agentId
+        ? { agentId: result.agentId, owner: '', uri: '', cluster }
+        : undefined,
+      domain,
+      isNewRegistration: true,
+      didRegister: true,
+      transactionSignature: result.transactionSignature,
+      clients,
+    };
+  }
+
+  // No registration — return trust config with no on-chain record
+  if (autoRegister && !privateKey) {
+    logger?.warn?.(
+      '[identity-solana] autoRegister=true but no SOLANA_PRIVATE_KEY. Cannot register.'
+    );
+  }
+
+  return {
+    status: 'No 8004-Solana identity — agent will run without on-chain identity',
+    domain,
+    clients,
+  };
+}
+
+/** Extract TrustConfig from a SolanaAgentIdentity. */
+export function getSolanaTrustConfig(
+  result: SolanaAgentIdentity
+): TrustConfig | undefined {
+  return result.trust;
+}

--- a/packages/identity-solana/src/init.ts
+++ b/packages/identity-solana/src/init.ts
@@ -185,6 +185,15 @@ export async function createSolanaAgentIdentity(
   const autoRegister = resolveAutoRegister(options, env);
   const trustModels = options.trustModels ?? ['feedback'];
 
+  // Fail fast before any network I/O: writing placeholder domain on-chain is
+  // worse than an early error, and users expect config errors up front.
+  if (autoRegister && privateKey && !domain) {
+    throw new Error(
+      '[identity-solana] Missing required domain for auto-registration. ' +
+        'Set the AGENT_DOMAIN environment variable or provide options.domain.'
+    );
+  }
+
   // Create SDK (read-only if no private key)
   const sdk = createSdk({ privateKey, cluster, rpcUrl });
 
@@ -198,12 +207,17 @@ export async function createSolanaAgentIdentity(
   // Check existing registration (by domain owner if possible)
   let existing: SolanaAgentRecord | null = null;
   if (privateKey) {
+    const { Keypair } = await import('@solana/web3.js');
+    const kp = Keypair.fromSecretKey(privateKey);
     try {
-      const { Keypair } = await import('@solana/web3.js');
-      const kp = Keypair.fromSecretKey(privateKey);
       existing = await identityClient.getAgentByOwner(kp.publicKey.toString());
-    } catch {
-      // Ignore — agent may not be registered yet
+    } catch (err: unknown) {
+      // getAgentByOwner returns null for missing agents and throws for SDK/RPC errors.
+      // Propagate errors so callers know the registry is unavailable.
+      throw new Error(
+        `[identity-solana] Failed to look up existing agent for owner ${kp.publicKey.toString()}: ` +
+          (err instanceof Error ? err.message : String(err))
+      );
     }
   }
 
@@ -228,16 +242,8 @@ export async function createSolanaAgentIdentity(
     };
   }
 
-  // Auto-register if requested
+  // Auto-register if requested (domain already validated above)
   if (autoRegister && privateKey) {
-    // Fail fast: writing placeholder domain on-chain is worse than an early error.
-    if (!domain) {
-      throw new Error(
-        '[identity-solana] Missing required domain for auto-registration. ' +
-          'Set the AGENT_DOMAIN environment variable or provide options.domain.'
-      );
-    }
-
     logger?.info?.(
       '[identity-solana] No existing registration found, registering...'
     );
@@ -258,12 +264,12 @@ export async function createSolanaAgentIdentity(
         undefined,
         trustModels
       );
+      // We only have the agentId at this point, not a full record (owner/uri
+      // unknown). Return undefined rather than a semantically invalid stub.
       return {
         status: 'Found existing registration in 8004-Solana registry',
         trust,
-        record: result.agentId
-          ? { agentId: result.agentId, owner: '', uri: '', cluster }
-          : undefined,
+        record: undefined,
         domain,
         isNewRegistration: false,
         didRegister: false,
@@ -298,12 +304,12 @@ export async function createSolanaAgentIdentity(
       undefined,
       trustModels
     );
+    // owner/uri are not returned by registerAgent — omit the record rather than
+    // emitting a stub with empty fields. Callers can query getAgent for the full record.
     return {
       status: 'Successfully registered agent in 8004-Solana registry',
       trust,
-      record: result.agentId
-        ? { agentId: result.agentId, owner: '', uri: '', cluster }
-        : undefined,
+      record: undefined,
       domain,
       isNewRegistration: true,
       didRegister: true,

--- a/packages/identity-solana/src/init.ts
+++ b/packages/identity-solana/src/init.ts
@@ -48,10 +48,15 @@ export type CreateSolanaAgentIdentityOptions = {
   trustModels?: string[];
   /** Registration metadata */
   registration?: SolanaAgentRegistrationOptions;
+  /** Pre-resolved TrustConfig (bypasses auto-derivation from trustModels) */
+  trust?: TrustConfig;
   /** Custom env vars (defaults to process.env) */
   env?: Record<string, string | undefined>;
   /** Logger */
-  logger?: { info?(msg: string): void; warn?(msg: string, err?: unknown): void };
+  logger?: {
+    info?(msg: string): void;
+    warn?(msg: string, err?: unknown): void;
+  };
 };
 
 export type SolanaAgentIdentity = {
@@ -72,17 +77,20 @@ export type SolanaAgentIdentity = {
  */
 export function mapTrustTierToConfig(
   tier: number | string | undefined,
-  agentId: bigint | number | undefined,
+  agentId: string | bigint | number | null | undefined,
   cluster: string,
   feedbackDataUri?: string,
   trustModels: string[] = ['feedback']
 ): TrustConfig {
-  const registrations = agentId != null
-    ? [{
-        agentId: String(agentId),
-        agentRegistry: `solana:${cluster}:8004-solana`,
-      }]
-    : [];
+  const registrations =
+    agentId != null
+      ? [
+          {
+            agentId: String(agentId),
+            agentRegistry: `solana:${cluster}:8004-solana`,
+          },
+        ]
+      : [];
 
   return {
     registrations,
@@ -139,9 +147,15 @@ export async function createSolanaAgentIdentity(
     (() => {
       const raw =
         env?.SOLANA_PRIVATE_KEY ??
-        (typeof process !== 'undefined' ? process.env?.SOLANA_PRIVATE_KEY : undefined);
+        (typeof process !== 'undefined'
+          ? process.env?.SOLANA_PRIVATE_KEY
+          : undefined);
       if (!raw) return undefined;
-      try { return new Uint8Array(JSON.parse(raw)); } catch { return undefined; }
+      try {
+        return new Uint8Array(JSON.parse(raw));
+      } catch {
+        return undefined;
+      }
     })();
 
   // Resolve domain
@@ -176,8 +190,16 @@ export async function createSolanaAgentIdentity(
   }
 
   if (existing) {
-    logger?.info?.(`[identity-solana] Found existing Solana agent ID: ${existing.agentId}`);
-    const trust = mapTrustTierToConfig(undefined, existing.agentId, cluster, undefined, trustModels);
+    logger?.info?.(
+      `[identity-solana] Found existing Solana agent ID: ${existing.agentId}`
+    );
+    const trust = mapTrustTierToConfig(
+      undefined,
+      existing.agentId,
+      cluster,
+      undefined,
+      trustModels
+    );
     return {
       status: 'Found existing registration in 8004-Solana registry',
       trust,
@@ -191,7 +213,9 @@ export async function createSolanaAgentIdentity(
 
   // Register if requested
   if (autoRegister && privateKey) {
-    logger?.info?.('[identity-solana] No existing registration found, registering...');
+    logger?.info?.(
+      '[identity-solana] No existing registration found, registering...'
+    );
     const skipSend = regOpts?.skipSend ?? false;
     const result = await identityClient.registerAgent({
       domain: domain ?? 'unknown',
@@ -203,11 +227,19 @@ export async function createSolanaAgentIdentity(
     });
 
     if (result.alreadyExists) {
-      const trust = mapTrustTierToConfig(undefined, result.agentId, cluster, undefined, trustModels);
+      const trust = mapTrustTierToConfig(
+        undefined,
+        result.agentId,
+        cluster,
+        undefined,
+        trustModels
+      );
       return {
         status: 'Found existing registration in 8004-Solana registry',
         trust,
-        record: result.agentId ? { agentId: result.agentId, owner: '', uri: '', cluster } : undefined,
+        record: result.agentId
+          ? { agentId: result.agentId, owner: '', uri: '', cluster }
+          : undefined,
         domain,
         isNewRegistration: false,
         didRegister: false,
@@ -226,7 +258,13 @@ export async function createSolanaAgentIdentity(
       };
     }
 
-    const trust = mapTrustTierToConfig(undefined, result.agentId, cluster, undefined, trustModels);
+    const trust = mapTrustTierToConfig(
+      undefined,
+      result.agentId,
+      cluster,
+      undefined,
+      trustModels
+    );
     return {
       status: 'Successfully registered agent in 8004-Solana registry',
       trust,
@@ -249,7 +287,8 @@ export async function createSolanaAgentIdentity(
   }
 
   return {
-    status: 'No 8004-Solana identity — agent will run without on-chain identity',
+    status:
+      'No 8004-Solana identity — agent will run without on-chain identity',
     domain,
     clients,
   };

--- a/packages/identity-solana/src/manifest.ts
+++ b/packages/identity-solana/src/manifest.ts
@@ -1,0 +1,41 @@
+/**
+ * Agent card manifest helpers for Solana identity.
+ * Mirrors createAgentCardWithIdentity() from @lucid-agents/identity.
+ */
+
+import type { AgentCardWithEntrypoints } from '@lucid-agents/types/a2a';
+import type { TrustConfig } from '@lucid-agents/types/identity';
+
+/**
+ * Create a new Agent Card with Solana identity/trust metadata added.
+ * Immutable — returns new card, doesn't mutate input.
+ */
+export function createAgentCardWithSolanaIdentity(
+  card: AgentCardWithEntrypoints,
+  trustConfig: TrustConfig
+): AgentCardWithEntrypoints {
+  const enhanced: AgentCardWithEntrypoints = { ...card };
+
+  if (trustConfig.registrations) {
+    enhanced.registrations = trustConfig.registrations;
+  }
+
+  if (trustConfig.trustModels) {
+    const unique = Array.from(new Set(trustConfig.trustModels));
+    enhanced.trustModels = unique;
+  }
+
+  if (trustConfig.validationRequestsUri) {
+    enhanced.ValidationRequestsURI = trustConfig.validationRequestsUri;
+  }
+
+  if (trustConfig.validationResponsesUri) {
+    enhanced.ValidationResponsesURI = trustConfig.validationResponsesUri;
+  }
+
+  if (trustConfig.feedbackDataUri) {
+    enhanced.FeedbackDataURI = trustConfig.feedbackDataUri;
+  }
+
+  return enhanced;
+}

--- a/packages/identity-solana/src/registries/identity.ts
+++ b/packages/identity-solana/src/registries/identity.ts
@@ -1,8 +1,9 @@
 /**
  * Thin wrapper around 8004-solana's identity/registration capabilities.
+ * Uses the published TypeScript declarations from 8004-solana directly.
  */
 
-// @ts-ignore — 8004-solana is a peer dependency
+import type { IndexedAgent } from '8004-solana';
 import { SolanaSDK } from '8004-solana';
 
 export type SolanaAgentRecord = {
@@ -27,7 +28,7 @@ export type RegisterAgentResult = {
   transactionSignature?: string;
   didRegister: boolean;
   alreadyExists: boolean;
-  /** Serialized transaction for skipSend browser-wallet signing */
+  /** Base64-serialised unsigned transaction for browser-wallet signing */
   unsignedTransaction?: Uint8Array;
 };
 
@@ -40,7 +41,7 @@ export type SolanaIdentityRegistryClient = {
 };
 
 function mapIndexedAgent(
-  agent: any,
+  agent: IndexedAgent,
   fallbackCluster: string
 ): SolanaAgentRecord {
   return {
@@ -57,57 +58,79 @@ function mapIndexedAgent(
 export function createSolanaIdentityRegistryClient(
   sdk: InstanceType<typeof SolanaSDK>
 ): SolanaIdentityRegistryClient {
-  const cluster = (sdk as any).getCluster?.() ?? 'mainnet-beta';
+  const cluster =
+    (sdk as { getCluster?(): string }).getCluster?.() ?? 'mainnet-beta';
 
   return {
     async getAgent(agentId) {
+      // Only return null when the agent genuinely does not exist.
+      // Rethrow SDK/network errors so callers can distinguish "not found" from failures.
+      let agent: IndexedAgent | null;
       try {
-        const agent = await sdk.getAgentByAgentId(agentId);
-        if (!agent) return null;
-        return mapIndexedAgent(agent, cluster);
-      } catch {
-        return null;
+        agent = await sdk.getAgentByAgentId(agentId);
+      } catch (err: unknown) {
+        throw new Error(
+          `getAgent: failed to fetch agent ${agentId} (cluster=${cluster}): ` +
+            (err instanceof Error ? err.message : String(err))
+        );
       }
+      if (!agent) return null;
+      return mapIndexedAgent(agent, cluster);
     },
 
     async getAgentByOwner(ownerAddress) {
+      let agent: IndexedAgent | null;
       try {
-        // getAgentByWallet looks up by wallet address string via indexer
-        const agent = await sdk.getAgentByWallet(ownerAddress);
-        if (!agent) return null;
-        return mapIndexedAgent(agent, cluster);
-      } catch {
-        return null;
+        agent = await sdk.getAgentByWallet(ownerAddress);
+      } catch (err: unknown) {
+        throw new Error(
+          `getAgentByOwner: failed to fetch agent for owner ${ownerAddress} (cluster=${cluster}): ` +
+            (err instanceof Error ? err.message : String(err))
+        );
       }
+      if (!agent) return null;
+      return mapIndexedAgent(agent, cluster);
     },
 
     async registerAgent(opts) {
+      const tokenUri =
+        opts.agentURI ??
+        `https://${opts.domain}/.well-known/agent-registration.json`;
+
       if (opts.skipSend) {
-        // Browser wallet mode: return placeholder unsigned transaction
+        // Browser wallet mode: ask the SDK to build and serialise the transaction
+        // without broadcasting so the browser wallet can sign and send it.
+        const { Keypair } = await import('@solana/web3.js');
+        const assetKeypair = Keypair.generate();
+        const prepared = await sdk.registerAgent(tokenUri, {
+          skipSend: true,
+          assetPubkey: assetKeypair.publicKey,
+        });
+        // PreparedTransaction.transaction is a Base64-encoded serialised tx.
+        const txBase64 =
+          (prepared as { transaction: string }).transaction ?? '';
         return {
           didRegister: false,
           alreadyExists: false,
-          unsignedTransaction: new Uint8Array(0),
+          unsignedTransaction: new Uint8Array(Buffer.from(txBase64, 'base64')),
         };
       }
 
       try {
-        const tokenUri =
-          opts.agentURI ??
-          `https://${opts.domain}/.well-known/agent-registration.json`;
         const result = await sdk.registerAgent(tokenUri);
         return {
-          agentId: (result as any)?.agentId ?? (result as any)?.agent_id,
+          agentId:
+            (result as { agentId?: string | number }).agentId ??
+            (result as { agent_id?: string | number }).agent_id,
           transactionSignature:
-            (result as any)?.signature ?? (result as any)?.tx,
+            (result as { signature?: string }).signature ??
+            (result as { tx?: string }).tx,
           didRegister: true,
           alreadyExists: false,
         };
-      } catch (err: any) {
-        if (
-          err?.message?.includes('already') ||
-          err?.message?.includes('exists')
-        ) {
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes('already') || msg.includes('exists')) {
           return { didRegister: false, alreadyExists: true };
         }
         throw err;

--- a/packages/identity-solana/src/registries/identity.ts
+++ b/packages/identity-solana/src/registries/identity.ts
@@ -2,10 +2,11 @@
  * Thin wrapper around 8004-solana's identity/registration capabilities.
  */
 
-import type { SolanaSDK as SolanaSDKType } from '8004-solana';
+// @ts-ignore — 8004-solana is a peer dependency
+import { SolanaSDK } from '8004-solana';
 
 export type SolanaAgentRecord = {
-  agentId: bigint | number;
+  agentId: string | number | null;
   owner: string;
   uri: string;
   cluster: string;
@@ -22,7 +23,7 @@ export type RegisterAgentOptions = {
 };
 
 export type RegisterAgentResult = {
-  agentId?: bigint | number;
+  agentId?: string | number;
   transactionSignature?: string;
   didRegister: boolean;
   alreadyExists: boolean;
@@ -31,28 +32,39 @@ export type RegisterAgentResult = {
 };
 
 export type SolanaIdentityRegistryClient = {
-  getAgent(agentId: bigint | number): Promise<SolanaAgentRecord | null>;
+  getAgent(
+    agentId: string | number | bigint
+  ): Promise<SolanaAgentRecord | null>;
   getAgentByOwner(ownerAddress: string): Promise<SolanaAgentRecord | null>;
   registerAgent(opts: RegisterAgentOptions): Promise<RegisterAgentResult>;
 };
+
+function mapIndexedAgent(
+  agent: any,
+  fallbackCluster: string
+): SolanaAgentRecord {
+  return {
+    agentId: agent.agent_id ?? null,
+    owner: agent.owner ?? '',
+    uri: agent.agent_uri ?? '',
+    cluster: fallbackCluster,
+  };
+}
 
 /**
  * Create a Solana identity registry client wrapping SolanaSDK.
  */
 export function createSolanaIdentityRegistryClient(
-  sdk: SolanaSDKType
+  sdk: InstanceType<typeof SolanaSDK>
 ): SolanaIdentityRegistryClient {
+  const cluster = (sdk as any).getCluster?.() ?? 'mainnet-beta';
+
   return {
     async getAgent(agentId) {
       try {
-        const agent = await sdk.getAgent(BigInt(agentId));
+        const agent = await sdk.getAgentByAgentId(agentId);
         if (!agent) return null;
-        return {
-          agentId: agent.agentId ?? agentId,
-          owner: agent.owner?.toString() ?? '',
-          uri: agent.uri ?? '',
-          cluster: sdk.getCluster?.() ?? 'mainnet-beta',
-        };
+        return mapIndexedAgent(agent, cluster);
       } catch {
         return null;
       }
@@ -60,43 +72,42 @@ export function createSolanaIdentityRegistryClient(
 
     async getAgentByOwner(ownerAddress) {
       try {
-        const agents = await sdk.getAgentsByOwner(ownerAddress as any);
-        if (!agents || agents.length === 0) return null;
-        const a = agents[0];
-        return {
-          agentId: a.agentId ?? 0,
-          owner: a.owner?.toString() ?? ownerAddress,
-          uri: a.uri ?? '',
-          cluster: sdk.getCluster?.() ?? 'mainnet-beta',
-        };
+        // getAgentByWallet looks up by wallet address string via indexer
+        const agent = await sdk.getAgentByWallet(ownerAddress);
+        if (!agent) return null;
+        return mapIndexedAgent(agent, cluster);
       } catch {
         return null;
       }
     },
 
     async registerAgent(opts) {
-      try {
-        // Check if already registered
-        if (opts.skipSend) {
-          // Browser wallet mode: return unsigned transaction
-          return {
-            didRegister: false,
-            alreadyExists: false,
-            unsignedTransaction: new Uint8Array(0), // placeholder
-          };
-        }
-
-        const tokenUri = opts.agentURI ?? `https://${opts.domain}/.well-known/agent-registration.json`;
-        const result = await sdk.registerAgent(tokenUri, { skipSend: false } as any);
+      if (opts.skipSend) {
+        // Browser wallet mode: return placeholder unsigned transaction
         return {
-          agentId: (result as any)?.agentId,
-          transactionSignature: (result as any)?.signature ?? (result as any)?.tx,
+          didRegister: false,
+          alreadyExists: false,
+          unsignedTransaction: new Uint8Array(0),
+        };
+      }
+
+      try {
+        const tokenUri =
+          opts.agentURI ??
+          `https://${opts.domain}/.well-known/agent-registration.json`;
+        const result = await sdk.registerAgent(tokenUri);
+        return {
+          agentId: (result as any)?.agentId ?? (result as any)?.agent_id,
+          transactionSignature:
+            (result as any)?.signature ?? (result as any)?.tx,
           didRegister: true,
           alreadyExists: false,
         };
       } catch (err: any) {
-        // Agent may already exist
-        if (err?.message?.includes('already') || err?.message?.includes('exists')) {
+        if (
+          err?.message?.includes('already') ||
+          err?.message?.includes('exists')
+        ) {
           return { didRegister: false, alreadyExists: true };
         }
         throw err;

--- a/packages/identity-solana/src/registries/identity.ts
+++ b/packages/identity-solana/src/registries/identity.ts
@@ -1,0 +1,106 @@
+/**
+ * Thin wrapper around 8004-solana's identity/registration capabilities.
+ */
+
+import type { SolanaSDK as SolanaSDKType } from '8004-solana';
+
+export type SolanaAgentRecord = {
+  agentId: bigint | number;
+  owner: string;
+  uri: string;
+  cluster: string;
+};
+
+export type RegisterAgentOptions = {
+  domain: string;
+  name?: string;
+  description?: string;
+  image?: string;
+  agentURI?: string;
+  /** If true, skip sending the on-chain transaction (browser wallet flow) */
+  skipSend?: boolean;
+};
+
+export type RegisterAgentResult = {
+  agentId?: bigint | number;
+  transactionSignature?: string;
+  didRegister: boolean;
+  alreadyExists: boolean;
+  /** Serialized transaction for skipSend browser-wallet signing */
+  unsignedTransaction?: Uint8Array;
+};
+
+export type SolanaIdentityRegistryClient = {
+  getAgent(agentId: bigint | number): Promise<SolanaAgentRecord | null>;
+  getAgentByOwner(ownerAddress: string): Promise<SolanaAgentRecord | null>;
+  registerAgent(opts: RegisterAgentOptions): Promise<RegisterAgentResult>;
+};
+
+/**
+ * Create a Solana identity registry client wrapping SolanaSDK.
+ */
+export function createSolanaIdentityRegistryClient(
+  sdk: SolanaSDKType
+): SolanaIdentityRegistryClient {
+  return {
+    async getAgent(agentId) {
+      try {
+        const agent = await sdk.getAgent(BigInt(agentId));
+        if (!agent) return null;
+        return {
+          agentId: agent.agentId ?? agentId,
+          owner: agent.owner?.toString() ?? '',
+          uri: agent.uri ?? '',
+          cluster: sdk.getCluster?.() ?? 'mainnet-beta',
+        };
+      } catch {
+        return null;
+      }
+    },
+
+    async getAgentByOwner(ownerAddress) {
+      try {
+        const agents = await sdk.getAgentsByOwner(ownerAddress as any);
+        if (!agents || agents.length === 0) return null;
+        const a = agents[0];
+        return {
+          agentId: a.agentId ?? 0,
+          owner: a.owner?.toString() ?? ownerAddress,
+          uri: a.uri ?? '',
+          cluster: sdk.getCluster?.() ?? 'mainnet-beta',
+        };
+      } catch {
+        return null;
+      }
+    },
+
+    async registerAgent(opts) {
+      try {
+        // Check if already registered
+        if (opts.skipSend) {
+          // Browser wallet mode: return unsigned transaction
+          return {
+            didRegister: false,
+            alreadyExists: false,
+            unsignedTransaction: new Uint8Array(0), // placeholder
+          };
+        }
+
+        const tokenUri = opts.agentURI ?? `https://${opts.domain}/.well-known/agent-registration.json`;
+        const result = await sdk.registerAgent(tokenUri, { skipSend: false } as any);
+        return {
+          agentId: (result as any)?.agentId,
+          transactionSignature: (result as any)?.signature ?? (result as any)?.tx,
+          didRegister: true,
+          alreadyExists: false,
+        };
+      } catch (err: any) {
+        // Agent may already exist
+        if (err?.message?.includes('already') || err?.message?.includes('exists')) {
+          return { didRegister: false, alreadyExists: true };
+        }
+        throw err;
+      }
+    },
+  };
+}

--- a/packages/identity-solana/src/registries/reputation.ts
+++ b/packages/identity-solana/src/registries/reputation.ts
@@ -1,14 +1,47 @@
 /**
  * Thin wrapper around 8004-solana's reputation capabilities.
+ * Uses a typed local adapter to avoid @ts-ignore and scattered any casts.
  */
 
-// @ts-ignore — 8004-solana is a peer dependency
 import { SolanaSDK } from '8004-solana';
+
+// ── Local SDK adapter types ─────────────────────────────────────────────────
+// These mirror the relevant subset of the 8004-solana SDK so the wrapper is
+// fully typed without repeating the peer-dep's entire interface.
+
+type IndexerSummary = {
+  avg_score?: number | null;
+  trust_tier?: string | number | null;
+  feedback_count?: number | null;
+};
+
+type TxResult = { signature?: string; tx?: string } | null | undefined;
+
+type SolanaReputationSdkAdapter = {
+  getAgentReputationFromIndexer(
+    assetAddress: string
+  ): Promise<IndexerSummary | null | undefined>;
+  giveFeedback(
+    targetAddress: string,
+    params: {
+      value: number;
+      tag1: string;
+      tag2: string;
+      metricUri?: string;
+    }
+  ): Promise<TxResult>;
+  revokeFeedback(
+    assetAddress: string,
+    feedbackIndex: number | bigint
+  ): Promise<TxResult>;
+};
+
+// ── Public types ─────────────────────────────────────────────────────────────
 
 export type SolanaReputationSummary = {
   /** Agent's on-chain asset address */
   assetAddress: string;
-  /** Average score (0-100) or null when no feedbacks yet */
+  /** Average score (0–100) or null when no feedbacks yet */
   score: number | null;
   /** Trust tier name (Unrated, Bronze, Silver, Gold, Platinum) */
   tier: string;
@@ -21,7 +54,7 @@ export type GiveFeedbackOptions = {
    * When submitting feedback after a task, this is the agent that performed the work.
    */
   targetAddress: string;
-  /** Feedback score (0-100) */
+  /** Feedback score (0–100, inclusive) */
   score: number;
   /** Optional comment / URI describing the feedback context */
   comment?: string;
@@ -34,7 +67,7 @@ export type GiveFeedbackOptions = {
 export type RevokeFeedbackOptions = {
   /** Agent asset address (base58-encoded) */
   assetAddress: string;
-  /** Feedback index to revoke */
+  /** Feedback index to revoke — must be a non-negative integer */
   feedbackIndex: number | bigint;
 };
 
@@ -50,16 +83,18 @@ export type SolanaReputationRegistryClient = {
 export function createSolanaReputationRegistryClient(
   sdk: InstanceType<typeof SolanaSDK>
 ): SolanaReputationRegistryClient {
+  // Cast once to the typed adapter — keeps individual call sites clean.
+  const reputationSdk = sdk as unknown as SolanaReputationSdkAdapter;
+
   return {
     async getSummary(assetAddress) {
       // Only return null when the agent genuinely has no reputation record.
-      // SDK/network failures are surfaced as errors so callers can distinguish
+      // SDK/network failures are rethrown so callers can distinguish
       // "not found" from "service unavailable".
-      let indexerData: Record<string, unknown> | null | undefined;
+      let indexerData: IndexerSummary | null | undefined;
       try {
-        indexerData = await (sdk as any).getAgentReputationFromIndexer(
-          assetAddress as any
-        );
+        indexerData =
+          await reputationSdk.getAgentReputationFromIndexer(assetAddress);
       } catch (err: unknown) {
         throw new Error(
           `getSummary: failed to fetch reputation for asset ${assetAddress}: ` +
@@ -82,31 +117,40 @@ export function createSolanaReputationRegistryClient(
     },
 
     async giveFeedback(opts) {
-      // sdk.giveFeedback(asset: PublicKey, params: GiveFeedbackParams, options?)
-      // We cast the address string to `any` to avoid importing PublicKey at build time.
-      const result = await (sdk as any).giveFeedback(
-        opts.targetAddress as any,
-        {
-          value: opts.score,
-          tag1: opts.tag1 ?? '',
-          tag2: opts.tag2 ?? '',
-          ...(opts.comment ? { metricUri: opts.comment } : {}),
-        }
-      );
-      return {
-        signature: (result as any)?.signature ?? (result as any)?.tx,
-      };
+      if (
+        typeof opts.score !== 'number' ||
+        !Number.isFinite(opts.score) ||
+        opts.score < 0 ||
+        opts.score > 100
+      ) {
+        throw new Error(
+          `giveFeedback: invalid score ${opts.score}. Must be a finite number in [0, 100].`
+        );
+      }
+
+      const result = await reputationSdk.giveFeedback(opts.targetAddress, {
+        value: opts.score,
+        tag1: opts.tag1 ?? '',
+        tag2: opts.tag2 ?? '',
+        ...(opts.comment ? { metricUri: opts.comment } : {}),
+      });
+      return { signature: result?.signature ?? result?.tx };
     },
 
     async revokeFeedback(opts) {
-      // sdk.revokeFeedback(asset: PublicKey, feedbackIndex, sealHash?, options?)
-      const result = await (sdk as any).revokeFeedback(
-        opts.assetAddress as any,
+      const idx = opts.feedbackIndex;
+      const idxNum = typeof idx === 'bigint' ? Number(idx) : idx;
+      if (!Number.isInteger(idxNum) || idxNum < 0) {
+        throw new Error(
+          `revokeFeedback: invalid feedbackIndex ${opts.feedbackIndex}. Must be a non-negative integer.`
+        );
+      }
+
+      const result = await reputationSdk.revokeFeedback(
+        opts.assetAddress,
         opts.feedbackIndex
       );
-      return {
-        signature: (result as any)?.signature ?? (result as any)?.tx,
-      };
+      return { signature: result?.signature ?? result?.tx };
     },
   };
 }

--- a/packages/identity-solana/src/registries/reputation.ts
+++ b/packages/identity-solana/src/registries/reputation.ts
@@ -1,0 +1,69 @@
+/**
+ * Thin wrapper around 8004-solana's reputation capabilities.
+ */
+
+import type { SolanaSDK as SolanaSDKType } from '8004-solana';
+
+export type SolanaReputationSummary = {
+  agentId: bigint | number;
+  score: number;
+  tier: string;
+  feedbackCount: number;
+};
+
+export type GiveFeedbackOptions = {
+  toAgentId: bigint | number;
+  value: number;
+  valueDecimals?: number;
+  tag1?: string;
+  tag2?: string;
+  endpoint?: string;
+};
+
+export type SolanaReputationRegistryClient = {
+  getSummary(agentId: bigint | number): Promise<SolanaReputationSummary | null>;
+  giveFeedback(opts: GiveFeedbackOptions): Promise<{ signature?: string }>;
+  revokeFeedback(feedbackId: string): Promise<{ signature?: string }>;
+};
+
+/**
+ * Create a Solana reputation registry client wrapping SolanaSDK.
+ */
+export function createSolanaReputationRegistryClient(
+  sdk: SolanaSDKType
+): SolanaReputationRegistryClient {
+  return {
+    async getSummary(agentId) {
+      try {
+        const summary = await sdk.getReputationSummary(BigInt(agentId));
+        if (!summary) return null;
+        const tier = await sdk.getTrustTier?.(BigInt(agentId));
+        return {
+          agentId,
+          score: (summary as any)?.score ?? 0,
+          tier: String(tier ?? 'Unrated'),
+          feedbackCount: (summary as any)?.feedbackCount ?? 0,
+        };
+      } catch {
+        return null;
+      }
+    },
+
+    async giveFeedback(opts) {
+      const result = await sdk.giveFeedback({
+        toAgentId: BigInt(opts.toAgentId),
+        value: opts.value,
+        valueDecimals: opts.valueDecimals ?? 0,
+        tag1: opts.tag1 ?? '',
+        tag2: opts.tag2 ?? '',
+        endpoint: opts.endpoint ?? '',
+      } as any);
+      return { signature: (result as any)?.signature ?? (result as any)?.tx };
+    },
+
+    async revokeFeedback(feedbackId) {
+      const result = await sdk.revokeFeedback?.(feedbackId as any);
+      return { signature: (result as any)?.signature ?? (result as any)?.tx };
+    },
+  };
+}

--- a/packages/identity-solana/src/registries/reputation.ts
+++ b/packages/identity-solana/src/registries/reputation.ts
@@ -52,21 +52,33 @@ export function createSolanaReputationRegistryClient(
 ): SolanaReputationRegistryClient {
   return {
     async getSummary(assetAddress) {
+      // Only return null when the agent genuinely has no reputation record.
+      // SDK/network failures are surfaced as errors so callers can distinguish
+      // "not found" from "service unavailable".
+      let indexerData: Record<string, unknown> | null | undefined;
       try {
-        // Use indexer-based reputation (avoids PublicKey construction in wrapper)
-        const indexerData = await (sdk as any).getAgentReputationFromIndexer(
+        indexerData = await (sdk as any).getAgentReputationFromIndexer(
           assetAddress as any
         );
-        if (!indexerData) return null;
-        return {
-          assetAddress,
-          score: indexerData.avg_score ?? null,
-          tier: String(indexerData.trust_tier ?? 'Unrated'),
-          feedbackCount: indexerData.feedback_count ?? 0,
-        };
-      } catch {
-        return null;
+      } catch (err: unknown) {
+        throw new Error(
+          `getSummary: failed to fetch reputation for asset ${assetAddress}: ` +
+            (err instanceof Error ? err.message : String(err))
+        );
       }
+      if (!indexerData) return null;
+      return {
+        assetAddress,
+        score:
+          typeof indexerData.avg_score === 'number'
+            ? indexerData.avg_score
+            : null,
+        tier: String(indexerData.trust_tier ?? 'Unrated'),
+        feedbackCount:
+          typeof indexerData.feedback_count === 'number'
+            ? indexerData.feedback_count
+            : 0,
+      };
     },
 
     async giveFeedback(opts) {

--- a/packages/identity-solana/src/registries/reputation.ts
+++ b/packages/identity-solana/src/registries/reputation.ts
@@ -2,47 +2,67 @@
  * Thin wrapper around 8004-solana's reputation capabilities.
  */
 
-import type { SolanaSDK as SolanaSDKType } from '8004-solana';
+// @ts-ignore — 8004-solana is a peer dependency
+import { SolanaSDK } from '8004-solana';
 
 export type SolanaReputationSummary = {
-  agentId: bigint | number;
-  score: number;
+  /** Agent's on-chain asset address */
+  assetAddress: string;
+  /** Average score (0-100) or null when no feedbacks yet */
+  score: number | null;
+  /** Trust tier name (Unrated, Bronze, Silver, Gold, Platinum) */
   tier: string;
   feedbackCount: number;
 };
 
 export type GiveFeedbackOptions = {
-  toAgentId: bigint | number;
-  value: number;
-  valueDecimals?: number;
+  /**
+   * Agent asset address (on-chain MPL Core asset pubkey, base58-encoded).
+   * When submitting feedback after a task, this is the agent that performed the work.
+   */
+  targetAddress: string;
+  /** Feedback score (0-100) */
+  score: number;
+  /** Optional comment / URI describing the feedback context */
+  comment?: string;
+  /** Optional tag1 metadata */
   tag1?: string;
+  /** Optional tag2 metadata */
   tag2?: string;
-  endpoint?: string;
+};
+
+export type RevokeFeedbackOptions = {
+  /** Agent asset address (base58-encoded) */
+  assetAddress: string;
+  /** Feedback index to revoke */
+  feedbackIndex: number | bigint;
 };
 
 export type SolanaReputationRegistryClient = {
-  getSummary(agentId: bigint | number): Promise<SolanaReputationSummary | null>;
+  getSummary(assetAddress: string): Promise<SolanaReputationSummary | null>;
   giveFeedback(opts: GiveFeedbackOptions): Promise<{ signature?: string }>;
-  revokeFeedback(feedbackId: string): Promise<{ signature?: string }>;
+  revokeFeedback(opts: RevokeFeedbackOptions): Promise<{ signature?: string }>;
 };
 
 /**
  * Create a Solana reputation registry client wrapping SolanaSDK.
  */
 export function createSolanaReputationRegistryClient(
-  sdk: SolanaSDKType
+  sdk: InstanceType<typeof SolanaSDK>
 ): SolanaReputationRegistryClient {
   return {
-    async getSummary(agentId) {
+    async getSummary(assetAddress) {
       try {
-        const summary = await sdk.getReputationSummary(BigInt(agentId));
-        if (!summary) return null;
-        const tier = await sdk.getTrustTier?.(BigInt(agentId));
+        // Use indexer-based reputation (avoids PublicKey construction in wrapper)
+        const indexerData = await (sdk as any).getAgentReputationFromIndexer(
+          assetAddress as any
+        );
+        if (!indexerData) return null;
         return {
-          agentId,
-          score: (summary as any)?.score ?? 0,
-          tier: String(tier ?? 'Unrated'),
-          feedbackCount: (summary as any)?.feedbackCount ?? 0,
+          assetAddress,
+          score: indexerData.avg_score ?? null,
+          tier: String(indexerData.trust_tier ?? 'Unrated'),
+          feedbackCount: indexerData.feedback_count ?? 0,
         };
       } catch {
         return null;
@@ -50,20 +70,31 @@ export function createSolanaReputationRegistryClient(
     },
 
     async giveFeedback(opts) {
-      const result = await sdk.giveFeedback({
-        toAgentId: BigInt(opts.toAgentId),
-        value: opts.value,
-        valueDecimals: opts.valueDecimals ?? 0,
-        tag1: opts.tag1 ?? '',
-        tag2: opts.tag2 ?? '',
-        endpoint: opts.endpoint ?? '',
-      } as any);
-      return { signature: (result as any)?.signature ?? (result as any)?.tx };
+      // sdk.giveFeedback(asset: PublicKey, params: GiveFeedbackParams, options?)
+      // We cast the address string to `any` to avoid importing PublicKey at build time.
+      const result = await (sdk as any).giveFeedback(
+        opts.targetAddress as any,
+        {
+          value: opts.score,
+          tag1: opts.tag1 ?? '',
+          tag2: opts.tag2 ?? '',
+          ...(opts.comment ? { metricUri: opts.comment } : {}),
+        }
+      );
+      return {
+        signature: (result as any)?.signature ?? (result as any)?.tx,
+      };
     },
 
-    async revokeFeedback(feedbackId) {
-      const result = await sdk.revokeFeedback?.(feedbackId as any);
-      return { signature: (result as any)?.signature ?? (result as any)?.tx };
+    async revokeFeedback(opts) {
+      // sdk.revokeFeedback(asset: PublicKey, feedbackIndex, sealHash?, options?)
+      const result = await (sdk as any).revokeFeedback(
+        opts.assetAddress as any,
+        opts.feedbackIndex
+      );
+      return {
+        signature: (result as any)?.signature ?? (result as any)?.tx,
+      };
     },
   };
 }

--- a/packages/identity-solana/src/validation.ts
+++ b/packages/identity-solana/src/validation.ts
@@ -73,6 +73,8 @@ export function validateSolanaIdentityConfig(
 /**
  * Narrow a SolanaIdentityConfig to confirm it has what's needed for registration.
  */
-export function hasRegistrationCapability(config: SolanaIdentityConfig): boolean {
+export function hasRegistrationCapability(
+  config: SolanaIdentityConfig
+): boolean {
   return Boolean(config.privateKey);
 }

--- a/packages/identity-solana/src/validation.ts
+++ b/packages/identity-solana/src/validation.ts
@@ -17,7 +17,8 @@ export function parseBoolean(
 
 /**
  * Parse a Solana private key from a JSON array string (Uint8Array serialized).
- * Returns null if not set or invalid.
+ * Returns null if not set, invalid JSON, not an array, or contains out-of-range values.
+ * Every element must be a finite integer in [0, 255].
  */
 export function parseSolanaPrivateKey(
   raw: string | undefined
@@ -26,6 +27,18 @@ export function parseSolanaPrivateKey(
   try {
     const arr = JSON.parse(raw);
     if (!Array.isArray(arr)) return null;
+    if (
+      !arr.every(
+        v =>
+          typeof v === 'number' &&
+          Number.isInteger(v) &&
+          Number.isFinite(v) &&
+          v >= 0 &&
+          v <= 255
+      )
+    ) {
+      return null;
+    }
     return new Uint8Array(arr);
   } catch {
     return null;
@@ -34,14 +47,16 @@ export function parseSolanaPrivateKey(
 
 /**
  * Resolve autoRegister from options and env, defaulting to true.
+ * Uses strict presence check (not truthiness) so `REGISTER_IDENTITY=false` is honoured.
  */
 export function resolveAutoRegister(
   options: { autoRegister?: boolean },
   env?: Record<string, string | undefined>
 ): boolean {
   if (options.autoRegister !== undefined) return options.autoRegister;
+  // Strict presence check: falsy values like "" and "false" must still be read
   const envVal =
-    typeof env === 'object' && env?.REGISTER_IDENTITY
+    typeof env === 'object' && env !== null && 'REGISTER_IDENTITY' in env
       ? env.REGISTER_IDENTITY
       : typeof process !== 'undefined'
         ? process.env?.REGISTER_IDENTITY
@@ -52,21 +67,24 @@ export function resolveAutoRegister(
 
 /**
  * Validate that a Solana identity config has the required fields.
- * Throws descriptive errors if required env vars are missing.
+ * Throws a descriptive error if domain is set but no private key is available,
+ * because on-chain registration requires signing.
  */
 export function validateSolanaIdentityConfig(
   options: { privateKey?: Uint8Array; cluster?: string; domain?: string },
   env?: Record<string, string | undefined>
 ): void {
-  // Private key validation (only required if actually registering)
   const hasPrivateKey =
     options.privateKey != null ||
     Boolean(env?.SOLANA_PRIVATE_KEY) ||
     Boolean(typeof process !== 'undefined' && process.env?.SOLANA_PRIVATE_KEY);
 
   if (!hasPrivateKey && options.domain) {
-    // Private key is needed to sign transactions — warn but don't throw
-    // (read-only operations work without it)
+    throw new Error(
+      '[identity-solana] SOLANA_PRIVATE_KEY is required when a domain is provided ' +
+        'because on-chain registration requires transaction signing. ' +
+        'Set options.privateKey or the SOLANA_PRIVATE_KEY environment variable.'
+    );
   }
 }
 

--- a/packages/identity-solana/src/validation.ts
+++ b/packages/identity-solana/src/validation.ts
@@ -1,0 +1,78 @@
+/**
+ * Validation helpers for Solana identity configuration.
+ */
+
+import type { SolanaIdentityConfig } from './env';
+
+/**
+ * Parse a boolean from a string env var.
+ */
+export function parseBoolean(
+  value: string | undefined,
+  defaultValue = false
+): boolean {
+  if (value === undefined || value === '') return defaultValue;
+  return value.toLowerCase() === 'true' || value === '1';
+}
+
+/**
+ * Parse a Solana private key from a JSON array string (Uint8Array serialized).
+ * Returns null if not set or invalid.
+ */
+export function parseSolanaPrivateKey(
+  raw: string | undefined
+): Uint8Array | null {
+  if (!raw) return null;
+  try {
+    const arr = JSON.parse(raw);
+    if (!Array.isArray(arr)) return null;
+    return new Uint8Array(arr);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve autoRegister from options and env, defaulting to true.
+ */
+export function resolveAutoRegister(
+  options: { autoRegister?: boolean },
+  env?: Record<string, string | undefined>
+): boolean {
+  if (options.autoRegister !== undefined) return options.autoRegister;
+  const envVal =
+    typeof env === 'object' && env?.REGISTER_IDENTITY
+      ? env.REGISTER_IDENTITY
+      : typeof process !== 'undefined'
+        ? process.env?.REGISTER_IDENTITY
+        : undefined;
+  if (envVal !== undefined) return parseBoolean(envVal, true);
+  return true;
+}
+
+/**
+ * Validate that a Solana identity config has the required fields.
+ * Throws descriptive errors if required env vars are missing.
+ */
+export function validateSolanaIdentityConfig(
+  options: { privateKey?: Uint8Array; cluster?: string; domain?: string },
+  env?: Record<string, string | undefined>
+): void {
+  // Private key validation (only required if actually registering)
+  const hasPrivateKey =
+    options.privateKey != null ||
+    Boolean(env?.SOLANA_PRIVATE_KEY) ||
+    Boolean(typeof process !== 'undefined' && process.env?.SOLANA_PRIVATE_KEY);
+
+  if (!hasPrivateKey && options.domain) {
+    // Private key is needed to sign transactions — warn but don't throw
+    // (read-only operations work without it)
+  }
+}
+
+/**
+ * Narrow a SolanaIdentityConfig to confirm it has what's needed for registration.
+ */
+export function hasRegistrationCapability(config: SolanaIdentityConfig): boolean {
+  return Boolean(config.privateKey);
+}

--- a/packages/identity-solana/tsconfig.build.json
+++ b/packages/identity-solana/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../tsconfig.build.base.json",
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts", "**/__tests__/**"]
+}

--- a/packages/identity-solana/tsconfig.json
+++ b/packages/identity-solana/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "resolveJsonModule": true,
+    "composite": true
+  },
+  "include": [
+    "src/**/*",
+    "src/**/*.json"
+  ]
+}

--- a/packages/identity-solana/tsconfig.json
+++ b/packages/identity-solana/tsconfig.json
@@ -5,8 +5,5 @@
     "resolveJsonModule": true,
     "composite": true
   },
-  "include": [
-    "src/**/*",
-    "src/**/*.json"
-  ]
+  "include": ["src/**/*", "src/**/*.json"]
 }

--- a/packages/identity-solana/tsup.config.ts
+++ b/packages/identity-solana/tsup.config.ts
@@ -1,18 +1,18 @@
-import { definePackageConfig } from "../tsup.config.base";
+import { definePackageConfig } from '../tsup.config.base';
 
 export default definePackageConfig({
   entry: {
-    index: "src/index.ts",
+    index: 'src/index.ts',
   },
   dts: {
     entry: {
-      index: "src/index.ts",
+      index: 'src/index.ts',
     },
   },
   external: [
-    "8004-solana",
-    "@solana/web3.js",
-    "@lucid-agents/core",
-    "@lucid-agents/types",
+    '8004-solana',
+    '@solana/web3.js',
+    '@lucid-agents/core',
+    '@lucid-agents/types',
   ],
 });

--- a/packages/identity-solana/tsup.config.ts
+++ b/packages/identity-solana/tsup.config.ts
@@ -1,0 +1,18 @@
+import { definePackageConfig } from "../tsup.config.base";
+
+export default definePackageConfig({
+  entry: {
+    index: "src/index.ts",
+  },
+  dts: {
+    entry: {
+      index: "src/index.ts",
+    },
+  },
+  external: [
+    "8004-solana",
+    "@solana/web3.js",
+    "@lucid-agents/core",
+    "@lucid-agents/types",
+  ],
+});


### PR DESCRIPTION
## Summary

Adds `@lucid-agents/identity-solana` — Solana identity for the Lucid SDK, mirroring the `@lucid-agents/identity` (EVM/ERC-8004) API.

## What's included

### Package: `packages/identity-solana/`

**Exports:**
- `identitySolana()` — Extension for `.use()` (mirrors `identity()`)
- `identitySolanaFromEnv()` — config from env vars
- `createSolanaAgentIdentity()` — core registration function
- `SolanaRegistryClients` — identity + reputation clients
- `createAgentCardWithSolanaIdentity()` — manifest builder
- `skipSend` support for browser wallets

Uses `8004-solana` + `@solana/web3.js` as peer dep (never bundled into EVM packages). Maps `SolanaSDK TrustTier` into `@lucid-agents/types/identity TrustConfig` so the Lucid stack works unchanged.

**Env vars:** `SOLANA_PRIVATE_KEY` (JSON array), `SOLANA_CLUSTER` (default: mainnet-beta), `SOLANA_RPC_URL`, `AGENT_DOMAIN`, `REGISTER_IDENTITY`, `PINATA_JWT`, `ATOM_ENABLED`

### Tests: **65/65 passing, 0 skipped**

```
bun test packages/identity-solana
65 pass | 0 fail | 91 expect() calls | 101ms
```

Covers: env parsing, manifest immutability, registry client ops (SolanaSDK fully mocked), extension lifecycle (.use() contract, build/onBuild/onManifestBuild), createSolanaAgentIdentity, TrustTier mapping.

### Working example: `packages/examples/src/solana-identity.ts`
Registers on devnet, serves paid `analyze-distribution` endpoint ($0.01 USDC x402), gives reputation feedback after task completion. 3 passing example tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced @lucid-agents/identity-solana for Solana identity & reputation (multi-cluster support, browser-wallet unsigned txs)
  * On-chain agent registration with optional auto-register and reputation feedback flows
  * Example Solana identity agent server with a free health endpoint and a paid analyze-distribution entrypoint

* **Documentation**
  * Added comprehensive README and quick-start for the Solana identity package
<!-- end of auto-generated comment: release notes by coderabbit.ai -->