### PR TITLE
feat: add @lucid-agents/xmpt agent-to-agent messaging extension

### DIFF
--- a/packages/examples/src/xmpt-messaging.ts
+++ b/packages/examples/src/xmpt-messaging.ts
@@ -1,0 +1,132 @@
+/**
+ * @example XMPT Messaging — Agent-to-Agent Communication
+ *
+ * This example demonstrates how two agents can exchange messages using the
+ * @lucid-agents/xmpt extension.
+ *
+ * In a real deployment:
+ * - Each agent runs on its own HTTP server
+ * - The server routes POST /xmpt-inbox → runtime.xmpt.receive(message)
+ * - Peers discover each other via Agent Cards
+ *
+ * This file shows the core API patterns.
+ */
+
+// import { createAgent } from '@lucid-agents/core';
+import { createXMPTRuntime, createMemoryStore, xmpt } from '@lucid-agents/xmpt';
+
+// ---------------------------------------------------------------------------
+// Pattern 1: Low-level runtime usage (no framework)
+// ---------------------------------------------------------------------------
+
+async function lowLevelExample() {
+  // Create an in-memory store
+  const store = createMemoryStore();
+
+  // Create a runtime for "beta" agent that echoes messages
+  const betaRuntime = createXMPTRuntime({
+    store,
+    handler: async ({ message }) => {
+      console.log('[beta] received:', message.content.text);
+      return {
+        content: { text: `echo: ${message.content.text}` },
+      };
+    },
+  });
+
+  // Register an additional handler dynamically
+  const unsub = betaRuntime.onMessage(async ({ message }) => {
+    console.log('[beta] audit log:', message.id);
+  });
+
+  // Simulate alpha sending a message to beta (in production, this goes over HTTP)
+  const alphaRuntime = createXMPTRuntime({
+    // In production, use the real global fetch
+    fetchFn: async (url, init) => {
+      // Simulate routing to beta's inbox handler
+      const body = JSON.parse((init?.body as string) ?? '{}');
+      const result = await betaRuntime.receive(body);
+      return new Response(JSON.stringify(result ?? {}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    },
+  });
+
+  // Send a fire-and-forget message
+  const delivery = await alphaRuntime.send(
+    { url: 'http://beta.local' },
+    { content: { text: 'hello beta!' }, threadId: 'thread-001' }
+  );
+  console.log('[alpha] delivery:', delivery.status, delivery.messageId);
+
+  // Send and wait for a reply
+  const reply = await alphaRuntime.sendAndWait(
+    { url: 'http://beta.local' },
+    { content: { text: 'ping' }, threadId: 'thread-001' },
+    { timeoutMs: 5000 }
+  );
+  console.log('[alpha] reply:', reply?.content.text);
+
+  // List messages in thread
+  const thread = await betaRuntime.listMessages({ threadId: 'thread-001' });
+  console.log('[beta] thread messages:', thread.length);
+
+  // Cleanup dynamic handler
+  unsub();
+}
+
+// ---------------------------------------------------------------------------
+// Pattern 2: Extension-based usage with createAgent()
+// ---------------------------------------------------------------------------
+
+async function extensionExample() {
+  /**
+   * In a real app, you'd use createAgent from @lucid-agents/core:
+   *
+   * ```ts
+   * import { createAgent } from '@lucid-agents/core';
+   * import { xmpt } from '@lucid-agents/xmpt';
+   *
+   * const runtime = await createAgent({ name: 'alpha', version: '0.1.0' })
+   *   .use(xmpt({
+   *     inbox: {
+   *       key: 'xmpt-inbox',    // optional: default is 'xmpt-inbox'
+   *       handler: async ({ message }) => {
+   *         return { content: { text: `ack: ${message.content.text}` } };
+   *       },
+   *     },
+   *   }))
+   *   .build();
+   *
+   * // The runtime now has an xmpt slice
+   * await runtime.xmpt.send(
+   *   { url: 'http://other-agent.example.com' },
+   *   { content: { text: 'hello!' } }
+   * );
+   * ```
+   *
+   * The extension also registers an "XMPT Inbox" skill in the agent card,
+   * making the agent discoverable to other XMPT-capable agents.
+   */
+
+  // Show the extension object shape
+  const ext = xmpt({
+    inbox: {
+      handler: async ({ message }) => {
+        return { content: { text: `ack: ${message.content.text}` } };
+      },
+    },
+  });
+
+  console.log('[ext] name:', ext.name);
+  console.log('[ext] has build:', typeof ext.build === 'function');
+  console.log('[ext] has onManifestBuild:', typeof ext.onManifestBuild === 'function');
+}
+
+// ---------------------------------------------------------------------------
+// Run examples
+// ---------------------------------------------------------------------------
+
+await lowLevelExample();
+await extensionExample();

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -56,6 +56,11 @@
       "import": "./dist/wallets/index.js",
       "default": "./dist/wallets/index.js"
     },
+    "./xmpt": {
+      "types": "./dist/xmpt/index.d.ts",
+      "import": "./dist/xmpt/index.js",
+      "default": "./dist/xmpt/index.js"
+    },
     "./package.json": "./package.json"
   },
   "sideEffects": false,

--- a/packages/types/src/core/runtime.ts
+++ b/packages/types/src/core/runtime.ts
@@ -8,6 +8,7 @@ import type { EntrypointsRuntime } from './entrypoint';
 import type { AnalyticsRuntime } from '../analytics';
 import type { SchedulerRuntime } from '../scheduler';
 import type { AgentCore } from './agent';
+import type { XMPTRuntime } from '../xmpt';
 
 /**
  * Agent runtime interface.
@@ -27,6 +28,7 @@ export type AgentRuntime = {
   a2a?: A2ARuntime;
   ap2?: AP2Runtime;
   scheduler?: SchedulerRuntime;
+  xmpt?: XMPTRuntime;
   handlers?: AgentHttpHandlers;
   entrypoints: EntrypointsRuntime;
   manifest: ManifestRuntime;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,6 +1,7 @@
 export * from './core';
 export type { BuildContext } from './core';
 export type { Extension } from './core';
+export * from './xmpt/index';
 export * from './a2a';
 export * from './analytics';
 export * from './ap2';

--- a/packages/types/src/xmpt/index.ts
+++ b/packages/types/src/xmpt/index.ts
@@ -1,0 +1,50 @@
+import type { AgentCard } from '../a2a';
+
+export type XMPTContent = {
+  text?: string;
+  data?: unknown;
+  mime?: string;
+};
+
+export type XMPTMessage = {
+  id: string;
+  threadId?: string;
+  from?: string;
+  to?: string;
+  content: XMPTContent;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+};
+
+export type XMPTPeer = { url: string } | { card: AgentCard };
+
+export type XMPTDeliveryResult = {
+  taskId: string;
+  status: string;
+  messageId: string;
+};
+
+export type XMPTInboxHandler = (ctx: {
+  message: XMPTMessage;
+}) => Promise<{ content: XMPTContent } | void>;
+
+export type XMPTStore = {
+  save(message: XMPTMessage): Promise<void>;
+  list(filter?: { threadId?: string }): Promise<XMPTMessage[]>;
+};
+
+export type XMPTRuntime = {
+  send(
+    peer: XMPTPeer,
+    message: Omit<XMPTMessage, 'id' | 'createdAt'>,
+    options?: { timeoutMs?: number }
+  ): Promise<XMPTDeliveryResult>;
+  sendAndWait(
+    peer: XMPTPeer,
+    message: Omit<XMPTMessage, 'id' | 'createdAt'>,
+    options?: { timeoutMs?: number }
+  ): Promise<XMPTMessage | null>;
+  receive(message: XMPTMessage): Promise<{ content: XMPTContent } | void>;
+  onMessage(handler: XMPTInboxHandler): () => void;
+  listMessages(filter?: { threadId?: string }): Promise<XMPTMessage[]>;
+};

--- a/packages/xmpt/README.md
+++ b/packages/xmpt/README.md
@@ -1,0 +1,132 @@
+# @lucid-agents/xmpt
+
+Agent-to-agent messaging extension for the [Lucid SDK](https://github.com/daydreamsai/lucid-agents).
+
+## Overview
+
+`@lucid-agents/xmpt` provides a composable extension that enables direct agent-to-agent (A2A) messaging via a lightweight XMPT (eXtensible Message Protocol Transport) inbox. Agents can send messages to peers by URL or Agent Card, receive and reply to inbound messages, and maintain a persistent or in-memory message store.
+
+## Installation
+
+```bash
+bun add @lucid-agents/xmpt
+```
+
+## Usage
+
+### Basic Setup
+
+```typescript
+import { createAgent } from '@lucid-agents/core';
+import { xmpt } from '@lucid-agents/xmpt';
+
+const runtime = await createAgent({ name: 'alpha', version: '0.1.0' })
+  .use(
+    xmpt({
+      inbox: {
+        handler: async ({ message }) => {
+          console.log('Received:', message.content.text);
+          return {
+            content: { text: `ack: ${message.content.text}` },
+          };
+        },
+      },
+    })
+  )
+  .build();
+
+// Send a message to another agent
+const result = await runtime.xmpt.send(
+  { url: 'http://other-agent.example.com' },
+  { content: { text: 'hello from alpha' } }
+);
+console.log('Delivered:', result.status);
+```
+
+### Send and Wait for Reply
+
+```typescript
+const reply = await runtime.xmpt.sendAndWait(
+  { url: 'http://other-agent.example.com' },
+  { content: { text: 'ping' }, threadId: 'thread-123' },
+  { timeoutMs: 5000 }
+);
+if (reply) {
+  console.log('Reply:', reply.content.text);
+}
+```
+
+### Subscribe to Incoming Messages
+
+```typescript
+const unsubscribe = runtime.xmpt.onMessage(async ({ message }) => {
+  console.log('Got message from', message.from, ':', message.content.text);
+});
+
+// Later, unsubscribe:
+unsubscribe();
+```
+
+### List Messages
+
+```typescript
+// All messages
+const all = await runtime.xmpt.listMessages();
+
+// Filter by thread
+const thread = await runtime.xmpt.listMessages({ threadId: 'thread-123' });
+```
+
+### Peer-by-Agent-Card
+
+```typescript
+import { type AgentCard } from '@lucid-agents/types';
+
+const card: AgentCard = {
+  name: 'beta-agent',
+  url: 'http://beta.example.com',
+};
+
+await runtime.xmpt.send({ card }, { content: { text: 'hi beta' } });
+```
+
+## API
+
+### `xmpt(options?: XMPTConfig): Extension<{ xmpt: XMPTRuntime }>`
+
+Creates the XMPT extension.
+
+**Options:**
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `inbox.key` | `string` | Custom inbox route key (default: `'xmpt-inbox'`) |
+| `inbox.handler` | `XMPTInboxHandler` | Default handler for incoming messages |
+| `store` | `XMPTStore` | Custom message store (default: in-memory) |
+
+### `XMPTRuntime`
+
+| Method | Description |
+|--------|-------------|
+| `send(peer, message, options?)` | Send a message to a peer, returns delivery result |
+| `sendAndWait(peer, message, options?)` | Send and wait for a reply, returns reply message or null |
+| `receive(message)` | Process an inbound message through registered handlers |
+| `onMessage(handler)` | Register a handler, returns unsubscribe function |
+| `listMessages(filter?)` | List stored messages, optionally filtered by `threadId` |
+
+### `createXMPTRuntime(options)`
+
+Low-level factory for creating an XMPT runtime without the extension wrapper. Useful for testing and custom integrations.
+
+```typescript
+import { createXMPTRuntime, createMemoryStore } from '@lucid-agents/xmpt';
+
+const runtime = createXMPTRuntime({
+  store: createMemoryStore(),
+  fetchFn: customFetch, // injectable for testing
+});
+```
+
+## License
+
+MIT

--- a/packages/xmpt/package.json
+++ b/packages/xmpt/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@lucid-agents/xmpt",
+  "version": "0.1.0",
+  "description": "Agent-to-agent messaging extension for Lucid SDK",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/daydreamsai/lucid-agents",
+    "directory": "packages/xmpt"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "files": ["dist", "README.md"],
+  "publishConfig": { "access": "public" },
+  "scripts": {
+    "build": "tsup",
+    "clean": "rm -rf dist",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@lucid-agents/types": "workspace:*"
+  },
+  "devDependencies": {
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "@types/bun": "latest",
+    "@lucid-agents/eslint-config": "workspace:*",
+    "@lucid-agents/prettier-config": "workspace:*"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/xmpt/src/__tests__/xmpt.test.ts
+++ b/packages/xmpt/src/__tests__/xmpt.test.ts
@@ -1,0 +1,370 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import type {
+  XMPTMessage,
+  XMPTPeer,
+  XMPTContent,
+} from '@lucid-agents/types/xmpt';
+import { createMemoryStore } from '../store/memory';
+import { createXMPTRuntime } from '../runtime';
+import { xmpt } from '../extension';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMessage(overrides: Partial<XMPTMessage> = {}): XMPTMessage {
+  return {
+    id: 'msg-1',
+    content: { text: 'hello' },
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeFetch(
+  status: number,
+  body: unknown
+): typeof fetch {
+  return async (_url: RequestInfo | URL, _init?: RequestInit) => {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    } as Response;
+  };
+}
+
+function makeFailFetch(): typeof fetch {
+  return async () => {
+    throw new Error('network error');
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Types — shape validation at runtime (structural checks)
+// ---------------------------------------------------------------------------
+
+describe('Types', () => {
+  it('XMPTMessage has required fields', () => {
+    const msg: XMPTMessage = {
+      id: 'test-id',
+      content: { text: 'hi' },
+      createdAt: new Date().toISOString(),
+    };
+    expect(msg.id).toBe('test-id');
+    expect(msg.content.text).toBe('hi');
+    expect(typeof msg.createdAt).toBe('string');
+  });
+
+  it('XMPTPeer accepts url variant', () => {
+    const peer: XMPTPeer = { url: 'http://localhost:3000' };
+    expect('url' in peer).toBe(true);
+    if ('url' in peer) {
+      expect(peer.url).toBe('http://localhost:3000');
+    }
+  });
+
+  it('XMPTContent fields are all optional', () => {
+    const empty: XMPTContent = {};
+    const full: XMPTContent = { text: 'hi', data: { foo: 1 }, mime: 'application/json' };
+    expect(empty.text).toBeUndefined();
+    expect(full.text).toBe('hi');
+    expect(full.mime).toBe('application/json');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. MemoryStore
+// ---------------------------------------------------------------------------
+
+describe('MemoryStore', () => {
+  it('saves and lists messages', async () => {
+    const store = createMemoryStore();
+    const msg = makeMessage();
+    await store.save(msg);
+    const list = await store.list();
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe('msg-1');
+  });
+
+  it('filters by threadId', async () => {
+    const store = createMemoryStore();
+    await store.save(makeMessage({ id: 'a', threadId: 'thread-1' }));
+    await store.save(makeMessage({ id: 'b', threadId: 'thread-2' }));
+    await store.save(makeMessage({ id: 'c', threadId: 'thread-1' }));
+
+    const t1 = await store.list({ threadId: 'thread-1' });
+    expect(t1).toHaveLength(2);
+    expect(t1.map((m) => m.id)).toEqual(['a', 'c']);
+  });
+
+  it('returns empty list initially', async () => {
+    const store = createMemoryStore();
+    const list = await store.list();
+    expect(list).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Runtime — receive
+// ---------------------------------------------------------------------------
+
+describe('Runtime - receive', () => {
+  it('calls registered handler with message', async () => {
+    let received: XMPTMessage | null = null;
+    const rt = createXMPTRuntime({
+      handler: async ({ message }) => {
+        received = message;
+      },
+    });
+    const msg = makeMessage({ id: 'rx-1' });
+    await rt.receive(msg);
+    expect(received).not.toBeNull();
+    expect((received as XMPTMessage | null)?.id).toBe('rx-1');
+  });
+
+  it('stores received message', async () => {
+    const store = createMemoryStore();
+    const rt = createXMPTRuntime({ store });
+    const msg = makeMessage({ id: 'stored-1' });
+    await rt.receive(msg);
+    const list = await store.list();
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe('stored-1');
+  });
+
+  it('does not crash with no handlers', async () => {
+    const rt = createXMPTRuntime({});
+    const msg = makeMessage({ id: 'no-handler' });
+    // Should not throw
+    const result = await rt.receive(msg);
+    expect(result).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Runtime — onMessage
+// ---------------------------------------------------------------------------
+
+describe('Runtime - onMessage', () => {
+  it('registers a handler that receives messages', async () => {
+    const rt = createXMPTRuntime({});
+    const received: XMPTMessage[] = [];
+    rt.onMessage(async ({ message }) => {
+      received.push(message);
+    });
+    await rt.receive(makeMessage({ id: 'om-1' }));
+    expect(received).toHaveLength(1);
+    expect(received[0].id).toBe('om-1');
+  });
+
+  it('unsubscribes correctly', async () => {
+    const rt = createXMPTRuntime({});
+    const received: XMPTMessage[] = [];
+    const unsub = rt.onMessage(async ({ message }) => {
+      received.push(message);
+    });
+    await rt.receive(makeMessage({ id: 'before-unsub' }));
+    unsub();
+    await rt.receive(makeMessage({ id: 'after-unsub' }));
+    expect(received).toHaveLength(1);
+    expect(received[0].id).toBe('before-unsub');
+  });
+
+  it('multiple handlers called in order', async () => {
+    const rt = createXMPTRuntime({});
+    const order: string[] = [];
+    rt.onMessage(async () => { order.push('first'); });
+    rt.onMessage(async () => { order.push('second'); });
+    await rt.receive(makeMessage());
+    expect(order).toEqual(['first', 'second']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Runtime — send
+// ---------------------------------------------------------------------------
+
+describe('Runtime - send', () => {
+  it('POSTs to the correct inbox URL', async () => {
+    let capturedUrl = '';
+    const fetchFn: typeof fetch = async (url, _init) => {
+      capturedUrl = url.toString();
+      return { ok: true, status: 200, json: async () => ({}) } as Response;
+    };
+    const rt = createXMPTRuntime({ fetchFn });
+    await rt.send({ url: 'http://peer.example.com' }, { content: { text: 'test' } });
+    expect(capturedUrl).toBe('http://peer.example.com/xmpt-inbox');
+  });
+
+  it('stores the outbound message', async () => {
+    const store = createMemoryStore();
+    const rt = createXMPTRuntime({ store, fetchFn: makeFetch(200, {}) });
+    await rt.send({ url: 'http://peer.example.com' }, { content: { text: 'outbound' } });
+    const list = await store.list();
+    expect(list).toHaveLength(1);
+    expect(list[0].content.text).toBe('outbound');
+  });
+
+  it('returns a delivery result with correct status', async () => {
+    const rt = createXMPTRuntime({ fetchFn: makeFetch(200, { taskId: 'task-xyz' }) });
+    const result = await rt.send({ url: 'http://peer.example.com' }, { content: { text: 'hi' } });
+    expect(result.status).toBe('delivered');
+    expect(result.taskId).toBe('task-xyz');
+    expect(typeof result.messageId).toBe('string');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Runtime — sendAndWait
+// ---------------------------------------------------------------------------
+
+describe('Runtime - sendAndWait', () => {
+  it('returns reply message on success', async () => {
+    const replyContent: XMPTContent = { text: 'pong' };
+    const rt = createXMPTRuntime({ fetchFn: makeFetch(200, { content: replyContent }) });
+    const reply = await rt.sendAndWait(
+      { url: 'http://peer.example.com' },
+      { content: { text: 'ping' } }
+    );
+    expect(reply).not.toBeNull();
+    expect(reply?.content.text).toBe('pong');
+  });
+
+  it('returns null on fetch failure', async () => {
+    const rt = createXMPTRuntime({ fetchFn: makeFailFetch() });
+    const reply = await rt.sendAndWait(
+      { url: 'http://peer.example.com' },
+      { content: { text: 'ping' } }
+    );
+    expect(reply).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Runtime — listMessages
+// ---------------------------------------------------------------------------
+
+describe('Runtime - listMessages', () => {
+  it('returns all stored messages', async () => {
+    const store = createMemoryStore();
+    const rt = createXMPTRuntime({ store });
+    await rt.receive(makeMessage({ id: 'lm-1' }));
+    await rt.receive(makeMessage({ id: 'lm-2' }));
+    const list = await rt.listMessages();
+    expect(list).toHaveLength(2);
+  });
+
+  it('filters by threadId', async () => {
+    const store = createMemoryStore();
+    const rt = createXMPTRuntime({ store });
+    await rt.receive(makeMessage({ id: 'lm-a', threadId: 'thread-A' }));
+    await rt.receive(makeMessage({ id: 'lm-b', threadId: 'thread-B' }));
+    const threadA = await rt.listMessages({ threadId: 'thread-A' });
+    expect(threadA).toHaveLength(1);
+    expect(threadA[0].id).toBe('lm-a');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Extension
+// ---------------------------------------------------------------------------
+
+describe('Extension', () => {
+  it('build() returns xmpt runtime slice', () => {
+    const ext = xmpt();
+    const ctx = { meta: { name: 'test', version: '0.1.0' }, runtime: {} };
+    const slice = ext.build(ctx as any);
+    expect(slice.xmpt).toBeDefined();
+    expect(typeof slice.xmpt.send).toBe('function');
+    expect(typeof slice.xmpt.receive).toBe('function');
+  });
+
+  it('adds xmpt-inbox skill to manifest card', () => {
+    const ext = xmpt();
+    const ctx = { meta: { name: 'test', version: '0.1.0' }, runtime: {} };
+    ext.build(ctx as any);
+    const card = {
+      name: 'test-agent',
+      entrypoints: [],
+      skills: [],
+    } as any;
+    const updated = ext.onManifestBuild!(card, {} as any);
+    const skill = updated.skills?.find((s: any) => s.id === 'xmpt-inbox');
+    expect(skill).toBeDefined();
+    expect(skill?.name).toBe('XMPT Inbox');
+  });
+
+  it('uses default inbox key of "xmpt-inbox"', () => {
+    const ext = xmpt();
+    const ctx = { meta: { name: 'test', version: '0.1.0' }, runtime: {} };
+    ext.build(ctx as any);
+    const card = { name: 'test', entrypoints: [], skills: [] } as any;
+    const updated = ext.onManifestBuild!(card, {} as any);
+    expect(updated.skills?.some((s: any) => s.id === 'xmpt-inbox')).toBe(true);
+  });
+
+  it('uses custom inbox key when provided', () => {
+    const ext = xmpt({ inbox: { key: 'my-custom-inbox' } });
+    const ctx = { meta: { name: 'test', version: '0.1.0' }, runtime: {} };
+    ext.build(ctx as any);
+    const card = { name: 'test', entrypoints: [], skills: [] } as any;
+    const updated = ext.onManifestBuild!(card, {} as any);
+    expect(updated.skills?.some((s: any) => s.id === 'my-custom-inbox')).toBe(true);
+    expect(updated.skills?.some((s: any) => s.id === 'xmpt-inbox')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Integration
+// ---------------------------------------------------------------------------
+
+describe('Integration', () => {
+  it('two runtimes exchange messages via mocked fetch', async () => {
+    // "beta" runtime receives messages
+    const betaStore = createMemoryStore();
+    const betaRuntime = createXMPTRuntime({
+      store: betaStore,
+      handler: async ({ message }) => ({
+        content: { text: `ack:${message.content.text}` },
+      }),
+    });
+
+    // Mock fetch routes alpha's POST to beta's receive
+    const mockFetch: typeof fetch = async (_url, init) => {
+      const body = JSON.parse((init?.body as string) ?? '{}') as XMPTMessage;
+      const result = await betaRuntime.receive(body);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => result ?? {},
+      } as Response;
+    };
+
+    const alphaRuntime = createXMPTRuntime({ fetchFn: mockFetch });
+    const deliveryResult = await alphaRuntime.send(
+      { url: 'http://beta.example.com' },
+      { content: { text: 'hello beta' } }
+    );
+
+    expect(deliveryResult.status).toBe('delivered');
+
+    const betaMessages = await betaStore.list();
+    expect(betaMessages).toHaveLength(1);
+    expect(betaMessages[0].content.text).toBe('hello beta');
+  });
+
+  it('threadId is preserved across send and receive', async () => {
+    const store = createMemoryStore();
+    const rt = createXMPTRuntime({ store, fetchFn: makeFetch(200, {}) });
+
+    await rt.send(
+      { url: 'http://peer.example.com' },
+      { content: { text: 'message in thread' }, threadId: 'thread-preserve' }
+    );
+
+    const list = await rt.listMessages({ threadId: 'thread-preserve' });
+    expect(list).toHaveLength(1);
+    expect(list[0].threadId).toBe('thread-preserve');
+  });
+});

--- a/packages/xmpt/src/extension.ts
+++ b/packages/xmpt/src/extension.ts
@@ -1,0 +1,48 @@
+import type { AgentCardWithEntrypoints } from '@lucid-agents/types/a2a';
+import type { AgentRuntime, BuildContext, Extension } from '@lucid-agents/types/core';
+import type { XMPTInboxHandler, XMPTRuntime, XMPTStore } from '@lucid-agents/types/xmpt';
+import { createXMPTRuntime } from './runtime';
+
+export type XMPTConfig = {
+  inbox?: {
+    key?: string;
+    handler?: XMPTInboxHandler;
+  };
+  store?: XMPTStore;
+};
+
+export function xmpt(options?: XMPTConfig): Extension<{ xmpt: XMPTRuntime }> {
+  let xmptRuntime: XMPTRuntime;
+  const inboxKey = options?.inbox?.key ?? 'xmpt-inbox';
+
+  return {
+    name: 'xmpt',
+    build(_ctx: BuildContext): { xmpt: XMPTRuntime } {
+      xmptRuntime = createXMPTRuntime({
+        inboxKey,
+        handler: options?.inbox?.handler,
+        store: options?.store,
+      });
+      return { xmpt: xmptRuntime };
+    },
+    onManifestBuild(
+      card: AgentCardWithEntrypoints,
+      _runtime: AgentRuntime
+    ): AgentCardWithEntrypoints {
+      // Add xmpt-inbox skill to manifest for discoverability
+      const skills = (card.skills ?? []).filter((s) => s.id !== inboxKey);
+      return {
+        ...card,
+        skills: [
+          ...skills,
+          {
+            id: inboxKey,
+            name: 'XMPT Inbox',
+            description: 'Agent-to-agent message inbox (XMPT)',
+            tags: ['xmpt', 'messaging', 'inbox'],
+          },
+        ],
+      };
+    },
+  };
+}

--- a/packages/xmpt/src/index.ts
+++ b/packages/xmpt/src/index.ts
@@ -1,0 +1,3 @@
+export { xmpt, type XMPTConfig } from './extension';
+export { createXMPTRuntime } from './runtime';
+export { createMemoryStore } from './store/memory';

--- a/packages/xmpt/src/runtime.ts
+++ b/packages/xmpt/src/runtime.ts
@@ -1,0 +1,127 @@
+import type {
+  XMPTContent,
+  XMPTDeliveryResult,
+  XMPTInboxHandler,
+  XMPTMessage,
+  XMPTPeer,
+  XMPTRuntime,
+  XMPTStore,
+} from '@lucid-agents/types/xmpt';
+import { createMemoryStore } from './store/memory';
+
+function generateId(): string {
+  return `xmpt-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function getPeerUrl(peer: XMPTPeer): string {
+  if ('url' in peer) return peer.url;
+  // card-based peer: extract url from card
+  const card = peer.card as Record<string, unknown>;
+  return (card.url as string) ?? (card.endpoint as string) ?? '';
+}
+
+export function createXMPTRuntime(options: {
+  inboxKey?: string;
+  handler?: XMPTInboxHandler;
+  store?: XMPTStore;
+  fetchFn?: typeof fetch;
+}): XMPTRuntime {
+  const store = options.store ?? createMemoryStore();
+  const fetchFn = options.fetchFn ?? fetch;
+  const handlers: XMPTInboxHandler[] = options.handler ? [options.handler] : [];
+  const inboxKey = options.inboxKey ?? 'xmpt-inbox';
+
+  return {
+    async send(
+      peer: XMPTPeer,
+      msg: Omit<XMPTMessage, 'id' | 'createdAt'>,
+      _options?: { timeoutMs?: number }
+    ): Promise<XMPTDeliveryResult> {
+      const message: XMPTMessage = {
+        ...msg,
+        id: generateId(),
+        createdAt: new Date().toISOString(),
+      };
+      await store.save(message);
+
+      const peerUrl = getPeerUrl(peer);
+      const inboxUrl = `${peerUrl.replace(/\/$/, '')}/${inboxKey}`;
+
+      const res = await fetchFn(inboxUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(message),
+      });
+
+      const body: unknown = res.ok ? await res.json().catch(() => ({})) : {};
+      return {
+        taskId: (body as Record<string, unknown>)?.taskId as string ?? message.id,
+        status: res.ok ? 'delivered' : 'failed',
+        messageId: message.id,
+      };
+    },
+
+    async sendAndWait(
+      peer: XMPTPeer,
+      msg: Omit<XMPTMessage, 'id' | 'createdAt'>,
+      options?: { timeoutMs?: number }
+    ): Promise<XMPTMessage | null> {
+      const message: XMPTMessage = {
+        ...msg,
+        id: generateId(),
+        createdAt: new Date().toISOString(),
+      };
+      await store.save(message);
+
+      const peerUrl = getPeerUrl(peer);
+      const inboxUrl = `${peerUrl.replace(/\/$/, '')}/${inboxKey}`;
+
+      const controller = new AbortController();
+      const timer = options?.timeoutMs
+        ? setTimeout(() => controller.abort(), options.timeoutMs)
+        : null;
+
+      try {
+        const res = await fetchFn(inboxUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(message),
+          signal: controller.signal,
+        });
+        if (!res.ok) return null;
+        const reply: unknown = await res.json().catch(() => null);
+        if (!reply) return null;
+        return {
+          id: generateId(),
+          threadId: message.threadId,
+          content: (reply as Record<string, unknown>)?.content as XMPTContent ?? reply as XMPTContent,
+          createdAt: new Date().toISOString(),
+        };
+      } catch {
+        return null;
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    },
+
+    async receive(message: XMPTMessage): Promise<{ content: XMPTContent } | void> {
+      await store.save(message);
+      for (const handler of handlers) {
+        const result = await handler({ message });
+        if (result) return result;
+      }
+    },
+
+    onMessage(handler: XMPTInboxHandler): () => void {
+      handlers.push(handler);
+      return () => {
+        const idx = handlers.indexOf(handler);
+        if (idx !== -1) handlers.splice(idx, 1);
+      };
+    },
+
+    async listMessages(filter?: { threadId?: string }): Promise<XMPTMessage[]> {
+      return store.list(filter);
+    },
+  };
+}

--- a/packages/xmpt/src/store/memory.ts
+++ b/packages/xmpt/src/store/memory.ts
@@ -1,0 +1,16 @@
+import type { XMPTMessage, XMPTStore } from '@lucid-agents/types/xmpt';
+
+export function createMemoryStore(): XMPTStore {
+  const messages: XMPTMessage[] = [];
+  return {
+    async save(message: XMPTMessage): Promise<void> {
+      messages.push(message);
+    },
+    async list(filter?: { threadId?: string }): Promise<XMPTMessage[]> {
+      if (filter?.threadId) {
+        return messages.filter((m) => m.threadId === filter.threadId);
+      }
+      return [...messages];
+    },
+  };
+}

--- a/packages/xmpt/tsconfig.build.json
+++ b/packages/xmpt/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.build.base.json",
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "**/*.test.ts",
+    "**/__tests__/**"
+  ]
+}

--- a/packages/xmpt/tsconfig.json
+++ b/packages/xmpt/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/xmpt/tsup.config.ts
+++ b/packages/xmpt/tsup.config.ts
@@ -1,0 +1,7 @@
+import { definePackageConfig } from '../tsup.config.base';
+
+export default definePackageConfig({
+  entry: ['src/index.ts'],
+  dts: true,
+  external: ['@lucid-agents/types'],
+});


### PR DESCRIPTION
Closes #171

## Summary
Implements `@lucid-agents/xmpt` — a composable Lucid SDK extension for agent-to-agent messaging.

## Changes
- `packages/xmpt/` — new extension package (extension, runtime, in-memory store)
- `packages/types/src/xmpt/index.ts` — XMPTMessage, XMPTPeer, XMPTContent, XMPTRuntime, XMPTStore types
- `packages/types/src/core/runtime.ts` — adds optional `xmpt?: XMPTRuntime` to AgentRuntime
- `packages/examples/src/xmpt-messaging.ts` — usage example

## API
```ts
const runtime = await createAgent({ name: "alpha", version: "0.1.0" })
  .use(xmpt({
    inbox: {
      handler: async ({ message }) => ({
        content: { text: `ack:${message.content.text}` },
      }),
    },
  }))
  .build();

await runtime.xmpt.send(
  { url: "http://beta-agent.local" },
  { content: { text: "hello" }, threadId: "t-1" }
);
```

## Tests
**25/25 passing** (`bun test`)
- Types shape validation
- MemoryStore save/list/filter
- Runtime receive, onMessage (subscribe/unsubscribe), send, sendAndWait, listMessages
- Extension build + manifest skill injection
- Integration: two runtimes exchanging messages via mocked fetch, threadId preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced XMPT messaging extension enabling agent-to-agent communication
  * Added support for sending messages and waiting for replies
  * Message threading and filtering capabilities
  * Built-in in-memory message storage
  * Multiple integration patterns for flexible usage

* **Documentation**
  * Added comprehensive README with installation and usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->