### PR TITLE
feat(payments): add Circle Gateway nanopayment support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -288,10 +288,17 @@
         "zod": "catalog:",
       },
       "devDependencies": {
+        "@circle-fin/x402-batching": "^2.0.4",
         "@types/pg": "^8.11.10",
         "tsup": "catalog:",
         "typescript": "catalog:",
       },
+      "peerDependencies": {
+        "@circle-fin/x402-batching": "^2.0.4",
+      },
+      "optionalPeers": [
+        "@circle-fin/x402-batching",
+      ],
     },
     "packages/prettier-config": {
       "name": "@lucid-agents/prettier-config",
@@ -478,6 +485,8 @@
     "@changesets/types": ["@changesets/types@6.1.0", "", {}, "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA=="],
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
+
+    "@circle-fin/x402-batching": ["@circle-fin/x402-batching@2.0.4", "", { "peerDependencies": { "@x402/core": "^2.3.0", "@x402/evm": "^2.3.0", "viem": "^2.0.0" }, "optionalPeers": ["@x402/evm"] }, "sha512-q1rGOuFHyday0Rbc5V9PnNmoRotxGjc+CxqimjW+A0fjcdvYUi3Lnud/+94/KYqUqFLgOR9/5E2X41a1HxaA4g=="],
 
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.1", "", { "dependencies": { "mime": "^3.0.0" } }, "sha512-Nu8ahitGFFJztxUml9oD/DLb7Z28C8cd8F46IVQ7y5Btz575pvMY8AqZsXkX7Gds29eCKdMgIHjIvzskHgPSFg=="],
 

--- a/packages/examples/src/circle-gateway-seller.ts
+++ b/packages/examples/src/circle-gateway-seller.ts
@@ -1,0 +1,53 @@
+import { createAgent } from '@lucid-agents/core';
+import { createAgentApp } from '@lucid-agents/hono';
+import { http } from '@lucid-agents/http';
+import { payments, paymentsFromEnv } from '@lucid-agents/payments';
+import { z } from 'zod';
+
+const PORT = Number(process.env.PORT ?? 3000);
+
+async function main() {
+  const agent = await createAgent({
+    name: 'circle-gateway-seller',
+    version: '0.1.0',
+    description: 'Seller agent configured for Circle Gateway settlement.',
+  })
+    .use(http())
+    .use(
+      payments({
+        config: paymentsFromEnv({
+          facilitator: 'circle-gateway',
+        }),
+      })
+    )
+    .build();
+
+  const { app, addEntrypoint } = await createAgentApp(agent);
+
+  addEntrypoint({
+    key: 'nanopayment-echo',
+    description: 'Paid endpoint suitable for Circle Gateway micropayments.',
+    input: z.object({ text: z.string() }),
+    output: z.object({ text: z.string() }),
+    price: '0.000001',
+    handler: async ({ input }) => ({
+      output: { text: input.text },
+      usage: { total_tokens: 0 },
+    }),
+  });
+
+  console.log(`[circle-gateway-seller] listening on http://localhost:${PORT}`);
+  console.log(
+    '[circle-gateway-seller] set CIRCLE_GATEWAY_FACILITATOR=true to enable gateway mode from env'
+  );
+
+  Bun.serve({
+    port: PORT,
+    fetch: app.fetch,
+  });
+}
+
+main().catch(error => {
+  console.error('[circle-gateway-seller] failed to start', error);
+  process.exit(1);
+});

--- a/packages/express/src/__tests__/paywall.middleware.test.ts
+++ b/packages/express/src/__tests__/paywall.middleware.test.ts
@@ -120,4 +120,39 @@ describe('withPayments middleware registration', () => {
     ] as any;
     expect(typeof postRoute?.accepts?.payTo).toBe('function');
   });
+
+  it('registers gateway evm scheme when circle gateway facilitator is enabled', () => {
+    let capturedSchemes: any[] | null = null;
+
+    const app = {
+      use: (..._args: any[]) => {},
+    };
+
+    const middlewareFactory = (
+      _routes: Record<string, unknown>,
+      _facilitatorClient: unknown,
+      schemes?: any[]
+    ) => {
+      capturedSchemes = schemes ?? null;
+      return (_req: unknown, _res: unknown, next: () => void) => next();
+    };
+
+    const didRegister = withPayments({
+      app: app as any,
+      path: '/entrypoints/test/invoke',
+      entrypoint,
+      kind: 'invoke',
+      payments: {
+        ...payments,
+        facilitator: 'circle-gateway',
+      },
+      middlewareFactory: middlewareFactory as any,
+    });
+
+    expect(didRegister).toBe(true);
+    expect(capturedSchemes).toBeTruthy();
+    expect(capturedSchemes?.[0]?.server?.constructor?.name).toBe(
+      'GatewayEvmScheme'
+    );
+  });
 });

--- a/packages/express/src/paywall.ts
+++ b/packages/express/src/paywall.ts
@@ -3,16 +3,15 @@ import {
   paymentMiddlewareFromConfig,
   type SchemeRegistration,
 } from '@x402/express';
-import { ExactEvmScheme } from '@x402/evm/exact/server';
 import {
-  HTTPFacilitatorClient,
   type FacilitatorConfig,
   type RouteConfig,
 } from '@x402/core/server';
 import type { EntrypointDef, AgentRuntime } from '@lucid-agents/types/core';
 import type { PaymentsConfig } from '@lucid-agents/types/payments';
 import {
-  createFacilitatorAuthHeaders,
+  createPaymentSchemeRegistrations,
+  createPaymentsFacilitatorClient,
   resolvePrice,
   resolvePayTo,
   validatePaymentsConfig,
@@ -25,12 +24,6 @@ import {
 } from '@lucid-agents/payments';
 
 const DEFAULT_SCHEME = 'exact';
-const DEFAULT_SCHEMES: SchemeRegistration[] = [
-  {
-    network: 'eip155:*',
-    server: new ExactEvmScheme(),
-  },
-];
 
 type PaymentMiddlewareFactory = typeof paymentMiddlewareFromConfig;
 
@@ -44,25 +37,6 @@ export type WithPaymentsParams = {
   middlewareFactory?: PaymentMiddlewareFactory;
   runtime?: AgentRuntime;
 };
-
-function addFacilitatorAuth(
-  facilitator: FacilitatorConfig,
-  token?: string
-): FacilitatorConfig {
-  if (facilitator.createAuthHeaders) {
-    return facilitator;
-  }
-
-  const authHeaders = createFacilitatorAuthHeaders(token);
-  if (!authHeaders) {
-    return facilitator;
-  }
-
-  return {
-    ...facilitator,
-    createAuthHeaders: async () => authHeaders,
-  };
-}
 
 export function withPayments({
   app,
@@ -89,14 +63,6 @@ export function withPayments({
     `${entrypoint.key}${kind === 'stream' ? ' (stream)' : ''}`;
   const postMimeType =
     kind === 'stream' ? 'text/event-stream' : 'application/json';
-
-  const baseFacilitator: FacilitatorConfig =
-    facilitator ??
-    ({ url: payments.facilitatorUrl } satisfies FacilitatorConfig);
-  const resolvedFacilitator = addFacilitatorAuth(
-    baseFacilitator,
-    payments.facilitatorAuth
-  );
 
   const postRoute: RouteConfig = {
     accepts: {
@@ -167,7 +133,13 @@ export function withPayments({
     });
   }
 
-  const facilitatorClient = new HTTPFacilitatorClient(resolvedFacilitator);
+  const schemeRegistrations = createPaymentSchemeRegistrations(
+    payments
+  ) as SchemeRegistration[];
+  const facilitatorClient = createPaymentsFacilitatorClient({
+    payments,
+    facilitator,
+  });
   const routes: Record<string, RouteConfig> = {
     [`POST ${path}`]: postRoute,
     [`GET ${path}`]: getRoute,
@@ -176,7 +148,7 @@ export function withPayments({
   const middleware = middlewareFactory(
     routes,
     facilitatorClient,
-    DEFAULT_SCHEMES
+    schemeRegistrations
   ) as RequestHandler;
 
   app.use((req, res, next) => {

--- a/packages/hono/src/__tests__/index.core.test.ts
+++ b/packages/hono/src/__tests__/index.core.test.ts
@@ -266,6 +266,37 @@ describe('withPayments helper', () => {
     const postRoute = capturedRoutes?.['POST /entrypoints/test/invoke'] ?? null;
     expect(typeof postRoute?.accepts?.payTo).toBe('function');
   });
+
+  it('uses gateway scheme registration when circle gateway facilitator is enabled', () => {
+    let capturedSchemes: any[] | null = null;
+    const app = { use: (..._args: any[]) => {} };
+    const middlewareFactory = (
+      routes: Record<string, any>,
+      facilitatorClient: any,
+      schemes?: any[]
+    ) => {
+      capturedSchemes = schemes ?? null;
+      return { routes, facilitator: facilitatorClient };
+    };
+
+    const didRegister = withPayments({
+      app: app as any,
+      path: '/entrypoints/test/invoke',
+      entrypoint,
+      kind: 'invoke',
+      payments: {
+        ...payments,
+        facilitator: 'circle-gateway',
+      },
+      middlewareFactory: middlewareFactory as any,
+    });
+
+    expect(didRegister).toBe(true);
+    expect(capturedSchemes).toBeTruthy();
+    expect(capturedSchemes?.[0]?.server?.constructor?.name).toBe(
+      'GatewayEvmScheme'
+    );
+  });
 });
 
 describe('manifest building', () => {

--- a/packages/hono/src/paywall.ts
+++ b/packages/hono/src/paywall.ts
@@ -3,16 +3,15 @@ import {
   paymentMiddlewareFromConfig,
   type SchemeRegistration,
 } from '@x402/hono';
-import { ExactEvmScheme } from '@x402/evm/exact/server';
 import {
-  HTTPFacilitatorClient,
   type FacilitatorConfig,
   type RouteConfig,
 } from '@x402/core/server';
 import type { EntrypointDef, AgentRuntime } from '@lucid-agents/types/core';
 import type { PaymentsConfig } from '@lucid-agents/types/payments';
 import {
-  createFacilitatorAuthHeaders,
+  createPaymentSchemeRegistrations,
+  createPaymentsFacilitatorClient,
   resolvePrice,
   resolvePayTo,
   validatePaymentsConfig,
@@ -38,12 +37,6 @@ export type WithPaymentsParams = {
 };
 
 const DEFAULT_SCHEME = 'exact';
-const DEFAULT_SCHEMES: SchemeRegistration[] = [
-  {
-    network: 'eip155:*',
-    server: new ExactEvmScheme(),
-  },
-];
 
 function withPaymentHeader(c: Context, paymentHeader: string): Context {
   const mergedHeaders = new Headers(c.req.raw.headers);
@@ -82,25 +75,6 @@ function withPaymentHeader(c: Context, paymentHeader: string): Context {
   return contextProxy as Context;
 }
 
-function addFacilitatorAuth(
-  facilitator: FacilitatorConfig,
-  token?: string
-): FacilitatorConfig {
-  if (facilitator.createAuthHeaders) {
-    return facilitator;
-  }
-
-  const authHeaders = createFacilitatorAuthHeaders(token);
-  if (!authHeaders) {
-    return facilitator;
-  }
-
-  return {
-    ...facilitator,
-    createAuthHeaders: async () => authHeaders,
-  };
-}
-
 export function withPayments({
   app,
   path,
@@ -126,14 +100,6 @@ export function withPayments({
     `${entrypoint.key}${kind === 'stream' ? ' (stream)' : ''}`;
   const postMimeType =
     kind === 'stream' ? 'text/event-stream' : 'application/json';
-
-  const baseFacilitator: FacilitatorConfig =
-    facilitator ??
-    ({ url: payments.facilitatorUrl } satisfies FacilitatorConfig);
-  const resolvedFacilitator = addFacilitatorAuth(
-    baseFacilitator,
-    payments.facilitatorAuth
-  );
 
   const postRoute: RouteConfig = {
     accepts: {
@@ -191,16 +157,23 @@ export function withPayments({
     });
   }
 
-  const facilitatorClient = new HTTPFacilitatorClient(resolvedFacilitator);
   const routes = {
     [`POST ${path}`]: postRoute,
     [`GET ${path}`]: getRoute,
   };
 
+  const schemeRegistrations = createPaymentSchemeRegistrations(
+    payments
+  ) as SchemeRegistration[];
+  const facilitatorClient = createPaymentsFacilitatorClient({
+    payments,
+    facilitator,
+  });
+
   const baseMiddleware = middlewareFactory(
     routes,
     facilitatorClient,
-    DEFAULT_SCHEMES
+    schemeRegistrations
   );
 
   app.use(path, async (c, next) => {

--- a/packages/payments/package.json
+++ b/packages/payments/package.json
@@ -42,7 +42,16 @@
     "stripe": "catalog:",
     "zod": "catalog:"
   },
+  "peerDependencies": {
+    "@circle-fin/x402-batching": "^2.0.4"
+  },
+  "peerDependenciesMeta": {
+    "@circle-fin/x402-batching": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@circle-fin/x402-batching": "^2.0.4",
     "tsup": "catalog:",
     "typescript": "catalog:",
     "@types/pg": "^8.11.10"

--- a/packages/payments/src/__tests__/gateway-deposit.test.ts
+++ b/packages/payments/src/__tests__/gateway-deposit.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { depositToGateway } from '../gateway/deposit';
+import type { CircleGatewayClientDeps } from '../gateway/types';
+
+const PRIVATE_KEY =
+  '0x2222222222222222222222222222222222222222222222222222222222222222' as const;
+
+function createDeps() {
+  const gatewayConfigs: Array<{ chain: string; privateKey: string; rpcUrl?: string }> = [];
+  const depositCalls: Array<{
+    amount: string;
+    options?: { approveAmount?: string; skipApprovalCheck?: boolean };
+  }> = [];
+
+  const deposit = mock(
+    async (
+      amount: string,
+      options?: { approveAmount?: string; skipApprovalCheck?: boolean }
+    ) => {
+      depositCalls.push({ amount, options });
+      return { depositTxHash: '0xdeposit', amount };
+    }
+  );
+
+  class GatewayClient {
+    constructor(config: { chain: string; privateKey: string; rpcUrl?: string }) {
+      gatewayConfigs.push(config);
+    }
+
+    getBalances = mock(async () => ({}));
+    deposit = deposit;
+  }
+
+  const deps: CircleGatewayClientDeps = {
+    BatchEvmScheme: class {
+      readonly scheme = 'exact';
+      constructor(_signer: unknown) {}
+    } as any,
+    GatewayClient: GatewayClient as any,
+  };
+
+  return {
+    deps,
+    gatewayConfigs,
+    depositCalls,
+  };
+}
+
+describe('depositToGateway', () => {
+  it('throws for empty amount', async () => {
+    const { deps } = createDeps();
+    await expect(
+      depositToGateway(
+        '',
+        {
+          privateKey: PRIVATE_KEY,
+          chain: 'base',
+        },
+        deps
+      )
+    ).rejects.toThrow('depositToGateway requires a non-empty amount');
+  });
+
+  it('throws for empty private key', async () => {
+    const { deps } = createDeps();
+    await expect(
+      depositToGateway(
+        '1.0',
+        {
+          privateKey: '' as `0x${string}`,
+          chain: 'base',
+        },
+        deps
+      )
+    ).rejects.toThrow('depositToGateway requires a non-empty privateKey');
+  });
+
+  it('normalizes base-sepolia and forwards deposit options', async () => {
+    const { deps, gatewayConfigs, depositCalls } = createDeps();
+    await depositToGateway(
+      '1.25',
+      {
+        privateKey: PRIVATE_KEY,
+        chain: 'base-sepolia',
+        approveAmount: '2.0',
+        skipApprovalCheck: true,
+      },
+      deps
+    );
+
+    expect(gatewayConfigs[0]?.chain).toBe('baseSepolia');
+    expect(depositCalls[0]).toEqual({
+      amount: '1.25',
+      options: { approveAmount: '2.0', skipApprovalCheck: true },
+    });
+  });
+
+  it('passes rpcUrl to GatewayClient and returns deposit result', async () => {
+    const { deps, gatewayConfigs } = createDeps();
+    const result = await depositToGateway(
+      '3.0',
+      {
+        privateKey: PRIVATE_KEY,
+        chain: 'base',
+        rpcUrl: 'https://rpc.base.org',
+      },
+      deps
+    );
+
+    expect(gatewayConfigs[0]?.rpcUrl).toBe('https://rpc.base.org');
+    expect(result).toEqual({ depositTxHash: '0xdeposit', amount: '3.0' });
+  });
+
+  it('throws on unsupported gateway chain', async () => {
+    const { deps } = createDeps();
+    await expect(
+      depositToGateway(
+        '1.0',
+        {
+          privateKey: PRIVATE_KEY,
+          chain: 'unknown' as any,
+        },
+        deps
+      )
+    ).rejects.toThrow('Unsupported Circle Gateway chain');
+  });
+});

--- a/packages/payments/src/__tests__/gateway-facilitator.test.ts
+++ b/packages/payments/src/__tests__/gateway-facilitator.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it, mock } from 'bun:test';
+import type { PaymentsConfig } from '@lucid-agents/types/payments';
+import {
+  createCircleGatewayFacilitator,
+  createPaymentSchemeRegistrations,
+  createPaymentsFacilitatorClient,
+  isCircleGatewayFacilitator,
+} from '../gateway/facilitator';
+import type { CircleGatewayFacilitatorDeps } from '../gateway/types';
+
+const basePaymentsConfig: PaymentsConfig = {
+  payTo: '0xabc0000000000000000000000000000000000000',
+  facilitatorUrl: 'https://facilitator.test',
+  network: 'eip155:8453',
+};
+
+function createDeps(overrides?: Partial<CircleGatewayFacilitatorDeps>) {
+  const batchVerify = mock(async () => ({ isValid: true }));
+  const batchSettle = mock(async () => ({
+    success: true,
+    transaction: '0xbatch',
+    network: 'eip155:8453',
+  }));
+  const batchSupported = mock(async () => ({
+    kinds: [
+      {
+        x402Version: 2,
+        scheme: 'exact',
+        network: 'eip155:8453',
+        extra: {
+          name: 'GatewayWalletBatched',
+          version: '1',
+          verifyingContract: '0x0000000000000000000000000000000000000001',
+        },
+      },
+    ],
+    extensions: ['batching'],
+    signers: { exact: ['0xbatch'] },
+  }));
+
+  const standardVerify = mock(async () => ({ isValid: true }));
+  const standardSettle = mock(async () => ({
+    success: true,
+    transaction: '0xstandard',
+    network: 'eip155:8453',
+  }));
+  const standardSupported = mock(async () => ({
+    kinds: [
+      {
+        x402Version: 2,
+        scheme: 'exact',
+        network: 'eip155:8453',
+      },
+      {
+        x402Version: 2,
+        scheme: 'exact',
+        network: 'eip155:11155111',
+      },
+    ],
+    extensions: ['standard'],
+    signers: { exact: ['0xstandard'] },
+  }));
+
+  class BatchFacilitatorClient {
+    verify = batchVerify;
+    settle = batchSettle;
+    getSupported = batchSupported;
+  }
+
+  class GatewayEvmScheme {}
+
+  const deps: CircleGatewayFacilitatorDeps = {
+    BatchFacilitatorClient: BatchFacilitatorClient as any,
+    GatewayEvmScheme: GatewayEvmScheme as any,
+    isBatchPayment: requirements =>
+      requirements?.extra?.name === 'GatewayWalletBatched',
+    createStandardFacilitatorClient: () => ({
+      verify: standardVerify as any,
+      settle: standardSettle as any,
+      getSupported: standardSupported as any,
+    }),
+    ...overrides,
+  };
+
+  return {
+    deps,
+    batchVerify,
+    batchSettle,
+    batchSupported,
+    standardVerify,
+    standardSettle,
+    standardSupported,
+  };
+}
+
+describe('gateway facilitator helpers', () => {
+  it('detects circle gateway facilitator mode', () => {
+    expect(
+      isCircleGatewayFacilitator({
+        ...basePaymentsConfig,
+        facilitator: 'circle-gateway',
+      })
+    ).toBe(true);
+    expect(isCircleGatewayFacilitator(basePaymentsConfig)).toBe(false);
+  });
+
+  it('routes verify to batch facilitator when requirements are batched', async () => {
+    const { deps, batchVerify, standardVerify } = createDeps();
+    const facilitator = createCircleGatewayFacilitator(
+      {
+        payments: {
+          ...basePaymentsConfig,
+          facilitator: 'circle-gateway',
+        },
+      },
+      deps
+    );
+
+    await facilitator.verify(
+      { x402Version: 2, payload: {} } as any,
+      {
+        scheme: 'exact',
+        network: 'eip155:8453',
+        extra: { name: 'GatewayWalletBatched', version: '1' },
+      } as any
+    );
+
+    expect(batchVerify).toHaveBeenCalledTimes(1);
+    expect(standardVerify).toHaveBeenCalledTimes(0);
+  });
+
+  it('routes settle to standard facilitator for non-batched requirements', async () => {
+    const { deps, batchSettle, standardSettle } = createDeps();
+    const facilitator = createCircleGatewayFacilitator(
+      {
+        payments: {
+          ...basePaymentsConfig,
+          facilitator: 'circle-gateway',
+        },
+      },
+      deps
+    );
+
+    await facilitator.settle(
+      { x402Version: 2, payload: {} } as any,
+      {
+        scheme: 'exact',
+        network: 'eip155:8453',
+      } as any
+    );
+
+    expect(batchSettle).toHaveBeenCalledTimes(0);
+    expect(standardSettle).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates settle errors from batch facilitator', async () => {
+    const settleError = new Error('batch settle failed');
+    const { deps } = createDeps({
+      BatchFacilitatorClient: class {
+        verify = mock(async () => ({ isValid: true }));
+        settle = mock(async () => {
+          throw settleError;
+        });
+        getSupported = mock(async () => ({
+          kinds: [],
+          extensions: [],
+          signers: {},
+        }));
+      } as any,
+    });
+    const facilitator = createCircleGatewayFacilitator(
+      {
+        payments: {
+          ...basePaymentsConfig,
+          facilitator: 'circle-gateway',
+        },
+      },
+      deps
+    );
+
+    await expect(
+      facilitator.settle(
+        { x402Version: 2, payload: {} } as any,
+        {
+          scheme: 'exact',
+          network: 'eip155:8453',
+          extra: { name: 'GatewayWalletBatched', version: '1' },
+        } as any
+      )
+    ).rejects.toThrow('batch settle failed');
+  });
+
+  it('merges supported kinds with batch precedence', async () => {
+    const { deps } = createDeps();
+    const facilitator = createCircleGatewayFacilitator(
+      {
+        payments: {
+          ...basePaymentsConfig,
+          facilitator: 'circle-gateway',
+        },
+      },
+      deps
+    );
+
+    const supported = await facilitator.getSupported();
+
+    expect(supported.kinds).toHaveLength(2);
+    expect(supported.kinds[0].extra?.name).toBe('GatewayWalletBatched');
+    expect(supported.extensions).toEqual(['batching', 'standard']);
+    expect(supported.signers.exact).toContain('0xbatch');
+    expect(supported.signers.exact).toContain('0xstandard');
+  });
+
+  it('falls back to standard supported response when batch supported fails', async () => {
+    const { deps } = createDeps({
+      BatchFacilitatorClient: class {
+        verify = mock(async () => ({ isValid: true }));
+        settle = mock(async () => ({ success: true }));
+        getSupported = mock(async () => {
+          throw new Error('batch unavailable');
+        });
+      } as any,
+    });
+    const facilitator = createCircleGatewayFacilitator(
+      {
+        payments: {
+          ...basePaymentsConfig,
+          facilitator: 'circle-gateway',
+        },
+      },
+      deps
+    );
+
+    const supported = await facilitator.getSupported();
+    expect(supported.kinds).toHaveLength(2);
+    expect(supported.extensions).toEqual(['standard']);
+  });
+
+  it('throws when both supported calls fail', async () => {
+    const { deps } = createDeps({
+      BatchFacilitatorClient: class {
+        verify = mock(async () => ({ isValid: true }));
+        settle = mock(async () => ({
+          success: true,
+          transaction: '0xbatch',
+          network: 'eip155:8453',
+        }));
+        getSupported = mock(async () => {
+          throw new Error('batch failed');
+        });
+      } as any,
+      createStandardFacilitatorClient: () => ({
+        verify: mock(async () => ({ isValid: true })),
+        settle: mock(async () => ({
+          success: true,
+          transaction: '0xstandard',
+          network: 'eip155:8453' as `${string}:${string}`,
+        })),
+        getSupported: mock(async () => {
+          throw new Error('standard failed');
+        }),
+      }),
+    });
+    const facilitator = createCircleGatewayFacilitator(
+      {
+        payments: {
+          ...basePaymentsConfig,
+          facilitator: 'circle-gateway',
+        },
+      },
+      deps
+    );
+
+    await expect(facilitator.getSupported()).rejects.toThrow('batch failed');
+  });
+
+  it('returns default exact scheme registration when circle gateway is disabled', () => {
+    const registrations = createPaymentSchemeRegistrations(basePaymentsConfig);
+
+    expect(registrations).toHaveLength(1);
+    expect(registrations[0].network).toBe('eip155:*');
+    expect((registrations[0].server as { constructor: { name: string } }).constructor.name).toBe(
+      'ExactEvmScheme'
+    );
+  });
+
+  it('returns gateway scheme registration when circle gateway is enabled', () => {
+    const { deps } = createDeps();
+    const registrations = createPaymentSchemeRegistrations(
+      {
+        ...basePaymentsConfig,
+        facilitator: 'circle-gateway',
+      },
+      deps
+    );
+
+    expect(registrations).toHaveLength(1);
+    expect((registrations[0].server as { constructor: { name: string } }).constructor.name).toBe(
+      'GatewayEvmScheme'
+    );
+  });
+
+  it('createPaymentsFacilitatorClient routes circle mode to batch client path', async () => {
+    const { deps, batchSettle } = createDeps();
+    const facilitator = createPaymentsFacilitatorClient(
+      {
+        payments: {
+          ...basePaymentsConfig,
+          facilitator: 'circle-gateway',
+        },
+      },
+      deps
+    );
+
+    await facilitator.settle(
+      { x402Version: 2, payload: {} } as any,
+      {
+        scheme: 'exact',
+        network: 'eip155:8453',
+        extra: { name: 'GatewayWalletBatched', version: '1' },
+      } as any
+    );
+
+    expect(batchSettle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/payments/src/__tests__/gateway-fetch.test.ts
+++ b/packages/payments/src/__tests__/gateway-fetch.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { createGatewayFetch } from '../gateway/fetch';
+import type { CircleGatewayClientDeps } from '../gateway/types';
+
+const PRIVATE_KEY =
+  '0x1111111111111111111111111111111111111111111111111111111111111111' as const;
+
+function createDeps() {
+  const batchSignerArgs: unknown[] = [];
+  const gatewayConfigs: Array<{ chain: string; privateKey: string; rpcUrl?: string }> = [];
+  const getBalances = mock(async () => ({ formattedAvailable: '1.0' }));
+
+  class BatchEvmScheme {
+    readonly scheme = 'exact';
+
+    constructor(signer: unknown) {
+      batchSignerArgs.push(signer);
+    }
+  }
+
+  class GatewayClient {
+    constructor(config: { chain: string; privateKey: string; rpcUrl?: string }) {
+      gatewayConfigs.push(config);
+    }
+
+    getBalances = getBalances;
+  }
+
+  const deps: CircleGatewayClientDeps = {
+    BatchEvmScheme: BatchEvmScheme as any,
+    GatewayClient: GatewayClient as any,
+  };
+
+  return {
+    deps,
+    batchSignerArgs,
+    gatewayConfigs,
+    getBalances,
+  };
+}
+
+describe('createGatewayFetch', () => {
+  it('throws when privateKey is missing', () => {
+    const { deps } = createDeps();
+    expect(() =>
+      createGatewayFetch(
+        {
+          privateKey: '' as `0x${string}`,
+          chain: 'base',
+        },
+        deps
+      )
+    ).toThrow('createGatewayFetch requires a non-empty privateKey');
+  });
+
+  it('uses GatewayClient with base chain config', () => {
+    const { deps, gatewayConfigs } = createDeps();
+    createGatewayFetch(
+      {
+        privateKey: PRIVATE_KEY,
+        chain: 'base',
+      },
+      deps
+    );
+
+    expect(gatewayConfigs).toHaveLength(1);
+    expect(gatewayConfigs[0]?.chain).toBe('base');
+    expect(gatewayConfigs[0]?.privateKey).toBe(PRIVATE_KEY);
+  });
+
+  it('normalizes base-sepolia alias to baseSepolia', () => {
+    const { deps, gatewayConfigs } = createDeps();
+    createGatewayFetch(
+      {
+        privateKey: PRIVATE_KEY,
+        chain: 'base-sepolia',
+      },
+      deps
+    );
+
+    expect(gatewayConfigs[0]?.chain).toBe('baseSepolia');
+  });
+
+  it('initializes BatchEvmScheme signer for payment client registration', () => {
+    const { deps, batchSignerArgs } = createDeps();
+    createGatewayFetch(
+      {
+        privateKey: PRIVATE_KEY,
+        chain: 'base',
+      },
+      deps
+    );
+
+    expect(batchSignerArgs).toHaveLength(1);
+    expect(batchSignerArgs[0]).toBeTruthy();
+  });
+
+  it('exposes preconnect that calls GatewayClient.getBalances()', async () => {
+    const { deps, getBalances } = createDeps();
+    const gatewayFetch = createGatewayFetch(
+      {
+        privateKey: PRIVATE_KEY,
+        chain: 'base',
+      },
+      deps
+    );
+
+    await gatewayFetch.preconnect();
+
+    expect(getBalances).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/payments/src/__tests__/utils.test.ts
+++ b/packages/payments/src/__tests__/utils.test.ts
@@ -13,6 +13,8 @@ const ENV_KEYS = [
   'FACILITATOR_AUTH',
   'PAYMENTS_FACILITATOR_AUTH',
   'DREAMS_AUTH_TOKEN',
+  'CIRCLE_GATEWAY_FACILITATOR',
+  'CIRCLE_GATEWAY_CHAIN',
 ] as const;
 
 const originalEnv: Record<string, string | undefined> = {};
@@ -131,6 +133,53 @@ describe('paymentsFromEnv', () => {
 
     expect(config.facilitatorUrl).toBe('https://facilitator.alias.test');
     expect(config.network).toBe('eip155:84532');
+  });
+
+  it('enables circle gateway facilitator mode from env', () => {
+    process.env.PAYMENTS_RECEIVABLE_ADDRESS =
+      '0xabc0000000000000000000000000000000000000';
+    process.env.FACILITATOR_URL = 'https://facilitator.test';
+    process.env.NETWORK = 'base';
+    process.env.CIRCLE_GATEWAY_FACILITATOR = 'true';
+
+    const config = paymentsFromEnv();
+
+    expect(config.facilitator).toBe('circle-gateway');
+  });
+
+  it('does not enable circle gateway facilitator mode when env is false', () => {
+    process.env.PAYMENTS_RECEIVABLE_ADDRESS =
+      '0xabc0000000000000000000000000000000000000';
+    process.env.FACILITATOR_URL = 'https://facilitator.test';
+    process.env.NETWORK = 'base';
+    process.env.CIRCLE_GATEWAY_FACILITATOR = 'false';
+
+    const config = paymentsFromEnv();
+
+    expect(config.facilitator).toBeUndefined();
+  });
+
+  it('derives payments network from CIRCLE_GATEWAY_CHAIN when NETWORK is unset', () => {
+    process.env.PAYMENTS_RECEIVABLE_ADDRESS =
+      '0xabc0000000000000000000000000000000000000';
+    process.env.FACILITATOR_URL = 'https://facilitator.test';
+    process.env.CIRCLE_GATEWAY_CHAIN = 'baseSepolia';
+
+    const config = paymentsFromEnv();
+
+    expect(config.circleGatewayChain).toBe('baseSepolia');
+    expect(config.network as string).toBe('base-sepolia');
+  });
+
+  it('maps CIRCLE_GATEWAY_CHAIN=arcTestnet to network eip155:5042002', () => {
+    process.env.PAYMENTS_RECEIVABLE_ADDRESS =
+      '0xabc0000000000000000000000000000000000000';
+    process.env.FACILITATOR_URL = 'https://facilitator.test';
+    process.env.CIRCLE_GATEWAY_CHAIN = 'arcTestnet';
+
+    const config = paymentsFromEnv();
+
+    expect(config.network).toBe('eip155:5042002');
   });
 });
 

--- a/packages/payments/src/__tests__/validation.test.ts
+++ b/packages/payments/src/__tests__/validation.test.ts
@@ -42,4 +42,17 @@ describe('validatePaymentsConfig', () => {
       'Stripe destination mode currently supports only Base mainnet'
     );
   });
+
+  it('accepts arc testnet CAIP network for circle gateway compatibility', () => {
+    const config: PaymentsConfig = {
+      payTo: '0xabc0000000000000000000000000000000000000',
+      facilitatorUrl: 'https://facilitator.test',
+      network: 'eip155:5042002',
+      facilitator: 'circle-gateway',
+    };
+
+    expect(() =>
+      validatePaymentsConfig(config, config.network, 'echo')
+    ).not.toThrow();
+  });
 });

--- a/packages/payments/src/gateway/deposit.ts
+++ b/packages/payments/src/gateway/deposit.ts
@@ -1,0 +1,102 @@
+import { createRequire } from 'node:module';
+import type { CircleGatewayClientDeps, GatewayDepositOptions } from './types';
+
+const CIRCLE_GATEWAY_MISSING_DEP_ERROR =
+  '[agent-kit-payments] Circle Gateway support requires optional peer dependency @circle-fin/x402-batching';
+
+const requireModule = createRequire(import.meta.url);
+
+const GATEWAY_CHAIN_ALIASES = {
+  arcTestnet: 'arcTestnet',
+  base: 'base',
+  baseSepolia: 'baseSepolia',
+  'base-sepolia': 'baseSepolia',
+} as const;
+
+type NormalizedGatewayChain = 'arcTestnet' | 'base' | 'baseSepolia';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function normalizeGatewayChain(
+  chain?: GatewayDepositOptions['chain']
+): NormalizedGatewayChain {
+  if (!chain) {
+    return 'base';
+  }
+
+  const normalized = GATEWAY_CHAIN_ALIASES[chain];
+  if (!normalized) {
+    throw new Error(
+      `[agent-kit-payments] Unsupported Circle Gateway chain: ${chain}`
+    );
+  }
+
+  return normalized;
+}
+
+function loadCircleGatewayClientDeps(): CircleGatewayClientDeps {
+  try {
+    const clientModule = requireModule('@circle-fin/x402-batching/client');
+
+    if (
+      !isRecord(clientModule) ||
+      typeof clientModule.BatchEvmScheme !== 'function' ||
+      typeof clientModule.GatewayClient !== 'function'
+    ) {
+      throw new Error(
+        '[agent-kit-payments] Invalid @circle-fin/x402-batching/client exports'
+      );
+    }
+
+    return {
+      BatchEvmScheme:
+        clientModule.BatchEvmScheme as CircleGatewayClientDeps['BatchEvmScheme'],
+      GatewayClient:
+        clientModule.GatewayClient as CircleGatewayClientDeps['GatewayClient'],
+    };
+  } catch (error) {
+    throw new Error(CIRCLE_GATEWAY_MISSING_DEP_ERROR, { cause: error });
+  }
+}
+
+export async function depositToGateway(
+  amount: string,
+  options: GatewayDepositOptions,
+  depsArg?: CircleGatewayClientDeps
+): Promise<unknown> {
+  if (!amount || amount.trim().length === 0) {
+    throw new Error(
+      '[agent-kit-payments] depositToGateway requires a non-empty amount'
+    );
+  }
+
+  if (!options.privateKey || options.privateKey.trim().length === 0) {
+    throw new Error(
+      '[agent-kit-payments] depositToGateway requires a non-empty privateKey'
+    );
+  }
+
+  const deps = depsArg ?? loadCircleGatewayClientDeps();
+  const chain = normalizeGatewayChain(options.chain);
+
+  const gatewayClient = new deps.GatewayClient({
+    chain,
+    privateKey: options.privateKey,
+    ...(options.rpcUrl ? { rpcUrl: options.rpcUrl } : {}),
+  });
+
+  if (typeof gatewayClient.deposit !== 'function') {
+    throw new Error(
+      '[agent-kit-payments] GatewayClient does not expose deposit()'
+    );
+  }
+
+  return gatewayClient.deposit(amount, {
+    ...(options.approveAmount ? { approveAmount: options.approveAmount } : {}),
+    ...(typeof options.skipApprovalCheck === 'boolean'
+      ? { skipApprovalCheck: options.skipApprovalCheck }
+      : {}),
+  });
+}

--- a/packages/payments/src/gateway/facilitator.ts
+++ b/packages/payments/src/gateway/facilitator.ts
@@ -1,0 +1,222 @@
+import type { PaymentsConfig } from '@lucid-agents/types/payments';
+import type {
+  FacilitatorClient,
+  FacilitatorConfig,
+} from '@x402/core/server';
+import { HTTPFacilitatorClient } from '@x402/core/server';
+import type { SupportedResponse } from '@x402/core/types';
+import { ExactEvmScheme } from '@x402/evm/exact/server';
+import { createRequire } from 'node:module';
+import { createFacilitatorAuthHeaders } from '../utils';
+import type { CircleGatewayConfig, CircleGatewayFacilitatorDeps } from './types';
+
+const CIRCLE_GATEWAY_MISSING_DEP_ERROR =
+  '[agent-kit-payments] Circle Gateway support requires optional peer dependency @circle-fin/x402-batching';
+
+const DEFAULT_NETWORK_PATTERN = 'eip155:*';
+
+const requireModule = createRequire(import.meta.url);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function loadCircleGatewayFacilitatorDeps(): CircleGatewayFacilitatorDeps {
+  try {
+    const serverModule = requireModule('@circle-fin/x402-batching/server');
+    const rootModule = requireModule('@circle-fin/x402-batching');
+
+    if (
+      !isRecord(serverModule) ||
+      !isRecord(rootModule) ||
+      typeof serverModule.BatchFacilitatorClient !== 'function' ||
+      typeof serverModule.GatewayEvmScheme !== 'function' ||
+      typeof rootModule.isBatchPayment !== 'function'
+    ) {
+      throw new Error(
+        '[agent-kit-payments] Invalid @circle-fin/x402-batching exports'
+      );
+    }
+
+    return {
+      BatchFacilitatorClient:
+        serverModule.BatchFacilitatorClient as CircleGatewayFacilitatorDeps['BatchFacilitatorClient'],
+      GatewayEvmScheme:
+        serverModule.GatewayEvmScheme as CircleGatewayFacilitatorDeps['GatewayEvmScheme'],
+      isBatchPayment:
+        rootModule.isBatchPayment as CircleGatewayFacilitatorDeps['isBatchPayment'],
+    };
+  } catch (error) {
+    throw new Error(CIRCLE_GATEWAY_MISSING_DEP_ERROR, { cause: error });
+  }
+}
+
+function addFacilitatorAuth(
+  facilitator: FacilitatorConfig,
+  token?: string
+): FacilitatorConfig {
+  if (facilitator.createAuthHeaders) {
+    return facilitator;
+  }
+
+  const authHeaders = createFacilitatorAuthHeaders(token);
+  if (!authHeaders) {
+    return facilitator;
+  }
+
+  return {
+    ...facilitator,
+    createAuthHeaders: async () => authHeaders,
+  };
+}
+
+function resolveFacilitatorConfig({
+  payments,
+  facilitator,
+}: CircleGatewayConfig): FacilitatorConfig {
+  const baseFacilitator: FacilitatorConfig =
+    facilitator ??
+    ({ url: payments.facilitatorUrl } satisfies FacilitatorConfig);
+  return addFacilitatorAuth(baseFacilitator, payments.facilitatorAuth);
+}
+
+function uniqueValues(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+function mergeSupportedResponses(
+  responses: SupportedResponse[]
+): SupportedResponse {
+  const kinds: SupportedResponse['kinds'] = [];
+  const kindKeys = new Set<string>();
+  const extensions: string[] = [];
+  const signers: Record<string, string[]> = {};
+
+  for (const response of responses) {
+    for (const kind of response.kinds) {
+      const key = `${kind.x402Version}|${kind.scheme}|${kind.network}`;
+      if (kindKeys.has(key)) {
+        continue;
+      }
+      kindKeys.add(key);
+      kinds.push(kind);
+    }
+
+    extensions.push(...response.extensions);
+
+    for (const [scheme, rawSchemeSigners] of Object.entries(
+      response.signers ?? {}
+    )) {
+      const schemeSigners = Array.isArray(rawSchemeSigners)
+        ? rawSchemeSigners.map(signer => String(signer))
+        : [];
+      const existing = signers[scheme] ?? [];
+      signers[scheme] = uniqueValues([...existing, ...schemeSigners]);
+    }
+  }
+
+  return {
+    kinds,
+    extensions: uniqueValues(extensions),
+    signers,
+  };
+}
+
+export function isCircleGatewayFacilitator(
+  payments?: PaymentsConfig
+): boolean {
+  return payments?.facilitator === 'circle-gateway';
+}
+
+export function createCircleGatewayFacilitator(
+  config: CircleGatewayConfig,
+  depsArg?: CircleGatewayFacilitatorDeps
+): FacilitatorClient {
+  const deps = depsArg ?? loadCircleGatewayFacilitatorDeps();
+  const facilitatorConfig = resolveFacilitatorConfig(config);
+
+  const standardFacilitator =
+    deps.createStandardFacilitatorClient?.(facilitatorConfig) ??
+    new HTTPFacilitatorClient(facilitatorConfig);
+  const batchFacilitator = new deps.BatchFacilitatorClient({
+    url: facilitatorConfig.url,
+    createAuthHeaders: facilitatorConfig.createAuthHeaders,
+  });
+
+  return {
+    verify: async (paymentPayload, paymentRequirements) => {
+      if (deps.isBatchPayment(paymentRequirements)) {
+        return batchFacilitator.verify(paymentPayload, paymentRequirements);
+      }
+      return standardFacilitator.verify(paymentPayload, paymentRequirements);
+    },
+    settle: async (paymentPayload, paymentRequirements) => {
+      if (deps.isBatchPayment(paymentRequirements)) {
+        return batchFacilitator.settle(paymentPayload, paymentRequirements);
+      }
+      return standardFacilitator.settle(paymentPayload, paymentRequirements);
+    },
+    getSupported: async () => {
+      const [batchResult, standardResult] = await Promise.allSettled([
+        batchFacilitator.getSupported(),
+        standardFacilitator.getSupported(),
+      ]);
+
+      const responses: SupportedResponse[] = [];
+      if (batchResult.status === 'fulfilled') {
+        responses.push(batchResult.value);
+      }
+      if (standardResult.status === 'fulfilled') {
+        responses.push(standardResult.value);
+      }
+
+      if (responses.length > 0) {
+        return mergeSupportedResponses(responses);
+      }
+
+      if (batchResult.status === 'rejected') {
+        throw batchResult.reason;
+      }
+      if (standardResult.status === 'rejected') {
+        throw standardResult.reason;
+      }
+      throw new Error(
+        '[agent-kit-payments] Failed to resolve supported gateway facilitator kinds'
+      );
+    },
+  };
+}
+
+export function createPaymentsFacilitatorClient(
+  config: CircleGatewayConfig,
+  depsArg?: CircleGatewayFacilitatorDeps
+): FacilitatorClient {
+  if (isCircleGatewayFacilitator(config.payments)) {
+    return createCircleGatewayFacilitator(config, depsArg);
+  }
+
+  const facilitatorConfig = resolveFacilitatorConfig(config);
+  return new HTTPFacilitatorClient(facilitatorConfig);
+}
+
+export function createPaymentSchemeRegistrations(
+  payments: PaymentsConfig,
+  depsArg?: CircleGatewayFacilitatorDeps
+): Array<{ network: string; server: unknown }> {
+  if (isCircleGatewayFacilitator(payments)) {
+    const deps = depsArg ?? loadCircleGatewayFacilitatorDeps();
+    return [
+      {
+        network: DEFAULT_NETWORK_PATTERN,
+        server: new deps.GatewayEvmScheme(),
+      },
+    ];
+  }
+
+  return [
+    {
+      network: DEFAULT_NETWORK_PATTERN,
+      server: new ExactEvmScheme(),
+    },
+  ];
+}

--- a/packages/payments/src/gateway/fetch.ts
+++ b/packages/payments/src/gateway/fetch.ts
@@ -1,0 +1,122 @@
+import { toClientEvmSigner } from '@x402/evm';
+import { wrapFetchWithPayment, x402Client } from '@x402/fetch';
+import { createRequire } from 'node:module';
+import { privateKeyToAccount } from 'viem/accounts';
+import type { CircleGatewayClientDeps, GatewayFetchOptions } from './types';
+
+const CIRCLE_GATEWAY_MISSING_DEP_ERROR =
+  '[agent-kit-payments] Circle Gateway support requires optional peer dependency @circle-fin/x402-batching';
+
+const requireModule = createRequire(import.meta.url);
+
+const GATEWAY_CHAIN_NETWORKS = {
+  arcTestnet: {
+    gatewayChain: 'arcTestnet',
+    network: 'eip155:5042002',
+  },
+  base: {
+    gatewayChain: 'base',
+    network: 'eip155:8453',
+  },
+  baseSepolia: {
+    gatewayChain: 'baseSepolia',
+    network: 'eip155:84532',
+  },
+} as const;
+
+type NormalizedGatewayChain = keyof typeof GATEWAY_CHAIN_NETWORKS;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function normalizeGatewayChain(
+  chain?: GatewayFetchOptions['chain']
+): NormalizedGatewayChain {
+  if (!chain) {
+    return 'base';
+  }
+
+  if (chain === 'base-sepolia') {
+    return 'baseSepolia';
+  }
+
+  if (chain in GATEWAY_CHAIN_NETWORKS) {
+    return chain as NormalizedGatewayChain;
+  }
+
+  throw new Error(
+    `[agent-kit-payments] Unsupported Circle Gateway chain: ${chain}`
+  );
+}
+
+function loadCircleGatewayClientDeps(): CircleGatewayClientDeps {
+  try {
+    const clientModule = requireModule('@circle-fin/x402-batching/client');
+
+    if (
+      !isRecord(clientModule) ||
+      typeof clientModule.BatchEvmScheme !== 'function' ||
+      typeof clientModule.GatewayClient !== 'function'
+    ) {
+      throw new Error(
+        '[agent-kit-payments] Invalid @circle-fin/x402-batching/client exports'
+      );
+    }
+
+    return {
+      BatchEvmScheme:
+        clientModule.BatchEvmScheme as CircleGatewayClientDeps['BatchEvmScheme'],
+      GatewayClient:
+        clientModule.GatewayClient as CircleGatewayClientDeps['GatewayClient'],
+    };
+  } catch (error) {
+    throw new Error(CIRCLE_GATEWAY_MISSING_DEP_ERROR, { cause: error });
+  }
+}
+
+export function createGatewayFetch(
+  options: GatewayFetchOptions,
+  depsArg?: CircleGatewayClientDeps
+): typeof fetch & { preconnect: () => Promise<void> } {
+  if (!options.privateKey || options.privateKey.trim().length === 0) {
+    throw new Error(
+      '[agent-kit-payments] createGatewayFetch requires a non-empty privateKey'
+    );
+  }
+
+  const deps = depsArg ?? loadCircleGatewayClientDeps();
+  const chain = normalizeGatewayChain(options.chain);
+  const network = GATEWAY_CHAIN_NETWORKS[chain].network;
+  const gatewayChain = GATEWAY_CHAIN_NETWORKS[chain].gatewayChain;
+
+  const account = privateKeyToAccount(options.privateKey);
+  const signer = toClientEvmSigner(account);
+  const client = new x402Client();
+  client.register(
+    network as `${string}:${string}`,
+    new deps.BatchEvmScheme(signer)
+  );
+
+  const gatewayClient = new deps.GatewayClient({
+    chain: gatewayChain,
+    privateKey: options.privateKey,
+    ...(options.rpcUrl ? { rpcUrl: options.rpcUrl } : {}),
+  });
+
+  const paymentFetch = wrapFetchWithPayment(options.fetchImpl ?? fetch, client);
+
+  const wrappedFetch = Object.assign(
+    async (
+      input: Parameters<typeof fetch>[0],
+      init?: Parameters<typeof fetch>[1]
+    ) => paymentFetch(input, init ?? {}),
+    {
+      preconnect: async () => {
+        await gatewayClient.getBalances();
+      },
+    }
+  );
+
+  return wrappedFetch;
+}

--- a/packages/payments/src/gateway/types.ts
+++ b/packages/payments/src/gateway/types.ts
@@ -1,0 +1,78 @@
+import type { CircleGatewayChain, PaymentsConfig } from '@lucid-agents/types/payments';
+import type { FacilitatorClient, FacilitatorConfig } from '@x402/core/server';
+import type { Hex } from '../crypto';
+
+export type GatewayWrappedFetch = typeof fetch & {
+  preconnect?: () => Promise<void>;
+};
+
+export type GatewayFetchOptions = {
+  privateKey: Hex;
+  chain?: CircleGatewayChain | 'base-sepolia';
+  fetchImpl?: typeof fetch;
+  rpcUrl?: string;
+};
+
+export type GatewayDepositOptions = {
+  privateKey: Hex;
+  chain?: CircleGatewayChain | 'base-sepolia';
+  rpcUrl?: string;
+  approveAmount?: string;
+  skipApprovalCheck?: boolean;
+};
+
+export type CircleGatewayConfig = {
+  payments: PaymentsConfig;
+  facilitator?: FacilitatorConfig;
+};
+
+export type CreateAuthHeaders = () => Promise<{
+  verify: Record<string, string>;
+  settle: Record<string, string>;
+  supported: Record<string, string>;
+}>;
+
+export type BatchRequirementsLike = {
+  extra?: Record<string, unknown>;
+};
+
+export type CircleGatewayFacilitatorDeps = {
+  BatchFacilitatorClient: new (config?: {
+    url?: string;
+    createAuthHeaders?: CreateAuthHeaders;
+  }) => FacilitatorClient;
+  GatewayEvmScheme: new () => unknown;
+  isBatchPayment: (requirements: BatchRequirementsLike) => boolean;
+  createStandardFacilitatorClient?: (
+    config: FacilitatorConfig
+  ) => FacilitatorClient;
+};
+
+export type CircleGatewayClientDeps = {
+  BatchEvmScheme: new (signer: unknown) => {
+    scheme: string;
+    createPaymentPayload: (
+      x402Version: number,
+      paymentRequirements: {
+        scheme: string;
+        network: string;
+        asset: string;
+        amount: string;
+        payTo: string;
+        maxTimeoutSeconds: number;
+        extra?: Record<string, unknown>;
+      }
+    ) => Promise<{ x402Version: number; payload: Record<string, unknown> }>;
+  };
+  GatewayClient: new (config: {
+    chain: string;
+    privateKey: Hex;
+    rpcUrl?: string;
+  }) => {
+    getBalances: () => Promise<unknown>;
+    deposit?: (
+      amount: string,
+      options?: { approveAmount?: string; skipApprovalCheck?: boolean }
+    ) => Promise<unknown>;
+  };
+};

--- a/packages/payments/src/index.ts
+++ b/packages/payments/src/index.ts
@@ -32,6 +32,7 @@ export {
 } from './payto-resolver';
 export {
   createX402Fetch,
+  createGatewayFetch,
   accountFromPrivateKey,
   createX402LLM,
   x402LLM,
@@ -40,6 +41,18 @@ export {
   type WrappedFetch,
   type X402Account,
 } from './x402';
+export {
+  createCircleGatewayFacilitator,
+  createPaymentsFacilitatorClient,
+  createPaymentSchemeRegistrations,
+  isCircleGatewayFacilitator,
+} from './gateway/facilitator';
+export { depositToGateway } from './gateway/deposit';
+export type {
+  CircleGatewayConfig,
+  GatewayFetchOptions,
+  GatewayDepositOptions,
+} from './gateway/types';
 export {
   sanitizeAddress,
   normalizeAddress,

--- a/packages/payments/src/utils.ts
+++ b/packages/payments/src/utils.ts
@@ -1,7 +1,34 @@
 import type {
+  CircleGatewayChain,
   PaymentsConfig,
   StripePaymentsConfig,
 } from '@lucid-agents/types/payments';
+
+function parseBooleanEnv(value?: string): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return (
+    normalized === '1' ||
+    normalized === 'true' ||
+    normalized === 'yes' ||
+    normalized === 'on'
+  );
+}
+
+function gatewayChainToNetwork(
+  chain?: string
+): PaymentsConfig['network'] | undefined {
+  if (!chain) return undefined;
+  const normalized = chain.trim().toLowerCase();
+  if (normalized === 'base') return 'base' as PaymentsConfig['network'];
+  if (normalized === 'basesepolia' || normalized === 'base-sepolia') {
+    return 'base-sepolia' as PaymentsConfig['network'];
+  }
+  if (normalized === 'arctestnet' || normalized === 'arc-testnet') {
+    return 'eip155:5042002' as PaymentsConfig['network'];
+  }
+  return undefined;
+}
 
 /**
  * Creates PaymentsConfig from environment variables and optional overrides.
@@ -12,6 +39,10 @@ import type {
 export function paymentsFromEnv(
   configOverrides?: Partial<PaymentsConfig>
 ): PaymentsConfig {
+  const circleGatewayChain =
+    configOverrides?.circleGatewayChain ??
+    (process.env.CIRCLE_GATEWAY_CHAIN as CircleGatewayChain | undefined);
+  const networkFromGatewayChain = gatewayChainToNetwork(circleGatewayChain);
   const facilitatorUrl =
     configOverrides?.facilitatorUrl ??
     process.env.FACILITATOR_URL ??
@@ -21,7 +52,12 @@ export function paymentsFromEnv(
     configOverrides?.network ??
     process.env.NETWORK ??
     process.env.PAYMENTS_NETWORK ??
-    undefined;
+    networkFromGatewayChain;
+  const facilitatorMode =
+    configOverrides?.facilitator ??
+    (parseBooleanEnv(process.env.CIRCLE_GATEWAY_FACILITATOR)
+      ? 'circle-gateway'
+      : undefined);
   const facilitatorAuth =
     configOverrides?.facilitatorAuth ??
     process.env.FACILITOR_AUTH ??
@@ -33,6 +69,8 @@ export function paymentsFromEnv(
     facilitatorUrl: facilitatorUrl as PaymentsConfig['facilitatorUrl'],
     facilitatorAuth,
     network: network as PaymentsConfig['network'],
+    facilitator: facilitatorMode,
+    circleGatewayChain,
     policyGroups: configOverrides?.policyGroups,
     storage: configOverrides?.storage,
   };

--- a/packages/payments/src/validation.ts
+++ b/packages/payments/src/validation.ts
@@ -13,6 +13,7 @@ const SupportedEVMNetworks: Network[] = [
   'eip155:80002',    // Polygon Amoy
   'eip155:43114',    // Avalanche
   'eip155:43113',    // Avalanche Fuji
+  'eip155:5042002',  // Arc Testnet
 ];
 
 /**

--- a/packages/payments/src/x402.ts
+++ b/packages/payments/src/x402.ts
@@ -3,6 +3,7 @@ import { privateKeyToAccount, type LocalAccount } from 'viem/accounts';
 import { wrapFetchWithPayment, x402Client } from '@x402/fetch';
 import { ExactEvmScheme, toClientEvmSigner } from '@x402/evm';
 import type { Hex } from './crypto';
+export { createGatewayFetch } from './gateway/fetch';
 
 const DEFAULT_MODEL = 'gpt-5';
 const DEFAULT_PROVIDER = 'openai';

--- a/packages/payments/tsup.config.ts
+++ b/packages/payments/tsup.config.ts
@@ -12,5 +12,8 @@ export default definePackageConfig({
     'viem',
     'stripe',
     'zod',
+    '@circle-fin/x402-batching',
+    '@circle-fin/x402-batching/client',
+    '@circle-fin/x402-batching/server',
   ],
 });

--- a/packages/tanstack/src/paywall.ts
+++ b/packages/tanstack/src/paywall.ts
@@ -2,6 +2,8 @@ import type { EntrypointDef } from '@lucid-agents/types/core';
 import type { PaymentsConfig } from '@lucid-agents/types/payments';
 import {
   createFacilitatorAuthHeaders,
+  createPaymentSchemeRegistrations,
+  createPaymentsFacilitatorClient,
   resolvePrice,
   resolvePayTo,
   validatePaymentsConfig,
@@ -153,6 +155,11 @@ export function createTanStackPaywall({
     baseFacilitator,
     activePayments.facilitatorAuth
   );
+  const schemeRegistrations = createPaymentSchemeRegistrations(activePayments);
+  const facilitatorClient = createPaymentsFacilitatorClient({
+    payments: activePayments,
+    facilitator: resolvedFacilitator,
+  });
 
   const invokeRoutes = buildEntrypointRoutes({
     entrypoints,
@@ -170,12 +177,18 @@ export function createTanStackPaywall({
 
   const invoke =
     Object.keys(invokeRoutes).length > 0
-      ? middlewareFactory(invokeRoutes, resolvedFacilitator, paywall)
+      ? middlewareFactory(invokeRoutes, resolvedFacilitator, paywall, {
+          facilitatorClient,
+          schemeRegistrations,
+        })
       : undefined;
 
   const stream =
     Object.keys(streamRoutes).length > 0
-      ? middlewareFactory(streamRoutes, resolvedFacilitator, paywall)
+      ? middlewareFactory(streamRoutes, resolvedFacilitator, paywall, {
+          facilitatorClient,
+          schemeRegistrations,
+        })
       : undefined;
 
   return { invoke, stream };

--- a/packages/tanstack/src/x402-paywall.ts
+++ b/packages/tanstack/src/x402-paywall.ts
@@ -7,6 +7,7 @@ import {
   x402ResourceServer,
   x402HTTPResourceServer,
   HTTPFacilitatorClient,
+  type FacilitatorClient,
   type FacilitatorConfig,
   type PaywallConfig,
   type RoutesConfig,
@@ -17,6 +18,16 @@ import {
 type RoutesConfigResolver =
   | RoutesConfig
   | (() => RoutesConfig | Promise<RoutesConfig>);
+
+type SchemeRegistration = {
+  network: string;
+  server: unknown;
+};
+
+type PaymentMiddlewareOptions = {
+  facilitatorClient?: FacilitatorClient;
+  schemeRegistrations?: SchemeRegistration[];
+};
 
 type AnyRequestServerOptions = RequestServerOptions<any, any>;
 type AnyRequestServerResult = RequestServerResult<any, any, any>;
@@ -157,7 +168,8 @@ function createPaymentHandler(
 export function paymentMiddleware(
   routes: RoutesConfigResolver,
   facilitator?: FacilitatorConfig,
-  paywall?: PaywallConfig
+  paywall?: PaywallConfig,
+  options?: PaymentMiddlewareOptions
 ) {
   let resolvedRoutes: RoutesConfig | null = null;
   let routesPromise: Promise<RoutesConfig> | null = null;
@@ -166,8 +178,15 @@ export function paymentMiddleware(
     resolvedRoutes = routes;
   }
 
-  const facilitatorClient = new HTTPFacilitatorClient(facilitator);
+  const facilitatorClient =
+    options?.facilitatorClient ?? new HTTPFacilitatorClient(facilitator);
   const resourceServer = new x402ResourceServer(facilitatorClient);
+  for (const registration of options?.schemeRegistrations ?? []) {
+    resourceServer.register(
+      registration.network as `${string}:${string}`,
+      registration.server as Parameters<typeof resourceServer.register>[1]
+    );
+  }
 
   let httpServer: x402HTTPResourceServer | null = null;
   let initPromise: Promise<void> | null = null;

--- a/packages/types/src/payments/index.ts
+++ b/packages/types/src/payments/index.ts
@@ -147,6 +147,18 @@ export type StripePaymentsConfig = {
 };
 
 /**
+ * Optional settlement facilitator mode.
+ * - Omitted: standard x402 facilitator behavior
+ * - circle-gateway: Circle Gateway batched settlement support
+ */
+export type PaymentsFacilitator = 'circle-gateway';
+
+/**
+ * Supported Circle Gateway chain aliases for buyer-side helpers.
+ */
+export type CircleGatewayChain = 'arcTestnet' | 'base' | 'baseSepolia';
+
+/**
  * Static destination configuration where payTo is known upfront.
  */
 export type StaticPaymentsDestination = {
@@ -170,6 +182,13 @@ export type PaymentsConfig = {
   facilitatorUrl: Resource;
   /** Optional bearer token used to authenticate facilitator requests. */
   facilitatorAuth?: string;
+  /** Optional facilitator mode for settlement routing. */
+  facilitator?: PaymentsFacilitator;
+  /**
+   * Optional Circle Gateway chain alias used by helper utilities.
+   * This does not replace `network`; it is used for gateway-specific helpers.
+   */
+  circleGatewayChain?: CircleGatewayChain;
   network: Network;
   /** Optional policy groups for payment controls and limits */
   policyGroups?: PaymentPolicyGroup[];


### PR DESCRIPTION
## Summary
- add Circle Gateway support to `@lucid-agents/payments` with opt-in `facilitator: 'circle-gateway'`
- add new gateway modules:
  - `packages/payments/src/gateway/facilitator.ts`
  - `packages/payments/src/gateway/fetch.ts`
  - `packages/payments/src/gateway/deposit.ts`
  - `packages/payments/src/gateway/types.ts`
- wire seller paywall paths (hono/express/tanstack) to use Circle Gateway facilitator + scheme registration when configured
- add buyer helper `createGatewayFetch({ privateKey, chain })` and `depositToGateway()` helper
- extend `paymentsFromEnv()` to read `CIRCLE_GATEWAY_FACILITATOR` and `CIRCLE_GATEWAY_CHAIN`
- add example seller: `packages/examples/src/circle-gateway-seller.ts`
- add optional peer dependency for `@circle-fin/x402-batching` and keep it optional via `peerDependenciesMeta`

## Validation
- `bun run format:check`
- `bun run lint`
- `bun run type-check`
- `bun run build:packages`
- `bun test packages/payments/src/__tests__ packages/hono/src/__tests__ packages/express/src/__tests__ packages/tanstack/src/__tests__`

## Notes
- Added Circle gateway-focused tests with all Circle SDK calls mocked/injected.
- Added gateway routing + settle-path coverage and default x402 regression coverage.

Closes #223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Circle Gateway support as a payment processing option
  * Introduced deposit functionality for Circle Gateway transactions
  * Added gateway-backed fetch with preconnect capability for improved connectivity
  * Extended network support to include Arc Testnet
  * Created example implementation for Circle Gateway seller integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->