### PR TITLE
feat(xmpt): add @lucid-agents/xmpt agent-to-agent messaging extension

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -355,6 +355,22 @@
         "thirdweb": "^5.84.0",
       },
     },
+    "packages/xmpt": {
+      "name": "@lucid-agents/xmpt",
+      "version": "0.1.0",
+      "dependencies": {
+        "@lucid-agents/a2a": "workspace:*",
+        "@lucid-agents/types": "workspace:*",
+        "zod": "catalog:",
+      },
+      "devDependencies": {
+        "@lucid-agents/core": "workspace:*",
+        "@lucid-agents/hono": "workspace:*",
+        "@lucid-agents/http": "workspace:*",
+        "tsup": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
   },
   "catalog": {
     "@ax-llm/ax": "^14.0.31",
@@ -722,6 +738,8 @@
     "@lucid-agents/types": ["@lucid-agents/types@workspace:packages/types"],
 
     "@lucid-agents/wallet": ["@lucid-agents/wallet@workspace:packages/wallet"],
+
+    "@lucid-agents/xmpt": ["@lucid-agents/xmpt@workspace:packages/xmpt"],
 
     "@lucid-dreams/agent-auth": ["@lucid-dreams/agent-auth@0.2.24", "", { "dependencies": { "@lucid-dreams/sdk": "^0.2.24", "viem": "^2.38.5" } }, "sha512-QiJQ2FTJXtd1o6c1fkEq/qawBJbhZdmGukwt+B8LztTmjjkdhfRZvWbNk3DUBIZIPsbInWdwbgPAUkzGMUNyDg=="],
 

--- a/packages/examples/src/xmpt/local-messaging.ts
+++ b/packages/examples/src/xmpt/local-messaging.ts
@@ -1,0 +1,81 @@
+import { a2a } from '@lucid-agents/a2a';
+import { createAgent } from '@lucid-agents/core';
+import { createAgentApp } from '@lucid-agents/hono';
+import { http } from '@lucid-agents/http';
+import { xmpt } from '@lucid-agents/xmpt';
+
+async function main(): Promise<void> {
+  const alpha = await createAgent({
+    name: 'alpha',
+    version: '1.0.0',
+    description: 'XMPT sender',
+  })
+    .use(a2a())
+    .use(http())
+    .use(xmpt())
+    .build();
+
+  const beta = await createAgent({
+    name: 'beta',
+    version: '1.0.0',
+    description: 'XMPT receiver',
+  })
+    .use(a2a())
+    .use(http())
+    .use(
+      xmpt({
+        inbox: {
+          handler: async ({ message }) => ({
+            content: {
+              text: `ack:${message.content.text ?? ''}`,
+            },
+          }),
+        },
+      })
+    )
+    .build();
+
+  const alphaApp = await createAgentApp(alpha);
+  const betaApp = await createAgentApp(beta);
+
+  const alphaServer = Bun.serve({
+    port: 8789,
+    fetch: alphaApp.app.fetch,
+  });
+
+  const betaServer = Bun.serve({
+    port: 8790,
+    fetch: betaApp.app.fetch,
+  });
+
+  try {
+    console.log('Alpha listening on http://localhost:8789');
+    console.log('Beta listening on http://localhost:8790');
+
+    const result = await alpha.xmpt!.sendAndWait(
+      { url: 'http://localhost:8790' },
+      {
+        threadId: 'example-thread',
+        content: { text: 'hello from alpha' },
+      },
+      {
+        timeoutMs: 5000,
+      }
+    );
+
+    console.log('Delivery:', result.delivery);
+    console.log('Task status:', result.task.status);
+    console.log('Reply output:', result.task.result?.output);
+
+    const betaMessages = await beta.xmpt!.listMessages({
+      threadId: 'example-thread',
+    });
+
+    console.log('Beta message history:', betaMessages);
+  } finally {
+    alphaServer.stop();
+    betaServer.stop();
+  }
+}
+
+await main();

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -56,6 +56,11 @@
       "import": "./dist/wallets/index.js",
       "default": "./dist/wallets/index.js"
     },
+    "./xmpt": {
+      "types": "./dist/xmpt/index.d.ts",
+      "import": "./dist/xmpt/index.js",
+      "default": "./dist/xmpt/index.js"
+    },
     "./package.json": "./package.json"
   },
   "sideEffects": false,

--- a/packages/types/src/core/runtime.ts
+++ b/packages/types/src/core/runtime.ts
@@ -8,6 +8,7 @@ import type { EntrypointsRuntime } from './entrypoint';
 import type { AnalyticsRuntime } from '../analytics';
 import type { SchedulerRuntime } from '../scheduler';
 import type { AgentCore } from './agent';
+import type { XMPTRuntime } from '../xmpt';
 
 /**
  * Agent runtime interface.
@@ -25,6 +26,7 @@ export type AgentRuntime = {
   payments?: PaymentsRuntime;
   analytics?: AnalyticsRuntime;
   a2a?: A2ARuntime;
+  xmpt?: XMPTRuntime;
   ap2?: AP2Runtime;
   scheduler?: SchedulerRuntime;
   handlers?: AgentHttpHandlers;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,3 +9,4 @@ export * from './identity';
 export * from './payments';
 export * from './scheduler';
 export * from './wallets';
+export * from './xmpt';

--- a/packages/types/src/xmpt/index.ts
+++ b/packages/types/src/xmpt/index.ts
@@ -1,0 +1,107 @@
+import type { AgentCard, Task } from '../a2a';
+import type { AgentRuntime } from '../core';
+import type { FetchFunction } from '../http';
+
+export type XMPTContent = {
+  text?: string;
+  data?: unknown;
+  mime?: string;
+};
+
+export type XMPTMessage = {
+  id: string;
+  threadId: string;
+  from?: string;
+  to?: string;
+  content: XMPTContent;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+};
+
+export type XMPTPeer = { url: string } | { card: AgentCard };
+
+export type XMPTDeliveryResult = {
+  taskId: string;
+  status: string;
+  messageId: string;
+};
+
+export type XMPTMessageDirection = 'inbound' | 'outbound';
+
+export type XMPTMessageRecord = XMPTMessage & {
+  direction: XMPTMessageDirection;
+  peer?: string;
+  taskId?: string;
+};
+
+export type XMPTListMessagesFilters = {
+  threadId?: string;
+  direction?: XMPTMessageDirection;
+  limit?: number;
+  offset?: number;
+};
+
+export type XMPTOnMessageHandler = (
+  message: XMPTMessage
+) => void | Promise<void>;
+
+export type XMPTInboxReply = {
+  content: XMPTContent;
+  metadata?: Record<string, unknown>;
+  threadId?: string;
+  to?: string;
+};
+
+export type XMPTInboxHandlerArgs = {
+  message: XMPTMessage;
+  runtime: AgentRuntime;
+};
+
+export type XMPTInboxHandler = (
+  args: XMPTInboxHandlerArgs
+) => XMPTInboxReply | void | Promise<XMPTInboxReply | void>;
+
+export type XMPTStore = {
+  append(message: XMPTMessageRecord): void | Promise<void>;
+  list(
+    filters?: XMPTListMessagesFilters
+  ): XMPTMessageRecord[] | Promise<XMPTMessageRecord[]>;
+};
+
+export type XMPTSendOptions = {
+  skillId?: string;
+  timeoutMs?: number;
+  fetch?: FetchFunction;
+  metadata?: Record<string, unknown>;
+};
+
+export type XMPTSendInput = {
+  id?: string;
+  threadId?: string;
+  from?: string;
+  to?: string;
+  content: XMPTContent;
+  metadata?: Record<string, unknown>;
+  createdAt?: string;
+};
+
+export type XMPTSendAndWaitResult = {
+  delivery: XMPTDeliveryResult;
+  task: Task<XMPTMessage | null>;
+};
+
+export type XMPTRuntime = {
+  send(
+    peer: XMPTPeer,
+    message: XMPTSendInput,
+    options?: XMPTSendOptions
+  ): Promise<XMPTDeliveryResult>;
+  sendAndWait(
+    peer: XMPTPeer,
+    message: XMPTSendInput,
+    options?: XMPTSendOptions
+  ): Promise<XMPTSendAndWaitResult>;
+  receive(message: XMPTMessage): Promise<XMPTMessage | undefined>;
+  onMessage(handler: XMPTOnMessageHandler): () => void;
+  listMessages(filters?: XMPTListMessagesFilters): Promise<XMPTMessageRecord[]>;
+};

--- a/packages/xmpt/README.md
+++ b/packages/xmpt/README.md
@@ -1,0 +1,165 @@
+# @lucid-agents/xmpt
+
+XMPT is the high-level messaging layer for Lucid Agents.
+
+It sits on top of A2A tasks and adds:
+
+- inbox semantics (`xmpt-inbox` by default)
+- a normalized message envelope (`id`, `threadId`, `content`, metadata)
+- thread-aware `send`, `sendAndWait`, and `receive` APIs
+- local message observability (`onMessage`) and history (`listMessages`)
+- manifest discovery tags (`xmpt`, `xmpt-inbox`) so peers can find inbox skills
+
+## When to use XMPT
+
+Use XMPT when your agent needs conversation-like messaging between agents:
+
+- multi-step delegation flows where context must persist via `threadId`
+- async request/reply patterns where `sendAndWait` is simpler than raw task polling
+- inbox behavior for peer-to-peer agent messaging
+- local transcript/history or analytics hooks through the pluggable store
+
+Use plain A2A directly when you only need one-off skill invocation and do not need messaging semantics.
+
+## Delivery and failure semantics
+
+- A2A delivery failures throw and fail `send`/`sendAndWait`
+- timeout waiting for task completion throws `XMPT_TIMEOUT`
+- local store append failures are best-effort and do not fail delivery
+- `onMessage` subscriber failures are best-effort and do not fail delivery
+
+## Install
+
+```bash
+bun add @lucid-agents/xmpt
+```
+
+## Quick start
+
+```ts
+import { createAgent } from '@lucid-agents/core';
+import { a2a } from '@lucid-agents/a2a';
+import { http } from '@lucid-agents/http';
+import { xmpt } from '@lucid-agents/xmpt';
+
+const runtime = await createAgent({
+  name: 'alpha',
+  version: '0.1.0',
+})
+  .use(http())
+  .use(a2a())
+  .use(
+    xmpt({
+      inbox: {
+        handler: async ({ message }) => ({
+          content: { text: `ack:${message.content.text ?? ''}` },
+        }),
+      },
+    })
+  )
+  .build();
+
+await runtime.xmpt?.send(
+  { url: 'http://localhost:8788' },
+  { content: { text: 'hello' }, threadId: 't-1' }
+);
+```
+
+## API overview
+
+`runtime.xmpt` exposes:
+
+- `send(peer, message, options?)` - deliver a message and return task metadata
+- `sendAndWait(peer, message, options?)` - deliver and wait for task completion
+- `receive(message)` - process an inbound XMPT message (inbox entrypoint uses this)
+- `onMessage(handler)` - subscribe to inbound message events
+- `listMessages(filters?)` - query local message records
+
+### `sendAndWait` example
+
+```ts
+const result = await runtime.xmpt!.sendAndWait(
+  { url: 'https://beta.example.com' },
+  {
+    threadId: 'portfolio-rebalance-42',
+    content: { text: 'calculate hedge ratio' },
+  },
+  { timeoutMs: 15_000 }
+);
+
+console.log(result.delivery.taskId);
+console.log(result.task.status);
+console.log(result.task.result?.output);
+```
+
+### Message observability and history
+
+```ts
+const unsubscribe = runtime.xmpt!.onMessage(message => {
+  console.log('Inbound message:', message.threadId, message.content.text);
+});
+
+const threadHistory = await runtime.xmpt!.listMessages({
+  threadId: 'portfolio-rebalance-42',
+});
+
+unsubscribe();
+```
+
+## Configuration
+
+```ts
+import { createMemoryXMPTStore, xmpt } from '@lucid-agents/xmpt';
+
+const store = createMemoryXMPTStore();
+
+xmpt({
+  inbox: {
+    key: 'custom-inbox',
+    handler: async ({ message }) => ({
+      content: { text: `ack:${message.content.text ?? ''}` },
+    }),
+  },
+  discovery: {
+    preferredSkillId: 'custom-inbox',
+  },
+  store,
+});
+```
+
+### Options
+
+- `inbox.key` - inbox entrypoint key (defaults to `xmpt-inbox`)
+- `inbox.handler` - optional handler to process inbound messages and produce a reply
+- `discovery.preferredSkillId` - preferred remote skill id during inbox resolution
+- `store` - pluggable local store for message records (`append`, `list`)
+
+## Use cases
+
+- Supervisor/worker orchestration where every job runs in a thread
+- Facilitator agents that route requests across specialist agents
+- Cross-agent negotiation loops that need durable conversation IDs
+- Human-in-the-loop systems that need local message audit trails
+
+## Running the working example
+
+A local two-agent XMPT example is available at:
+
+- `packages/examples/src/xmpt/local-messaging.ts`
+
+Run it from repo root:
+
+```bash
+bun run packages/examples/src/xmpt/local-messaging.ts
+```
+
+This example starts two agents (`alpha`, `beta`), sends a message with `sendAndWait`, and prints delivery status plus thread history.
+
+## Error codes
+
+XMPT throws structured `XMPTError` instances with these codes:
+
+- `XMPT_PEER_UNREACHABLE` - A2A is unavailable, peer card fetch fails, message send fails, or remote task polling fails.
+- `XMPT_INBOX_SKILL_MISSING` - Peer card does not expose an inbox skill matching preferred/default/tag-based discovery.
+- `XMPT_INVALID_MESSAGE_PAYLOAD` - Message payload/content shape is invalid (missing required ids/timestamps or invalid field types).
+- `XMPT_TIMEOUT` - `sendAndWait` exceeded `timeoutMs` before the remote task completed.

--- a/packages/xmpt/package.json
+++ b/packages/xmpt/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@lucid-agents/xmpt",
+  "version": "0.1.0",
+  "description": "XMPT messaging extension for Lucid agents",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/daydreamsai/lucid-agents",
+    "directory": "packages/xmpt"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "clean": "rm -rf dist",
+    "test": "bun test",
+    "type-check": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@lucid-agents/a2a": "workspace:*",
+    "@lucid-agents/types": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@lucid-agents/core": "workspace:*",
+    "@lucid-agents/http": "workspace:*",
+    "@lucid-agents/hono": "workspace:*",
+    "tsup": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/xmpt/src/__tests__/e2e.test.ts
+++ b/packages/xmpt/src/__tests__/e2e.test.ts
@@ -1,0 +1,81 @@
+import { a2a } from '@lucid-agents/a2a';
+import { createAgent } from '@lucid-agents/core';
+import { createAgentApp } from '@lucid-agents/hono';
+import { http } from '@lucid-agents/http';
+import { describe, expect, it } from 'bun:test';
+
+import { xmpt } from '../extension';
+
+describe('xmpt local e2e', () => {
+  it('exchanges messages between two local agents', async () => {
+    const alpha = await createAgent({
+      name: 'alpha',
+      version: '1.0.0',
+    })
+      .use(a2a())
+      .use(http())
+      .use(xmpt())
+      .build();
+
+    const beta = await createAgent({
+      name: 'beta',
+      version: '1.0.0',
+    })
+      .use(a2a())
+      .use(http())
+      .use(
+        xmpt({
+          inbox: {
+            handler: async ({ message }) => ({
+              content: {
+                text: `ack:${message.content.text ?? ''}`,
+              },
+            }),
+          },
+        })
+      )
+      .build();
+
+    const alphaApp = await createAgentApp(alpha);
+    const betaApp = await createAgentApp(beta);
+
+    const alphaServer = Bun.serve({
+      port: 0,
+      fetch: alphaApp.app.fetch,
+    });
+
+    const betaServer = Bun.serve({
+      port: 0,
+      fetch: betaApp.app.fetch,
+    });
+
+    try {
+      const betaUrl = `http://127.0.0.1:${betaServer.port}`;
+
+      const result = await alpha.xmpt!.sendAndWait(
+        { url: betaUrl },
+        {
+          threadId: 'thread-e2e',
+          content: { text: 'hello' },
+        },
+        {
+          timeoutMs: 3000,
+        }
+      );
+
+      expect(result.task.status).toBe('completed');
+      expect(result.task.result?.output?.threadId).toBe('thread-e2e');
+      expect(result.task.result?.output?.content.text).toBe('ack:hello');
+
+      const betaMessages = await beta.xmpt!.listMessages({
+        threadId: 'thread-e2e',
+      });
+      expect(betaMessages).toHaveLength(2);
+      expect(betaMessages[0]?.direction).toBe('inbound');
+      expect(betaMessages[1]?.direction).toBe('outbound');
+    } finally {
+      alphaServer.stop();
+      betaServer.stop();
+    }
+  });
+});

--- a/packages/xmpt/src/__tests__/extension.test.ts
+++ b/packages/xmpt/src/__tests__/extension.test.ts
@@ -1,0 +1,102 @@
+import { a2a } from '@lucid-agents/a2a';
+import { createAgent } from '@lucid-agents/core';
+import { http } from '@lucid-agents/http';
+import { describe, expect, it } from 'bun:test';
+import { z } from 'zod';
+
+import { xmpt } from '../extension';
+
+describe('xmpt extension', () => {
+  it('adds runtime slice and inbox entrypoint', async () => {
+    const runtime = await createAgent({
+      name: 'xmpt-agent',
+      version: '1.0.0',
+    })
+      .use(a2a())
+      .use(http())
+      .use(
+        xmpt({
+          inbox: {
+            handler: async ({ message }) => ({
+              content: {
+                text: `ack:${message.content.text ?? ''}`,
+              },
+            }),
+          },
+        })
+      )
+      .build();
+
+    expect(runtime.xmpt).toBeDefined();
+
+    const entrypoint = runtime.entrypoints
+      .snapshot()
+      .find(value => value.key === 'xmpt-inbox');
+
+    expect(entrypoint).toBeDefined();
+    expect(entrypoint?.handler).toBeDefined();
+  });
+
+  it('tags inbox skill for manifest discoverability', async () => {
+    const runtime = await createAgent({
+      name: 'discoverable-agent',
+      version: '1.0.0',
+    })
+      .use(a2a())
+      .use(http())
+      .use(xmpt())
+      .build();
+
+    const manifest = runtime.manifest.build('https://agent.example.com');
+    const inboxSkill = manifest.skills?.find(
+      skill => skill.id === 'xmpt-inbox'
+    );
+
+    expect(inboxSkill).toBeDefined();
+    expect(inboxSkill?.tags).toContain('xmpt');
+    expect(inboxSkill?.tags).toContain('xmpt-inbox');
+  });
+
+  it('keeps existing manifest skills unchanged', async () => {
+    const runtime = await createAgent({
+      name: 'compat-agent',
+      version: '1.0.0',
+    })
+      .addEntrypoint({
+        key: 'echo',
+        input: z.object({ text: z.string() }),
+        output: z.object({ text: z.string() }),
+        handler: async ctx => ({
+          output: { text: (ctx.input as { text: string }).text },
+        }),
+      })
+      .use(a2a())
+      .use(http())
+      .use(xmpt())
+      .build();
+
+    const manifest = runtime.manifest.build('https://agent.example.com');
+    const echoSkill = manifest.skills?.find(skill => skill.id === 'echo');
+
+    expect(echoSkill).toBeDefined();
+    expect(echoSkill?.tags).toBeUndefined();
+  });
+
+  it('fails to build when a2a runtime is missing', async () => {
+    await expect(
+      createAgent({
+        name: 'missing-a2a',
+        version: '1.0.0',
+      })
+        .use(http())
+        .use(xmpt())
+        .build()
+    ).rejects.toThrow('[XMPT_PEER_UNREACHABLE]');
+  });
+
+  it('fails fast for invalid configuration', () => {
+    expect(() => xmpt({ inbox: { key: '   ' } })).toThrow(
+      '[XMPT_INVALID_CONFIG]'
+    );
+  });
+});

--- a/packages/xmpt/src/__tests__/runtime.test.ts
+++ b/packages/xmpt/src/__tests__/runtime.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, it, mock } from 'bun:test';
+import type { AgentCard, A2AClient, A2ARuntime } from '@lucid-agents/types/a2a';
+import type { AgentRuntime } from '@lucid-agents/types/core';
+import type { XMPTMessage, XMPTStore } from '@lucid-agents/types/xmpt';
+
+import { createXMPTRuntime } from '../runtime';
+
+const peerCard: AgentCard = {
+  name: 'peer-agent',
+  version: '1.0.0',
+  url: 'https://peer.example.com/',
+  skills: [
+    {
+      id: 'xmpt-inbox',
+      tags: ['xmpt-inbox'],
+    },
+  ],
+};
+
+function createMockRuntime(options?: {
+  fetchCard?: ReturnType<typeof mock>;
+  sendMessage?: ReturnType<typeof mock>;
+  getTask?: ReturnType<typeof mock>;
+}): AgentRuntime {
+  const fetchCard =
+    options?.fetchCard ??
+    mock(async () => {
+      return peerCard;
+    });
+
+  const sendMessage =
+    options?.sendMessage ??
+    mock(async () => ({
+      taskId: 'task-1',
+      status: 'running' as const,
+    }));
+
+  const getTask =
+    options?.getTask ??
+    mock(async () => ({
+      taskId: 'task-1',
+      status: 'completed' as const,
+      result: {
+        output: {
+          id: 'reply-1',
+          threadId: 'thread-1',
+          content: { text: 'ack:hello' },
+          createdAt: new Date().toISOString(),
+        },
+      },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }));
+
+  const client: A2AClient = {
+    invoke: mock(async () => ({ status: 'succeeded' })),
+    stream: mock(async () => {}),
+    fetchAndInvoke: mock(async () => ({ status: 'succeeded' })),
+    sendMessage,
+    getTask,
+    subscribeTask: mock(async () => {}),
+    fetchAndSendMessage: mock(async () => ({
+      taskId: 'task-1',
+      status: 'running' as const,
+    })),
+    listTasks: mock(async () => ({ tasks: [] })),
+    cancelTask: mock(async () => ({
+      taskId: 'task-1',
+      status: 'cancelled' as const,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    })),
+  };
+
+  const a2aRuntime: A2ARuntime = {
+    buildCard: mock(() => ({ ...peerCard, entrypoints: {} })),
+    fetchCard,
+    fetchCardWithEntrypoints: mock(async () => ({
+      ...peerCard,
+      entrypoints: {},
+    })),
+    client,
+  };
+
+  return {
+    agent: {
+      config: {
+        meta: {
+          name: 'alpha',
+          version: '1.0.0',
+        },
+      },
+      addEntrypoint: mock(),
+      getEntrypoint: mock(),
+      listEntrypoints: mock(() => []),
+    },
+    a2a: a2aRuntime,
+    entrypoints: {
+      add: mock(),
+      list: mock(() => []),
+      snapshot: mock(() => []),
+    },
+    manifest: {
+      build: mock(() => ({ ...peerCard, entrypoints: {} })),
+      invalidate: mock(),
+    },
+  };
+}
+
+describe('createXMPTRuntime', () => {
+  it('send() resolves peer URL and creates task message', async () => {
+    const fetchCard = mock(async () => peerCard);
+    const sendMessage = mock(async () => ({
+      taskId: 'task-123',
+      status: 'running' as const,
+    }));
+
+    const runtime = createMockRuntime({ fetchCard, sendMessage });
+    const xmpt = createXMPTRuntime({ runtime });
+
+    const result = await xmpt.send(
+      { url: 'https://peer.example.com' },
+      {
+        threadId: 'thread-123',
+        content: { text: 'hello' },
+      }
+    );
+
+    expect(result.taskId).toBe('task-123');
+    expect(result.status).toBe('running');
+    expect(result.messageId).toBeDefined();
+    expect(fetchCard).toHaveBeenCalledWith(
+      'https://peer.example.com',
+      undefined
+    );
+
+    const firstCall = sendMessage.mock.calls[0];
+    expect(firstCall).toBeDefined();
+
+    const [, skillId, input, , taskOptions] = firstCall as unknown as [
+      AgentCard,
+      string,
+      XMPTMessage,
+      unknown,
+      { contextId: string },
+    ];
+
+    expect(skillId).toBe('xmpt-inbox');
+    expect(input.threadId).toBe('thread-123');
+    expect(taskOptions.contextId).toBe('thread-123');
+  });
+
+  it('receive() invokes inbox handler and returns reply', async () => {
+    const inboxHandler = mock(
+      async ({ message }: { message: XMPTMessage }) => ({
+        content: { text: `ack:${message.content.text}` },
+      })
+    );
+
+    const runtime = createMockRuntime();
+    const xmpt = createXMPTRuntime({ runtime, inboxHandler });
+
+    const incoming: XMPTMessage = {
+      id: 'incoming-1',
+      threadId: 'thread-1',
+      from: 'beta',
+      content: { text: 'hello' },
+      createdAt: new Date().toISOString(),
+    };
+
+    const reply = await xmpt.receive(incoming);
+
+    expect(reply).toBeDefined();
+    expect(reply?.threadId).toBe('thread-1');
+    expect(reply?.content.text).toBe('ack:hello');
+    expect(inboxHandler).toHaveBeenCalledTimes(1);
+
+    const messages = await xmpt.listMessages({ threadId: 'thread-1' });
+    expect(messages).toHaveLength(2);
+    expect(messages[0]?.direction).toBe('inbound');
+    expect(messages[1]?.direction).toBe('outbound');
+  });
+
+  it('sendAndWait() returns completed task result', async () => {
+    const runtime = createMockRuntime({
+      getTask: mock(async () => ({
+        taskId: 'task-1',
+        status: 'completed' as const,
+        result: {
+          output: {
+            id: 'reply-1',
+            threadId: 'thread-send-and-wait',
+            content: { text: 'ack:hello' },
+            createdAt: new Date().toISOString(),
+          },
+        },
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })),
+    });
+
+    const xmpt = createXMPTRuntime({ runtime });
+
+    const result = await xmpt.sendAndWait(
+      { card: peerCard },
+      {
+        threadId: 'thread-send-and-wait',
+        content: { text: 'hello' },
+      }
+    );
+
+    expect(result.delivery.taskId).toBe('task-1');
+    expect(result.task.status).toBe('completed');
+    expect(result.task.result?.output?.threadId).toBe('thread-send-and-wait');
+    expect(result.task.result?.output?.content.text).toBe('ack:hello');
+  });
+
+  it('send() succeeds even when store append fails after peer delivery', async () => {
+    const sendMessage = mock(async () => ({
+      taskId: 'task-store-failure',
+      status: 'running' as const,
+    }));
+    const runtime = createMockRuntime({ sendMessage });
+    const failingStore: XMPTStore = {
+      append: mock(async () => {
+        throw new Error('store unavailable');
+      }),
+      list: mock(() => []),
+    };
+    const xmpt = createXMPTRuntime({ runtime, store: failingStore });
+
+    const result = await xmpt.send(
+      { card: peerCard },
+      {
+        threadId: 'thread-store-failure',
+        content: { text: 'hello' },
+      }
+    );
+
+    expect(result.taskId).toBe('task-store-failure');
+    expect(result.status).toBe('running');
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws deterministic error when inbox skill is missing', async () => {
+    const fetchCard = mock(async () => ({
+      ...peerCard,
+      skills: [],
+    }));
+
+    const runtime = createMockRuntime({ fetchCard });
+    const xmpt = createXMPTRuntime({ runtime });
+
+    await expect(
+      xmpt.send(
+        { url: 'https://peer.example.com' },
+        {
+          content: { text: 'hello' },
+        }
+      )
+    ).rejects.toThrow('[XMPT_INBOX_SKILL_MISSING]');
+  });
+
+  it('listMessages() filters by thread and records inbound/outbound flows', async () => {
+    const runtime = createMockRuntime();
+    const xmpt = createXMPTRuntime({ runtime });
+
+    await xmpt.send(
+      { card: peerCard },
+      {
+        threadId: 'thread-1',
+        content: { text: 'outbound' },
+      }
+    );
+
+    await xmpt.receive({
+      id: 'inbound-1',
+      threadId: 'thread-1',
+      from: 'peer',
+      content: { text: 'inbound' },
+      createdAt: new Date().toISOString(),
+    });
+
+    await xmpt.receive({
+      id: 'other-thread',
+      threadId: 'thread-2',
+      from: 'peer',
+      content: { text: 'other' },
+      createdAt: new Date().toISOString(),
+    });
+
+    const threadMessages = await xmpt.listMessages({ threadId: 'thread-1' });
+    expect(threadMessages).toHaveLength(2);
+    expect(
+      threadMessages.some(message => message.direction === 'inbound')
+    ).toBe(true);
+    expect(
+      threadMessages.some(message => message.direction === 'outbound')
+    ).toBe(true);
+  });
+
+  it('receive() continues when a subscriber throws', async () => {
+    const inboxHandler = mock(async () => ({
+      content: { text: 'ack:hello' },
+    }));
+    const runtime = createMockRuntime();
+    const xmpt = createXMPTRuntime({ runtime, inboxHandler });
+    xmpt.onMessage(() => {
+      throw new Error('observer failure');
+    });
+
+    const reply = await xmpt.receive({
+      id: 'receive-observer-failure',
+      threadId: 'thread-observer-failure',
+      content: { text: 'hello' },
+      createdAt: new Date().toISOString(),
+    });
+
+    expect(reply?.content.text).toBe('ack:hello');
+    expect(inboxHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('sendAndWait() continues when a subscriber throws while processing reply', async () => {
+    const runtime = createMockRuntime({
+      getTask: mock(async () => ({
+        taskId: 'task-observer-failure',
+        status: 'completed' as const,
+        result: {
+          output: {
+            id: 'reply-observer-failure',
+            threadId: 'thread-observer-failure',
+            content: { text: 'ack:hello' },
+            createdAt: new Date().toISOString(),
+          },
+        },
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })),
+    });
+    const xmpt = createXMPTRuntime({ runtime });
+    xmpt.onMessage(() => {
+      throw new Error('observer failure');
+    });
+
+    const result = await xmpt.sendAndWait(
+      { card: peerCard },
+      {
+        threadId: 'thread-observer-failure',
+        content: { text: 'hello' },
+      }
+    );
+
+    expect(result.delivery.taskId).toBe('task-1');
+    expect(result.task.status).toBe('completed');
+    expect(result.task.result?.output?.content.text).toBe('ack:hello');
+  });
+
+  it('onMessage() subscribes and unsubscribes handlers', async () => {
+    const runtime = createMockRuntime();
+    const xmpt = createXMPTRuntime({ runtime });
+
+    const handler = mock(async (_message: XMPTMessage) => {});
+    const unsubscribe = xmpt.onMessage(handler);
+
+    await xmpt.receive({
+      id: 'm-1',
+      threadId: 'thread-1',
+      content: { text: 'hello' },
+      createdAt: new Date().toISOString(),
+    });
+
+    unsubscribe();
+
+    await xmpt.receive({
+      id: 'm-2',
+      threadId: 'thread-2',
+      content: { text: 'hello-again' },
+      createdAt: new Date().toISOString(),
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/xmpt/src/__tests__/store.test.ts
+++ b/packages/xmpt/src/__tests__/store.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'bun:test';
+import type { XMPTMessageRecord } from '@lucid-agents/types/xmpt';
+
+import { createMemoryXMPTStore } from '../store/memory';
+
+const makeMessage = (
+  id: string,
+  threadId: string,
+  direction: XMPTMessageRecord['direction']
+): XMPTMessageRecord => ({
+  id,
+  threadId,
+  direction,
+  content: { text: id },
+  createdAt: new Date().toISOString(),
+});
+
+describe('createMemoryXMPTStore', () => {
+  it('stores and lists messages', async () => {
+    const store = createMemoryXMPTStore();
+
+    const first = makeMessage('m-1', 't-1', 'inbound');
+    const second = makeMessage('m-2', 't-1', 'outbound');
+
+    await store.append(first);
+    await store.append(second);
+
+    const listed = await store.list();
+    expect(listed).toHaveLength(2);
+    expect(listed[0]?.id).toBe('m-1');
+    expect(listed[1]?.id).toBe('m-2');
+  });
+
+  it('filters by threadId and direction', async () => {
+    const store = createMemoryXMPTStore([
+      makeMessage('m-1', 't-1', 'inbound'),
+      makeMessage('m-2', 't-1', 'outbound'),
+      makeMessage('m-3', 't-2', 'inbound'),
+    ]);
+
+    const threadMessages = await store.list({ threadId: 't-1' });
+    expect(threadMessages).toHaveLength(2);
+
+    const outboundMessages = await store.list({ direction: 'outbound' });
+    expect(outboundMessages).toHaveLength(1);
+    expect(outboundMessages[0]?.id).toBe('m-2');
+  });
+
+  it('supports offset and limit', async () => {
+    const store = createMemoryXMPTStore([
+      makeMessage('m-1', 't-1', 'inbound'),
+      makeMessage('m-2', 't-1', 'outbound'),
+      makeMessage('m-3', 't-1', 'inbound'),
+    ]);
+
+    const paged = await store.list({ offset: 1, limit: 1 });
+    expect(paged).toHaveLength(1);
+    expect(paged[0]?.id).toBe('m-2');
+  });
+});

--- a/packages/xmpt/src/client.ts
+++ b/packages/xmpt/src/client.ts
@@ -1,0 +1,174 @@
+import { randomUUID } from 'node:crypto';
+
+import type { AgentCard } from '@lucid-agents/types/a2a';
+import type {
+  XMPTMessage,
+  XMPTPeer,
+  XMPTSendInput,
+} from '@lucid-agents/types/xmpt';
+
+import { XMPTError } from './errors';
+
+export const XMPT_INBOX_DISCOVERY_TAG = 'xmpt-inbox';
+export const XMPT_DISCOVERY_TAG = 'xmpt';
+
+export function resolvePeerUrl(peer: XMPTPeer): string | undefined {
+  if ('url' in peer) {
+    return peer.url;
+  }
+  return peer.card.url;
+}
+
+export function resolveInboxSkillId(
+  card: AgentCard,
+  defaultInboxSkillId: string,
+  preferredSkillId?: string
+): string | undefined {
+  const skills = card.skills ?? [];
+
+  if (preferredSkillId) {
+    const preferred = skills.find(skill => skill.id === preferredSkillId);
+    if (preferred) {
+      return preferred.id;
+    }
+  }
+
+  const defaultSkill = skills.find(skill => skill.id === defaultInboxSkillId);
+  if (defaultSkill) {
+    return defaultSkill.id;
+  }
+
+  const taggedSkill = skills.find(skill =>
+    skill.tags?.some(tag => {
+      const normalized = tag.toLowerCase();
+      return (
+        normalized === XMPT_DISCOVERY_TAG ||
+        normalized === XMPT_INBOX_DISCOVERY_TAG
+      );
+    })
+  );
+
+  return taggedSkill?.id;
+}
+
+export function normalizeXMPTMessage(
+  input: XMPTSendInput,
+  defaults: {
+    from?: string;
+    to?: string;
+    now: string;
+  }
+): XMPTMessage {
+  assertXMPTContent(input.content);
+
+  const id = normalizeOptionalString(input.id) ?? randomUUID();
+  const threadId = normalizeOptionalString(input.threadId) ?? randomUUID();
+
+  return {
+    id,
+    threadId,
+    from: normalizeOptionalString(input.from) ?? defaults.from,
+    to: normalizeOptionalString(input.to) ?? defaults.to,
+    content: input.content,
+    metadata: input.metadata,
+    createdAt: normalizeOptionalString(input.createdAt) ?? defaults.now,
+  };
+}
+
+export function parseXMPTMessage(payload: unknown): XMPTMessage {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new XMPTError(
+      'XMPT_INVALID_MESSAGE_PAYLOAD',
+      'Message payload must be an object'
+    );
+  }
+
+  const value = payload as Record<string, unknown>;
+
+  const id = asRequiredString(value.id, 'id');
+  const threadId = asRequiredString(value.threadId, 'threadId');
+  const createdAt = asRequiredString(value.createdAt, 'createdAt');
+
+  const content = value.content;
+  assertXMPTContent(content);
+
+  const metadata =
+    value.metadata && typeof value.metadata === 'object'
+      ? (value.metadata as Record<string, unknown>)
+      : undefined;
+
+  return {
+    id,
+    threadId,
+    from: asOptionalString(value.from),
+    to: asOptionalString(value.to),
+    content,
+    metadata,
+    createdAt,
+  };
+}
+
+function assertXMPTContent(
+  content: unknown
+): asserts content is XMPTMessage['content'] {
+  if (!content || typeof content !== 'object' || Array.isArray(content)) {
+    throw new XMPTError(
+      'XMPT_INVALID_MESSAGE_PAYLOAD',
+      'Message content must be an object'
+    );
+  }
+
+  const value = content as Record<string, unknown>;
+
+  if (
+    value.text === undefined &&
+    value.data === undefined &&
+    value.mime === undefined
+  ) {
+    throw new XMPTError(
+      'XMPT_INVALID_MESSAGE_PAYLOAD',
+      'Message content requires at least one of text, data, or mime'
+    );
+  }
+
+  if (value.text !== undefined && typeof value.text !== 'string') {
+    throw new XMPTError(
+      'XMPT_INVALID_MESSAGE_PAYLOAD',
+      'Message content.text must be a string'
+    );
+  }
+
+  if (value.mime !== undefined && typeof value.mime !== 'string') {
+    throw new XMPTError(
+      'XMPT_INVALID_MESSAGE_PAYLOAD',
+      'Message content.mime must be a string'
+    );
+  }
+}
+
+function asRequiredString(value: unknown, key: string): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new XMPTError(
+      'XMPT_INVALID_MESSAGE_PAYLOAD',
+      `Message ${key} must be a non-empty string`
+    );
+  }
+
+  return value;
+}
+
+function asOptionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized ? normalized : undefined;
+}
+
+function normalizeOptionalString(
+  value: string | undefined
+): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}

--- a/packages/xmpt/src/client.ts
+++ b/packages/xmpt/src/client.ts
@@ -93,9 +93,16 @@ export function parseXMPTMessage(payload: unknown): XMPTMessage {
   assertXMPTContent(content);
 
   const metadata =
-    value.metadata && typeof value.metadata === 'object'
+    value.metadata && typeof value.metadata === 'object' && !Array.isArray(value.metadata)
       ? (value.metadata as Record<string, unknown>)
-      : undefined;
+      : value.metadata !== undefined && value.metadata !== null
+        ? (() => {
+            throw new XMPTError(
+              'XMPT_INVALID_MESSAGE_PAYLOAD',
+              'Message metadata must be a plain object (not an array or primitive)'
+            );
+          })()
+        : undefined;
 
   return {
     id,

--- a/packages/xmpt/src/errors.ts
+++ b/packages/xmpt/src/errors.ts
@@ -1,0 +1,15 @@
+export type XMPTErrorCode =
+  | 'XMPT_PEER_UNREACHABLE'
+  | 'XMPT_INBOX_SKILL_MISSING'
+  | 'XMPT_INVALID_MESSAGE_PAYLOAD'
+  | 'XMPT_TIMEOUT';
+
+export class XMPTError extends Error {
+  readonly code: XMPTErrorCode;
+
+  constructor(code: XMPTErrorCode, message: string, cause?: unknown) {
+    super(`[${code}] ${message}`, cause ? { cause } : undefined);
+    this.name = 'XMPTError';
+    this.code = code;
+  }
+}

--- a/packages/xmpt/src/extension.ts
+++ b/packages/xmpt/src/extension.ts
@@ -1,0 +1,134 @@
+import type { AgentCardWithEntrypoints } from '@lucid-agents/types/a2a';
+import type {
+  AgentRuntime,
+  BuildContext,
+  Extension,
+} from '@lucid-agents/types/core';
+import type {
+  XMPTInboxHandler,
+  XMPTMessage,
+  XMPTRuntime,
+  XMPTStore,
+} from '@lucid-agents/types/xmpt';
+import { z } from 'zod';
+
+import { XMPT_DISCOVERY_TAG, XMPT_INBOX_DISCOVERY_TAG } from './client';
+import { createXMPTRuntime, DEFAULT_XMPT_INBOX_SKILL_ID } from './runtime';
+
+export type XMPTExtensionOptions = {
+  inbox?: {
+    key?: string;
+    handler?: XMPTInboxHandler;
+  };
+  store?: XMPTStore;
+  discovery?: {
+    preferredSkillId?: string;
+  };
+};
+
+export function xmpt(
+  options: XMPTExtensionOptions = {}
+): Extension<{ xmpt: XMPTRuntime }> {
+  const inboxKey = options.inbox?.key?.trim() || DEFAULT_XMPT_INBOX_SKILL_ID;
+
+  if (options.inbox?.key !== undefined && !options.inbox.key.trim()) {
+    throw new Error(
+      '[XMPT_INVALID_CONFIG] inbox.key must be a non-empty string'
+    );
+  }
+
+  if (
+    options.inbox?.handler !== undefined &&
+    typeof options.inbox.handler !== 'function'
+  ) {
+    throw new Error('[XMPT_INVALID_CONFIG] inbox.handler must be a function');
+  }
+
+  if (
+    options.discovery?.preferredSkillId !== undefined &&
+    !options.discovery.preferredSkillId.trim()
+  ) {
+    throw new Error(
+      '[XMPT_INVALID_CONFIG] discovery.preferredSkillId must be a non-empty string'
+    );
+  }
+
+  const messageSchema = z.object({
+    id: z.string().min(1),
+    threadId: z.string().min(1),
+    from: z.string().min(1).optional(),
+    to: z.string().min(1).optional(),
+    content: z
+      .object({
+        text: z.string().optional(),
+        data: z.unknown().optional(),
+        mime: z.string().optional(),
+      })
+      .refine(
+        value =>
+          value.text !== undefined ||
+          value.data !== undefined ||
+          value.mime !== undefined,
+        {
+          message: 'content must include text, data, or mime',
+        }
+      ),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+    createdAt: z.string().min(1),
+  });
+
+  return {
+    name: 'xmpt',
+
+    build(_ctx: BuildContext): { xmpt: XMPTRuntime } {
+      return {
+        xmpt: {} as XMPTRuntime,
+      };
+    },
+
+    onBuild(runtime: AgentRuntime): void {
+      const xmptRuntime = createXMPTRuntime({
+        runtime,
+        inboxSkillId: inboxKey,
+        inboxHandler: options.inbox?.handler,
+        store: options.store,
+        preferredSkillId: options.discovery?.preferredSkillId,
+      });
+
+      runtime.xmpt = xmptRuntime;
+
+      runtime.entrypoints.add({
+        key: inboxKey,
+        description: 'XMPT inbox for receiving messages from peer agents',
+        input: messageSchema,
+        output: messageSchema.nullable(),
+        handler: async ctx => {
+          const reply = await runtime.xmpt!.receive(ctx.input as XMPTMessage);
+          return {
+            output: reply ?? null,
+            usage: { total_tokens: 0 },
+          };
+        },
+      });
+    },
+
+    onManifestBuild(
+      card: AgentCardWithEntrypoints,
+      _runtime: AgentRuntime
+    ): AgentCardWithEntrypoints {
+      const skills = card.skills ?? [];
+      const inboxSkill = skills.find(skill => skill.id === inboxKey);
+      if (!inboxSkill) {
+        return card;
+      }
+
+      const tags = new Set<string>(inboxSkill.tags ?? []);
+      tags.add(XMPT_DISCOVERY_TAG);
+      tags.add(XMPT_INBOX_DISCOVERY_TAG);
+      inboxSkill.tags = Array.from(tags);
+      (inboxSkill as Record<string, unknown>).x_xmpt = { inbox: true };
+
+      return card;
+    },
+  };
+}

--- a/packages/xmpt/src/index.ts
+++ b/packages/xmpt/src/index.ts
@@ -1,0 +1,41 @@
+/**
+ * @lucid-agents/xmpt
+ *
+ * Agent-to-agent messaging extension for the Lucid SDK.
+ *
+ * @example
+ * ```ts
+ * import { createAgent } from '@lucid-agents/core';
+ * import { http } from '@lucid-agents/http';
+ * import { a2a } from '@lucid-agents/a2a';
+ * import { xmpt } from '@lucid-agents/xmpt';
+ *
+ * const runtime = await createAgent({ name: 'alpha', version: '0.1.0' })
+ *   .use(http())
+ *   .use(a2a())
+ *   .use(
+ *     xmpt({
+ *       inbox: {
+ *         handler: async ({ message }) => ({
+ *           content: { text: `ack:${message.content.text ?? ''}` },
+ *         }),
+ *       },
+ *     })
+ *   )
+ *   .build();
+ *
+ * await runtime.xmpt.send(
+ *   { url: 'http://localhost:8788' },
+ *   { content: { text: 'hello' }, threadId: 't-1' }
+ * );
+ * ```
+ */
+
+export { xmpt, type XMPTExtensionOptions } from './extension';
+export {
+  createXMPTRuntime,
+  DEFAULT_XMPT_INBOX_SKILL_ID,
+  type CreateXMPTRuntimeOptions,
+} from './runtime';
+export { createMemoryXMPTStore } from './store/memory';
+export { XMPTError, type XMPTErrorCode } from './errors';

--- a/packages/xmpt/src/runtime.ts
+++ b/packages/xmpt/src/runtime.ts
@@ -1,0 +1,314 @@
+import { waitForTask } from '@lucid-agents/a2a';
+import type { AgentCard, Task } from '@lucid-agents/types/a2a';
+import type { AgentRuntime } from '@lucid-agents/types/core';
+import type {
+  XMPTDeliveryResult,
+  XMPTInboxHandler,
+  XMPTListMessagesFilters,
+  XMPTMessage,
+  XMPTMessageRecord,
+  XMPTOnMessageHandler,
+  XMPTPeer,
+  XMPTRuntime,
+  XMPTSendAndWaitResult,
+  XMPTSendInput,
+  XMPTSendOptions,
+  XMPTStore,
+} from '@lucid-agents/types/xmpt';
+
+import {
+  normalizeXMPTMessage,
+  parseXMPTMessage,
+  resolveInboxSkillId,
+  resolvePeerUrl,
+} from './client';
+import { XMPTError } from './errors';
+import { createMemoryXMPTStore } from './store/memory';
+
+export const DEFAULT_XMPT_INBOX_SKILL_ID = 'xmpt-inbox';
+
+export type CreateXMPTRuntimeOptions = {
+  runtime: AgentRuntime;
+  inboxSkillId?: string;
+  inboxHandler?: XMPTInboxHandler;
+  store?: XMPTStore;
+  preferredSkillId?: string;
+  now?: () => string;
+};
+
+export function createXMPTRuntime(
+  options: CreateXMPTRuntimeOptions
+): XMPTRuntime {
+  if (!options.runtime.a2a) {
+    throw new XMPTError(
+      'XMPT_PEER_UNREACHABLE',
+      'A2A runtime is required for XMPT'
+    );
+  }
+
+  const runtime = options.runtime;
+  const store = options.store ?? createMemoryXMPTStore();
+  const now = options.now ?? (() => new Date().toISOString());
+  const inboxSkillId =
+    options.inboxSkillId?.trim() || DEFAULT_XMPT_INBOX_SKILL_ID;
+  const subscribers = new Set<XMPTOnMessageHandler>();
+
+  const notifySubscribers = async (message: XMPTMessage): Promise<void> => {
+    for (const handler of subscribers) {
+      try {
+        await handler(message);
+      } catch {
+        // XMPT observers are best-effort and should not break message delivery.
+      }
+    }
+  };
+
+  const appendRecord = async (message: XMPTMessageRecord): Promise<void> => {
+    await Promise.resolve(store.append(message));
+  };
+
+  const appendRecordSafely = async (
+    message: XMPTMessageRecord
+  ): Promise<void> => {
+    try {
+      await appendRecord(message);
+    } catch {
+      // Local persistence failures should not alter delivery semantics.
+    }
+  };
+
+  const resolvePeerCard = async (
+    peer: XMPTPeer,
+    fetchImpl: XMPTSendOptions['fetch']
+  ): Promise<AgentCard> => {
+    if ('card' in peer) {
+      return peer.card;
+    }
+
+    try {
+      return await runtime.a2a!.fetchCard(peer.url, fetchImpl);
+    } catch (error) {
+      throw new XMPTError(
+        'XMPT_PEER_UNREACHABLE',
+        `Unable to fetch peer card from ${peer.url}`,
+        error
+      );
+    }
+  };
+
+  const sendInternal = async (
+    peer: XMPTPeer,
+    message: XMPTSendInput,
+    optionsArg?: XMPTSendOptions
+  ): Promise<{
+    card: AgentCard;
+    normalized: XMPTMessage;
+    delivery: XMPTDeliveryResult;
+    peerUrl?: string;
+  }> => {
+    const normalized = normalizeXMPTMessage(message, {
+      from: runtime.agent.config.meta.name,
+      to: undefined,
+      now: now(),
+    });
+
+    const card = await resolvePeerCard(peer, optionsArg?.fetch);
+
+    const resolvedSkillId =
+      optionsArg?.skillId ??
+      resolveInboxSkillId(card, inboxSkillId, options.preferredSkillId);
+
+    if (!resolvedSkillId) {
+      throw new XMPTError(
+        'XMPT_INBOX_SKILL_MISSING',
+        `Peer does not expose an inbox skill (expected ${inboxSkillId})`
+      );
+    }
+
+    let task: Awaited<ReturnType<typeof runtime.a2a.client.sendMessage>>;
+    try {
+      task = await runtime.a2a!.client.sendMessage(
+        card,
+        resolvedSkillId,
+        normalized,
+        optionsArg?.fetch,
+        {
+          contextId: normalized.threadId,
+          metadata: {
+            ...(optionsArg?.metadata ?? {}),
+            xmpt: {
+              messageId: normalized.id,
+              threadId: normalized.threadId,
+            },
+          },
+        }
+      );
+    } catch (error) {
+      throw new XMPTError(
+        'XMPT_PEER_UNREACHABLE',
+        'Failed to send message to peer inbox',
+        error
+      );
+    }
+
+    const delivery: XMPTDeliveryResult = {
+      taskId: task.taskId,
+      status: task.status,
+      messageId: normalized.id,
+    };
+
+    const peerUrl = resolvePeerUrl(peer);
+    await appendRecordSafely({
+      ...normalized,
+      direction: 'outbound',
+      peer: peerUrl,
+      taskId: task.taskId,
+    });
+
+    return {
+      card,
+      normalized,
+      delivery,
+      peerUrl,
+    };
+  };
+
+  const receive = async (
+    message: XMPTMessage
+  ): Promise<XMPTMessage | undefined> => {
+    const parsedMessage = parseXMPTMessage(message);
+
+    await appendRecordSafely({
+      ...parsedMessage,
+      direction: 'inbound',
+      peer: parsedMessage.from,
+    });
+
+    await notifySubscribers(parsedMessage);
+
+    const inboxHandler = options.inboxHandler;
+    if (!inboxHandler) {
+      return undefined;
+    }
+
+    const reply = await inboxHandler({
+      message: parsedMessage,
+      runtime,
+    });
+
+    if (!reply) {
+      return undefined;
+    }
+
+    const replyMessage = normalizeXMPTMessage(
+      {
+        content: reply.content,
+        metadata: reply.metadata,
+        threadId: reply.threadId ?? parsedMessage.threadId,
+        to: reply.to ?? parsedMessage.from,
+      },
+      {
+        from: runtime.agent.config.meta.name,
+        to: parsedMessage.from,
+        now: now(),
+      }
+    );
+
+    await appendRecordSafely({
+      ...replyMessage,
+      direction: 'outbound',
+      peer: parsedMessage.from,
+    });
+
+    return replyMessage;
+  };
+
+  return {
+    async send(
+      peer: XMPTPeer,
+      message: XMPTSendInput,
+      optionsArg?: XMPTSendOptions
+    ): Promise<XMPTDeliveryResult> {
+      const sent = await sendInternal(peer, message, optionsArg);
+      return sent.delivery;
+    },
+
+    async sendAndWait(
+      peer: XMPTPeer,
+      message: XMPTSendInput,
+      optionsArg?: XMPTSendOptions
+    ): Promise<XMPTSendAndWaitResult> {
+      const sent = await sendInternal(peer, message, optionsArg);
+
+      let task: Task<XMPTMessage | null>;
+      try {
+        const resolvedTask = await waitForTask(
+          runtime.a2a!.client,
+          sent.card,
+          sent.delivery.taskId,
+          optionsArg?.timeoutMs ?? 30000
+        );
+
+        if (
+          resolvedTask.status === 'completed' &&
+          resolvedTask.result?.output !== undefined &&
+          resolvedTask.result?.output !== null
+        ) {
+          const parsedReply = parseXMPTMessage(resolvedTask.result.output);
+
+          await appendRecordSafely({
+            ...parsedReply,
+            direction: 'inbound',
+            peer: sent.peerUrl,
+            taskId: sent.delivery.taskId,
+          });
+
+          await notifySubscribers(parsedReply);
+
+          task = {
+            ...resolvedTask,
+            result: {
+              ...resolvedTask.result,
+              output: parsedReply,
+            },
+          };
+        } else {
+          task = resolvedTask as Task<XMPTMessage | null>;
+        }
+      } catch (error) {
+        if (error instanceof XMPTError) {
+          throw error;
+        }
+
+        const messageText =
+          error instanceof Error ? error.message : 'Task wait failed';
+
+        if (messageText.includes('did not complete within')) {
+          throw new XMPTError('XMPT_TIMEOUT', messageText, error);
+        }
+
+        throw new XMPTError('XMPT_PEER_UNREACHABLE', messageText, error);
+      }
+
+      return {
+        delivery: sent.delivery,
+        task,
+      };
+    },
+
+    receive,
+
+    onMessage(handler: XMPTOnMessageHandler): () => void {
+      subscribers.add(handler);
+      return () => {
+        subscribers.delete(handler);
+      };
+    },
+
+    async listMessages(
+      filters?: XMPTListMessagesFilters
+    ): Promise<XMPTMessageRecord[]> {
+      return await Promise.resolve(store.list(filters));
+    },
+  };
+}

--- a/packages/xmpt/src/runtime.ts
+++ b/packages/xmpt/src/runtime.ts
@@ -54,13 +54,12 @@ export function createXMPTRuntime(
   const subscribers = new Set<XMPTOnMessageHandler>();
 
   const notifySubscribers = async (message: XMPTMessage): Promise<void> => {
-    for (const handler of subscribers) {
-      try {
-        await handler(message);
-      } catch {
-        // XMPT observers are best-effort and should not break message delivery.
-      }
-    }
+    // Run all observers concurrently — none can block delivery or each other.
+    await Promise.allSettled(
+      Array.from(subscribers).map(handler =>
+        Promise.resolve().then(() => handler(message))
+      )
+    );
   };
 
   const appendRecord = async (message: XMPTMessageRecord): Promise<void> => {

--- a/packages/xmpt/src/store/memory.ts
+++ b/packages/xmpt/src/store/memory.ts
@@ -1,0 +1,42 @@
+import type {
+  XMPTListMessagesFilters,
+  XMPTMessageRecord,
+  XMPTStore,
+} from '@lucid-agents/types/xmpt';
+
+export function createMemoryXMPTStore(
+  initialMessages: XMPTMessageRecord[] = []
+): XMPTStore {
+  const messages: XMPTMessageRecord[] = [...initialMessages];
+
+  return {
+    append(message: XMPTMessageRecord): void {
+      messages.push(message);
+    },
+
+    list(filters?: XMPTListMessagesFilters): XMPTMessageRecord[] {
+      let result = [...messages];
+
+      if (filters?.threadId) {
+        result = result.filter(
+          message => message.threadId === filters.threadId
+        );
+      }
+
+      if (filters?.direction) {
+        result = result.filter(
+          message => message.direction === filters.direction
+        );
+      }
+
+      const offset = Math.max(filters?.offset ?? 0, 0);
+      const limit = filters?.limit;
+
+      if (limit !== undefined) {
+        return result.slice(offset, offset + Math.max(limit, 0));
+      }
+
+      return result.slice(offset);
+    },
+  };
+}

--- a/packages/xmpt/tsconfig.json
+++ b/packages/xmpt/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/xmpt/tsup.config.ts
+++ b/packages/xmpt/tsup.config.ts
@@ -1,0 +1,7 @@
+import { definePackageConfig } from '../tsup.config.base';
+
+export default definePackageConfig({
+  entry: ['src/index.ts'],
+  dts: true,
+  external: ['@lucid-agents/types', '@lucid-agents/a2a', 'zod'],
+});


### PR DESCRIPTION
## Summary

Implements `@lucid-agents/xmpt` as specified in issue #171.

XMPT is a composable Lucid SDK extension that adds high-level agent-to-agent messaging semantics on top of existing A2A/HTTP task primitives.

## Changes

### New package: `packages/xmpt/`

- `xmpt()` extension factory integrating with `createAgent().use(xmpt(opts)).build()`
- `XMPTRuntime` exposed at `runtime.xmpt` with:
  - `send(peer, message, options?)` — fire-and-forget delivery via A2A task
  - `sendAndWait(peer, message, options?)` — delivery + task completion polling
  - `receive(message)` — inbound dispatch (used by inbox entrypoint)
  - `onMessage(handler)` — best-effort subscriber, returns unsubscribe fn
  - `listMessages(filters?)` — query local message records by threadId/direction/pagination
- `createMemoryXMPTStore()` — pluggable in-memory store implementing `XMPTStore`
- `XMPTError` with deterministic error codes:
  - `XMPT_PEER_UNREACHABLE` — A2A unavailable, card fetch/send fails
  - `XMPT_INBOX_SKILL_MISSING` — peer has no matching inbox skill
  - `XMPT_INVALID_MESSAGE_PAYLOAD` — invalid message shape
  - `XMPT_TIMEOUT` — `sendAndWait` exceeded `timeoutMs`
- Manifest discoverability: inbox skill tagged with `xmpt` + `xmpt-inbox` + `x_xmpt: { inbox: true }`
- Store append failures are best-effort (do not fail delivery)
- Observer failures are best-effort (do not fail delivery or inbox handler)

### Type updates: `packages/types/`

- New `packages/types/src/xmpt/index.ts` with all XMPT types
- Added `xmpt?: XMPTRuntime` to `AgentRuntime` in `packages/types/src/core/runtime.ts`
- Added `export * from './xmpt'` to `packages/types/src/index.ts`
- Added `./xmpt` subpath export map entry to `packages/types/package.json`

### Example: `packages/examples/src/xmpt/local-messaging.ts`

Two local agents (alpha/beta) exchanging messages via `sendAndWait`, printing delivery status and thread history.

## Tests — 18 pass, 0 fail

```
packages/xmpt/src/__tests__/store.test.ts (3)
  ✓ stores and lists messages
  ✓ filters by threadId and direction
  ✓ supports offset and limit

packages/xmpt/src/__tests__/runtime.test.ts (9)
  ✓ send() resolves peer URL and creates task message
  ✓ receive() invokes inbox handler and returns reply
  ✓ sendAndWait() returns completed task result
  ✓ send() succeeds even when store append fails after peer delivery
  ✓ throws deterministic error when inbox skill is missing
  ✓ listMessages() filters by thread and records inbound/outbound flows
  ✓ receive() continues when a subscriber throws
  ✓ sendAndWait() continues when a subscriber throws while processing reply
  ✓ onMessage() subscribes and unsubscribes handlers

packages/xmpt/src/__tests__/extension.test.ts (5)
  ✓ adds runtime slice and inbox entrypoint
  ✓ tags inbox skill for manifest discoverability
  ✓ keeps existing manifest skills unchanged
  ✓ fails to build when a2a runtime is missing
  ✓ fails fast for invalid configuration

packages/xmpt/src/__tests__/e2e.test.ts (1)
  ✓ exchanges messages between two local agents [real HTTP, two Bun servers, 14ms]
```

Closes #171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced XMPT (Exchange Message Peer Transport), a new messaging layer enabling agents to send, receive, and exchange messages with thread awareness and message history tracking.
  * Added send/sendAndWait capabilities with configurable timeouts.
  * Added message observability with onMessage handlers and listMessages filtering by thread or direction.
  * Includes pluggable storage and custom inbox handler support for message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->