### PR TITLE
feat: add @lucid-agents/identity-solana

### DIFF
--- a/packages/identity-solana/README.md
+++ b/packages/identity-solana/README.md
@@ -1,0 +1,31 @@
+# @lucid-agents/identity-solana
+
+Solana identity extension for the Lucid Agents SDK.
+
+## Installation
+
+```bash
+npm install @lucid-agents/identity-solana
+```
+
+## Usage
+
+```typescript
+import { createAgent } from '@lucid-agents/core';
+import { identitySolana, identitySolanaFromEnv } from '@lucid-agents/identity-solana';
+
+const agent = createAgent({
+  name: 'SolanaAgent'
+})
+.use(identitySolana({ config: identitySolanaFromEnv() }))
+.build();
+
+console.log('Solana Public Key:', agent.identity.getPublicKey());
+```
+
+## Configuration
+
+Environment variables:
+- `SOLANA_PRIVATE_KEY`: JSON array of numbers.
+- `SOLANA_CLUSTER`: `mainnet-beta` or `devnet`.
+- `SOLANA_RPC_URL`: Custom RPC endpoint.

--- a/packages/identity-solana/package.json
+++ b/packages/identity-solana/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@lucid-agents/identity-solana",
+  "version": "1.0.0",
+  "description": "Solana identity extension for Lucid SDK",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@solana/web3.js": "^1.98.4",
+    "zod": "^4.3.6"
+  },
+  "peerDependencies": {
+    "@lucid-agents/core": "*"
+  }
+}

--- a/packages/identity-solana/package.json
+++ b/packages/identity-solana/package.json
@@ -9,9 +9,11 @@
   ],
   "dependencies": {
     "@solana/web3.js": "^1.98.4",
+    "bs58": "^6.0.0",
+    "tweetnacl": "^1.0.3",
     "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "@lucid-agents/core": "*"
+    "@lucid-agents/core": "^1.0.0"
   }
 }

--- a/packages/identity-solana/src/config.ts
+++ b/packages/identity-solana/src/config.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const IdentitySolanaConfigSchema = z.object({
+  solanaPrivateKey: z.string().optional().describe('JSON array of numbers or hex string'),
+  solanaCluster: z.string().default('mainnet-beta'),
+  solanaRpcUrl: z.string().optional(),
+  agentDomain: z.string().optional(),
+  registerIdentity: z.boolean().default(false),
+  pinataJwt: z.string().optional(),
+  atomEnabled: z.boolean().default(false),
+});
+
+export type IdentitySolanaConfig = z.infer<typeof IdentitySolanaConfigSchema>;

--- a/packages/identity-solana/src/config.ts
+++ b/packages/identity-solana/src/config.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
 export const IdentitySolanaConfigSchema = z.object({
-  solanaPrivateKey: z.string().optional().describe('JSON array of numbers or hex string'),
-  solanaCluster: z.string().default('mainnet-beta'),
+  solanaPrivateKey: z.string().optional().describe('JSON array of numbers or hex string (with or without 0x)'),
+  solanaCluster: z.enum(['mainnet-beta', 'testnet', 'devnet', 'localnet']).default('mainnet-beta'),
   solanaRpcUrl: z.string().optional(),
   agentDomain: z.string().optional(),
   registerIdentity: z.boolean().default(false),

--- a/packages/identity-solana/src/env.ts
+++ b/packages/identity-solana/src/env.ts
@@ -1,0 +1,13 @@
+import { IdentitySolanaConfig, IdentitySolanaConfigSchema } from './config';
+
+export function identitySolanaFromEnv(): IdentitySolanaConfig {
+  return IdentitySolanaConfigSchema.parse({
+    solanaPrivateKey: process.env.SOLANA_PRIVATE_KEY,
+    solanaCluster: process.env.SOLANA_CLUSTER,
+    solanaRpcUrl: process.env.SOLANA_RPC_URL,
+    agentDomain: process.env.AGENT_DOMAIN,
+    registerIdentity: process.env.REGISTER_IDENTITY === 'true',
+    pinataJwt: process.env.PINATA_JWT,
+    atomEnabled: process.env.ATOM_ENABLED === 'true',
+  });
+}

--- a/packages/identity-solana/src/env.ts
+++ b/packages/identity-solana/src/env.ts
@@ -1,13 +1,17 @@
 import { IdentitySolanaConfig, IdentitySolanaConfigSchema } from './config';
 
 export function identitySolanaFromEnv(): IdentitySolanaConfig {
-  return IdentitySolanaConfigSchema.parse({
-    solanaPrivateKey: process.env.SOLANA_PRIVATE_KEY,
-    solanaCluster: process.env.SOLANA_CLUSTER,
-    solanaRpcUrl: process.env.SOLANA_RPC_URL,
-    agentDomain: process.env.AGENT_DOMAIN,
-    registerIdentity: process.env.REGISTER_IDENTITY === 'true',
-    pinataJwt: process.env.PINATA_JWT,
-    atomEnabled: process.env.ATOM_ENABLED === 'true',
-  });
+  try {
+    return IdentitySolanaConfigSchema.parse({
+      solanaPrivateKey: process.env.SOLANA_PRIVATE_KEY,
+      solanaCluster: process.env.SOLANA_CLUSTER,
+      solanaRpcUrl: process.env.SOLANA_RPC_URL,
+      agentDomain: process.env.AGENT_DOMAIN,
+      registerIdentity: process.env.REGISTER_IDENTITY === 'true',
+      pinataJwt: process.env.PINATA_JWT,
+      atomEnabled: process.env.ATOM_ENABLED === 'true',
+    });
+  } catch (error) {
+    throw new Error('identitySolanaFromEnv: invalid Solana identity environment configuration', { cause: error });
+  }
 }

--- a/packages/identity-solana/src/env.ts
+++ b/packages/identity-solana/src/env.ts
@@ -1,5 +1,17 @@
 import { IdentitySolanaConfig, IdentitySolanaConfigSchema } from './config';
 
+function parseBooleanEnv(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  const truthy = ['true', '1', 'yes', 'y', 'on'];
+  const falsy = ['false', '0', 'no', 'n', 'off'];
+  
+  if (truthy.includes(normalized)) return true;
+  if (falsy.includes(normalized)) return false;
+  
+  throw new Error(`Invalid boolean environment variable value: "${value}"`);
+}
+
 export function identitySolanaFromEnv(): IdentitySolanaConfig {
   try {
     return IdentitySolanaConfigSchema.parse({
@@ -7,9 +19,9 @@ export function identitySolanaFromEnv(): IdentitySolanaConfig {
       solanaCluster: process.env.SOLANA_CLUSTER,
       solanaRpcUrl: process.env.SOLANA_RPC_URL,
       agentDomain: process.env.AGENT_DOMAIN,
-      registerIdentity: process.env.REGISTER_IDENTITY === 'true',
+      registerIdentity: parseBooleanEnv(process.env.REGISTER_IDENTITY),
       pinataJwt: process.env.PINATA_JWT,
-      atomEnabled: process.env.ATOM_ENABLED === 'true',
+      atomEnabled: parseBooleanEnv(process.env.ATOM_ENABLED),
     });
   } catch (error) {
     throw new Error('identitySolanaFromEnv: invalid Solana identity environment configuration', { cause: error });

--- a/packages/identity-solana/src/extension.ts
+++ b/packages/identity-solana/src/extension.ts
@@ -1,0 +1,35 @@
+import { Connection, Keypair } from '@solana/web3.js';
+import { IdentitySolanaConfig } from './config';
+
+export function identitySolana(options: { config: IdentitySolanaConfig }) {
+  return {
+    name: 'identity-solana',
+    install: (agent: any) => {
+      const config = options.config;
+      const connection = new Connection(config.solanaRpcUrl || 'https://api.mainnet-beta.solana.com');
+      
+      agent.identity = {
+        type: 'solana',
+        getPublicKey: () => {
+             if (config.solanaPrivateKey) {
+                 try {
+                    const secretKey = Uint8Array.from(JSON.parse(config.solanaPrivateKey));
+                    return Keypair.fromSecretKey(secretKey).publicKey.toBase58();
+                 } catch (e) {
+                    return null;
+                 }
+             }
+             return null;
+        },
+        signMessage: async (msg: string) => {
+            // In a real implementation, this would use the Keypair to sign
+            return "solana_sig_...";
+        }
+      };
+    },
+    onManifestBuild: (manifest: any) => {
+      manifest.trust = manifest.trust || {};
+      manifest.trust.solana = { tier: 1, assets: ['SOL', 'USDC'] };
+    }
+  };
+}

--- a/packages/identity-solana/src/extension.ts
+++ b/packages/identity-solana/src/extension.ts
@@ -1,35 +1,71 @@
-import { Connection, Keypair } from '@solana/web3.js';
+import { Connection, Keypair, clusterApiUrl } from '@solana/web3.js';
+import type { BuildContext, Extension, AgentRuntime } from '@lucid-agents/types/core';
+import type { AgentCardWithEntrypoints } from '@lucid-agents/types/a2a';
 import { IdentitySolanaConfig } from './config';
+import bs58 from 'bs58';
+import nacl from 'tweetnacl';
 
-export function identitySolana(options: { config: IdentitySolanaConfig }) {
+export function identitySolana(options: { config: IdentitySolanaConfig }): Extension<{
+  identity: {
+    type: string;
+    getPublicKey: () => string | null;
+    signMessage: (msg: string) => Promise<string>;
+  };
+}> {
+  const { config } = options;
+  
+  // Validate and derive RPC URL
+  const rpcUrl = config.solanaRpcUrl || clusterApiUrl(config.solanaCluster as any);
+  const connection = new Connection(rpcUrl);
+
+  // Keypair parsing helper
+  const getKeypair = (): Keypair | null => {
+    if (!config.solanaPrivateKey) return null;
+    try {
+      if (config.solanaPrivateKey.startsWith('[')) {
+        return Keypair.fromSecretKey(Uint8Array.from(JSON.parse(config.solanaPrivateKey)));
+      }
+      return Keypair.fromSecretKey(bs58.decode(config.solanaPrivateKey));
+    } catch (e) {
+      console.error('identity-solana: failed to parse private key', e);
+      return null;
+    }
+  };
+
+  const keypair = getKeypair();
+
+  if (config.registerIdentity) {
+      console.warn('identity-solana: registerIdentity is only supported in EVM identity flow. Ignoring.');
+  }
+
   return {
     name: 'identity-solana',
-    install: (agent: any) => {
-      const config = options.config;
-      const connection = new Connection(config.solanaRpcUrl || 'https://api.mainnet-beta.solana.com');
-      
-      agent.identity = {
-        type: 'solana',
-        getPublicKey: () => {
-             if (config.solanaPrivateKey) {
-                 try {
-                    const secretKey = Uint8Array.from(JSON.parse(config.solanaPrivateKey));
-                    return Keypair.fromSecretKey(secretKey).publicKey.toBase58();
-                 } catch (e) {
-                    return null;
-                 }
-             }
-             return null;
-        },
-        signMessage: async (msg: string) => {
-            // In a real implementation, this would use the Keypair to sign
-            return "solana_sig_...";
+    build: (_ctx: BuildContext) => {
+      return {
+        identity: {
+          type: 'solana',
+          getPublicKey: () => keypair?.publicKey.toBase58() || null,
+          signMessage: async (msg: string) => {
+            if (!keypair) throw new Error('identity-solana: no keypair available for signing');
+            try {
+              const messageBytes = new TextEncoder().encode(msg);
+              const signature = nacl.sign.detached(messageBytes, keypair.secretKey);
+              return bs58.encode(signature);
+            } catch (err: any) {
+              throw new Error(`identity-solana: signMessage failed: ${err.message}`);
+            }
+          }
         }
       };
     },
-    onManifestBuild: (manifest: any) => {
+    onManifestBuild: (card: AgentCardWithEntrypoints, _runtime: AgentRuntime) => {
+      const manifest = { ...card };
       manifest.trust = manifest.trust || {};
       manifest.trust.solana = { tier: 1, assets: ['SOL', 'USDC'] };
+      if (config.agentDomain) {
+          (manifest as any).domain = config.agentDomain;
+      }
+      return manifest;
     }
   };
 }

--- a/packages/identity-solana/src/index.ts
+++ b/packages/identity-solana/src/index.ts
@@ -1,0 +1,3 @@
+export * from './config';
+export { identitySolanaFromEnv } from './env';
+export { identitySolana } from './extension';

--- a/packages/identity-solana/src/index.ts
+++ b/packages/identity-solana/src/index.ts
@@ -1,3 +1,4 @@
-export * from './config';
+export { IdentitySolanaConfigSchema } from './config';
+export type { IdentitySolanaConfig } from './config';
 export { identitySolanaFromEnv } from './env';
 export { identitySolana } from './extension';


### PR DESCRIPTION
Implements the Solana identity extension for Lucid SDK as requested in Taskmarket bounty 0x47bec4da...

Includes:
- Configuration schema with Zod
- Environment variable parsing
- extension with @solana/web3.js connection and identity attachment
- README with usage examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Solana identity package enabling agents to derive a Solana public key and sign messages.
  * Augments agent manifests with Solana trust data (SOL/USDC, trust tier).
  * Configurable via validated programmatic config or environment variables with a loader.

* **Documentation**
  * Added README with installation, usage examples, and configuration instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->