### PR TITLE
feat: add NASA NeoWs asteroid risk Lucid agent example

### DIFF
--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -18,6 +18,9 @@ bun run src/core/full-agent.ts
 
 # Or from the repo root
 bun run packages/examples/src/core/full-agent.ts
+
+# NASA NeoWs risk agent
+bun run packages/examples/src/core/nasa-neows-agent.ts
 ```
 
 ## Type Checking

--- a/packages/examples/src/README.md
+++ b/packages/examples/src/README.md
@@ -26,6 +26,46 @@ PORT             # Optional; defaults to 3000
 The agent exposes a single `/entrypoints/brainstorm/invoke` route that accepts a
 `topic` string and responds with a summary plus a few follow-up ideas.
 
+## NASA NeoWs Asteroid Risk Agent
+
+`core/nasa-neows-agent.ts` runs a Lucid Agent that calls NASA NeoWs for the next
+7 days of near-earth objects, computes a per-object threat score, ranks
+asteroids, and returns an overall risk assessment.
+
+Run with Bun:
+
+```bash
+bun run packages/examples/src/core/nasa-neows-agent.ts
+```
+
+Invoke the entrypoint:
+
+```bash
+curl -X POST http://localhost:8788/entrypoints/asteroid-risk/invoke \
+  -H "content-type: application/json" \
+  -d '{"input":{"topN":5}}'
+```
+
+Environment variables:
+
+```
+NASA_API_KEY   # NASA API key; defaults to DEMO_KEY
+PORT           # Optional; defaults to 8788
+```
+
+Threat score inputs and weighting:
+
+- `estimatedDiameterMeters` (45%)
+- `relativeVelocityKph` (35%)
+- `missDistanceKm` proximity factor (20%)
+- hazard bonus if NASA flags object as potentially hazardous
+
+The result payload includes:
+
+- `topThreats[]` ranked by computed `threatScore`
+- `assessment.level` (`low` | `guarded` | `elevated` | `high`)
+- summary stats for the 7-day window (`windowStart`, `windowEnd`, `objectCount`)
+
 ## Full-Stack Agent Example
 
 This script contains a minimal, end-to-end showcase of everything

--- a/packages/examples/src/core/__tests__/nasa-neows-risk.test.ts
+++ b/packages/examples/src/core/__tests__/nasa-neows-risk.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+import {
+  buildRiskAssessment,
+  calculateThreatScore,
+  createNeoRiskReport,
+  extractThreatsFromFeed,
+  getNeoRiskReport,
+  rankThreats,
+} from '../nasa-neows-risk';
+
+describe('calculateThreatScore', () => {
+  it('increases when size/velocity/proximity increase', () => {
+    const low = calculateThreatScore({
+      estimatedDiameterMeters: 75,
+      relativeVelocityKph: 12000,
+      missDistanceKm: 12000000,
+      isPotentiallyHazardous: false,
+    });
+
+    const high = calculateThreatScore({
+      estimatedDiameterMeters: 980,
+      relativeVelocityKph: 92000,
+      missDistanceKm: 90000,
+      isPotentiallyHazardous: true,
+    });
+
+    expect(high).toBeGreaterThan(low);
+    expect(high).toBeLessThanOrEqual(100);
+    expect(low).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('extractThreatsFromFeed / rankThreats', () => {
+  const feed = {
+    near_earth_objects: {
+      '2026-03-05': [
+        {
+          id: 'A',
+          name: 'Asteroid A',
+          nasa_jpl_url: 'https://example.com/a',
+          is_potentially_hazardous_asteroid: false,
+          estimated_diameter: {
+            meters: { estimated_diameter_max: 140 },
+          },
+          close_approach_data: [
+            {
+              close_approach_date: '2026-03-05',
+              relative_velocity: { kilometers_per_hour: '22000' },
+              miss_distance: { kilometers: '2800000' },
+            },
+          ],
+        },
+      ],
+      '2026-03-06': [
+        {
+          id: 'B',
+          name: 'Asteroid B',
+          nasa_jpl_url: 'https://example.com/b',
+          is_potentially_hazardous_asteroid: true,
+          estimated_diameter: {
+            meters: { estimated_diameter_max: 600 },
+          },
+          close_approach_data: [
+            {
+              close_approach_date: '2026-03-06',
+              relative_velocity: { kilometers_per_hour: '68000' },
+              miss_distance: { kilometers: '350000' },
+            },
+          ],
+        },
+      ],
+      '2026-03-07': [
+        {
+          id: 'C',
+          name: 'Asteroid C',
+          nasa_jpl_url: 'https://example.com/c',
+          is_potentially_hazardous_asteroid: false,
+          estimated_diameter: {
+            meters: { estimated_diameter_max: 420 },
+          },
+          close_approach_data: [
+            {
+              close_approach_date: '2026-03-07',
+              relative_velocity: { kilometers_per_hour: '41000' },
+              miss_distance: { kilometers: '900000' },
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  it('extracts and ranks asteroid threats by descending threat score', () => {
+    const threats = extractThreatsFromFeed(feed);
+    expect(threats).toHaveLength(3);
+
+    const ranked = rankThreats(threats, 3);
+    expect(ranked[0]?.id).toBe('B');
+    expect(ranked[0]?.threatScore).toBeGreaterThan(ranked[1]?.threatScore ?? 0);
+  });
+
+  it('creates a risk report with capped topN', () => {
+    const threats = extractThreatsFromFeed(feed);
+    const report = createNeoRiskReport({
+      windowStart: '2026-03-05',
+      windowEnd: '2026-03-11',
+      threats,
+      topN: 2,
+    });
+
+    expect(report.windowStart).toBe('2026-03-05');
+    expect(report.windowEnd).toBe('2026-03-11');
+    expect(report.objectCount).toBe(3);
+    expect(report.topThreats).toHaveLength(2);
+  });
+});
+
+describe('buildRiskAssessment', () => {
+  it('returns low risk for empty result sets', () => {
+    const assessment = buildRiskAssessment([]);
+    expect(assessment.level).toBe('low');
+    expect(assessment.trackedCount).toBe(0);
+  });
+
+  it('returns high risk when highest score exceeds high threshold', () => {
+    const assessment = buildRiskAssessment([
+      {
+        id: 'X',
+        name: 'X',
+        nasaJplUrl: '',
+        isPotentiallyHazardous: true,
+        approachDate: '2026-03-05',
+        estimatedDiameterMeters: 900,
+        relativeVelocityKph: 80000,
+        missDistanceKm: 120000,
+        threatScore: 78,
+      },
+    ]);
+    expect(assessment.level).toBe('high');
+  });
+});
+
+describe('getNeoRiskReport', () => {
+  it('queries next 7-day window and returns ranked report', async () => {
+    const fetchMock = mock(async (url: string | URL | Request) => {
+      const parsed = new URL(String(url));
+      expect(parsed.origin + parsed.pathname).toBe(
+        'https://api.nasa.gov/neo/rest/v1/feed'
+      );
+      expect(parsed.searchParams.get('start_date')).toBe('2026-03-05');
+      expect(parsed.searchParams.get('end_date')).toBe('2026-03-11');
+      expect(parsed.searchParams.get('api_key')).toBe('TEST_KEY');
+
+      return new Response(
+        JSON.stringify({
+          near_earth_objects: {
+            '2026-03-05': [
+              {
+                id: 'N1',
+                name: 'Neo 1',
+                nasa_jpl_url: 'https://example.com/n1',
+                is_potentially_hazardous_asteroid: true,
+                estimated_diameter: {
+                  meters: { estimated_diameter_max: 510 },
+                },
+                close_approach_data: [
+                  {
+                    close_approach_date: '2026-03-05',
+                    relative_velocity: { kilometers_per_hour: '57000' },
+                    miss_distance: { kilometers: '500000' },
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }
+      );
+    });
+
+    const report = await getNeoRiskReport({
+      apiKey: 'TEST_KEY',
+      topN: 5,
+      now: new Date('2026-03-05T12:00:00Z'),
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(report.windowStart).toBe('2026-03-05');
+    expect(report.windowEnd).toBe('2026-03-11');
+    expect(report.objectCount).toBe(1);
+    expect(report.topThreats[0]?.id).toBe('N1');
+  });
+});

--- a/packages/examples/src/core/nasa-neows-agent.ts
+++ b/packages/examples/src/core/nasa-neows-agent.ts
@@ -1,0 +1,93 @@
+/*
+ * NASA NeoWs asteroid risk agent.
+ *
+ * Queries NASA's Near Earth Object Web Service (NeoWs) feed for the next 7 days,
+ * computes a threat score based on object size, velocity, and miss distance,
+ * ranks objects by score, and returns a risk assessment summary.
+ *
+ * Run with:
+ *   bun run packages/examples/src/core/nasa-neows-agent.ts
+ *
+ * Environment variables:
+ *   NASA_API_KEY  - NASA API key (defaults to DEMO_KEY)
+ *   PORT          - HTTP port (defaults to 8788)
+ */
+
+import { createAgent } from '@lucid-agents/core';
+import { createAgentApp } from '@lucid-agents/hono';
+import { http } from '@lucid-agents/http';
+import { z } from 'zod';
+
+import { getNeoRiskReport } from './nasa-neows-risk';
+
+const agent = await createAgent({
+  name: 'nasa-neo-risk-agent',
+  version: '1.0.0',
+  description:
+    'Assesses near-earth asteroid risk over the next 7 days using NASA NeoWs.',
+})
+  .use(http())
+  .build();
+
+const { app, addEntrypoint } = await createAgentApp(agent);
+
+addEntrypoint({
+  key: 'asteroid-risk',
+  description:
+    'Fetch next-7-day NEO data from NASA, score threats, rank results, and return risk assessment.',
+  input: z.object({
+    topN: z.number().int().min(1).max(50).optional().default(10),
+  }),
+  output: z.object({
+    windowStart: z.string(),
+    windowEnd: z.string(),
+    generatedAt: z.string(),
+    objectCount: z.number(),
+    topThreats: z.array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        nasaJplUrl: z.string(),
+        isPotentiallyHazardous: z.boolean(),
+        approachDate: z.string(),
+        estimatedDiameterMeters: z.number(),
+        relativeVelocityKph: z.number(),
+        missDistanceKm: z.number(),
+        threatScore: z.number(),
+      })
+    ),
+    assessment: z.object({
+      level: z.enum(['low', 'guarded', 'elevated', 'high']),
+      summary: z.string(),
+      highestThreatScore: z.number(),
+      highThreatCount: z.number(),
+      trackedCount: z.number(),
+    }),
+  }),
+  async handler({ input }) {
+    const apiKey = process.env.NASA_API_KEY ?? 'DEMO_KEY';
+    const report = await getNeoRiskReport({
+      apiKey,
+      topN: input.topN,
+    });
+
+    return {
+      output: report,
+      usage: { total_tokens: report.objectCount },
+    };
+  },
+});
+
+const port = Number(process.env.PORT ?? 8788);
+const origin = `http://localhost:${port}`;
+
+if (typeof Bun !== 'undefined') {
+  Bun.serve({
+    port,
+    fetch: app.fetch,
+  });
+  console.log(`[examples] NASA Neo risk agent running at ${origin}`);
+  console.log(
+    `[examples] Try: curl -X POST ${origin}/entrypoints/asteroid-risk/invoke -H "content-type: application/json" -d '{"input":{"topN":5}}'`
+  );
+}

--- a/packages/examples/src/core/nasa-neows-risk.ts
+++ b/packages/examples/src/core/nasa-neows-risk.ts
@@ -1,0 +1,305 @@
+const NASA_NEOWS_FEED_URL = 'https://api.nasa.gov/neo/rest/v1/feed';
+
+export type RiskLevel = 'low' | 'guarded' | 'elevated' | 'high';
+
+export type AsteroidThreat = {
+  id: string;
+  name: string;
+  nasaJplUrl: string;
+  isPotentiallyHazardous: boolean;
+  approachDate: string;
+  estimatedDiameterMeters: number;
+  relativeVelocityKph: number;
+  missDistanceKm: number;
+  threatScore: number;
+};
+
+export type NeoRiskAssessment = {
+  level: RiskLevel;
+  summary: string;
+  highestThreatScore: number;
+  highThreatCount: number;
+  trackedCount: number;
+};
+
+export type NeoRiskReport = {
+  windowStart: string;
+  windowEnd: string;
+  generatedAt: string;
+  objectCount: number;
+  topThreats: AsteroidThreat[];
+  assessment: NeoRiskAssessment;
+};
+
+type NasaCloseApproachData = {
+  close_approach_date?: string;
+  close_approach_date_full?: string;
+  relative_velocity?: {
+    kilometers_per_hour?: string;
+  };
+  miss_distance?: {
+    kilometers?: string;
+  };
+};
+
+type NasaNeo = {
+  id?: string;
+  name?: string;
+  nasa_jpl_url?: string;
+  is_potentially_hazardous_asteroid?: boolean;
+  estimated_diameter?: {
+    meters?: {
+      estimated_diameter_max?: number;
+    };
+  };
+  close_approach_data?: NasaCloseApproachData[];
+};
+
+type NasaNeoFeedResponse = {
+  near_earth_objects?: Record<string, NasaNeo[]>;
+};
+
+type ScoringInput = {
+  estimatedDiameterMeters: number;
+  relativeVelocityKph: number;
+  missDistanceKm: number;
+  isPotentiallyHazardous: boolean;
+};
+
+type GetNeoRiskReportOptions = {
+  apiKey: string;
+  topN?: number;
+  now?: Date;
+  fetchImpl?: typeof fetch;
+};
+
+type FetchNeoFeedOptions = {
+  apiKey: string;
+  startDate: string;
+  endDate: string;
+  fetchImpl?: typeof fetch;
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function toNumber(value: string | number | undefined): number {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : 0;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function formatDateUtc(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = `${date.getUTCMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getUTCDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function getNextSevenDayWindow(now: Date): { startDate: string; endDate: string } {
+  const start = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  );
+  const end = new Date(start);
+  end.setUTCDate(end.getUTCDate() + 6);
+  return {
+    startDate: formatDateUtc(start),
+    endDate: formatDateUtc(end),
+  };
+}
+
+function findApproachForDate(
+  approaches: NasaCloseApproachData[] | undefined,
+  dateKey: string
+): NasaCloseApproachData | undefined {
+  if (!approaches || approaches.length === 0) {
+    return undefined;
+  }
+
+  const match = approaches.find(approach => {
+    if (approach.close_approach_date === dateKey) {
+      return true;
+    }
+    if (
+      approach.close_approach_date_full &&
+      approach.close_approach_date_full.startsWith(dateKey)
+    ) {
+      return true;
+    }
+    return false;
+  });
+
+  return match ?? approaches[0];
+}
+
+export function calculateThreatScore(input: ScoringInput): number {
+  const sizeNormalized = clamp(input.estimatedDiameterMeters / 1000, 0, 1);
+  const velocityNormalized = clamp(input.relativeVelocityKph / 100000, 0, 1);
+  const proximityNormalized = clamp(1 - input.missDistanceKm / 7500000, 0, 1);
+  const hazardBonus = input.isPotentiallyHazardous ? 0.15 : 0;
+
+  const weighted =
+    sizeNormalized * 0.45 +
+    velocityNormalized * 0.35 +
+    proximityNormalized * 0.2 +
+    hazardBonus;
+
+  return Number((clamp(weighted, 0, 1) * 100).toFixed(2));
+}
+
+export function extractThreatsFromFeed(data: NasaNeoFeedResponse): AsteroidThreat[] {
+  const byDate = data.near_earth_objects ?? {};
+  const threats: AsteroidThreat[] = [];
+
+  for (const [dateKey, items] of Object.entries(byDate)) {
+    for (const item of items) {
+      const approach = findApproachForDate(item.close_approach_data, dateKey);
+      if (!approach) {
+        continue;
+      }
+
+      const estimatedDiameterMeters = toNumber(
+        item.estimated_diameter?.meters?.estimated_diameter_max
+      );
+      const relativeVelocityKph = toNumber(
+        approach.relative_velocity?.kilometers_per_hour
+      );
+      const missDistanceKm = toNumber(approach.miss_distance?.kilometers);
+      const isPotentiallyHazardous = Boolean(
+        item.is_potentially_hazardous_asteroid
+      );
+
+      const threat = {
+        id: item.id ?? `${item.name ?? 'unknown'}-${dateKey}`,
+        name: item.name ?? 'Unknown asteroid',
+        nasaJplUrl: item.nasa_jpl_url ?? '',
+        isPotentiallyHazardous,
+        approachDate: dateKey,
+        estimatedDiameterMeters,
+        relativeVelocityKph,
+        missDistanceKm,
+        threatScore: calculateThreatScore({
+          estimatedDiameterMeters,
+          relativeVelocityKph,
+          missDistanceKm,
+          isPotentiallyHazardous,
+        }),
+      } satisfies AsteroidThreat;
+
+      threats.push(threat);
+    }
+  }
+
+  return threats;
+}
+
+export function rankThreats(threats: AsteroidThreat[], topN = 10): AsteroidThreat[] {
+  return [...threats]
+    .sort((a, b) => {
+      if (b.threatScore !== a.threatScore) {
+        return b.threatScore - a.threatScore;
+      }
+      return a.missDistanceKm - b.missDistanceKm;
+    })
+    .slice(0, Math.max(1, topN));
+}
+
+export function buildRiskAssessment(threats: AsteroidThreat[]): NeoRiskAssessment {
+  const highestThreatScore = threats[0]?.threatScore ?? 0;
+  const highThreatCount = threats.filter(t => t.threatScore >= 55).length;
+  const trackedCount = threats.length;
+
+  let level: RiskLevel = 'low';
+  if (highestThreatScore >= 70 || highThreatCount >= 3) {
+    level = 'high';
+  } else if (highestThreatScore >= 45 || highThreatCount >= 2) {
+    level = 'elevated';
+  } else if (highestThreatScore >= 25) {
+    level = 'guarded';
+  }
+
+  const summary =
+    level === 'high'
+      ? 'High-risk window: one or more objects have a high modeled threat score.'
+      : level === 'elevated'
+        ? 'Elevated-risk window: monitor top objects with notable speed/size/proximity.'
+        : level === 'guarded'
+          ? 'Guarded-risk window: no high-risk objects, but track the top approaches.'
+          : 'Low-risk window: modeled scores are low across the observed objects.';
+
+  return {
+    level,
+    summary,
+    highestThreatScore,
+    highThreatCount,
+    trackedCount,
+  };
+}
+
+export function createNeoRiskReport(options: {
+  windowStart: string;
+  windowEnd: string;
+  threats: AsteroidThreat[];
+  topN?: number;
+}): NeoRiskReport {
+  const rankedThreats = rankThreats(
+    options.threats,
+    Math.max(options.threats.length, 1)
+  );
+  const topThreats = rankedThreats.slice(0, Math.max(1, options.topN ?? 10));
+  return {
+    windowStart: options.windowStart,
+    windowEnd: options.windowEnd,
+    generatedAt: new Date().toISOString(),
+    objectCount: options.threats.length,
+    topThreats,
+    assessment: buildRiskAssessment(rankedThreats),
+  };
+}
+
+export async function fetchNeoFeed(
+  options: FetchNeoFeedOptions
+): Promise<NasaNeoFeedResponse> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const params = new URLSearchParams({
+    start_date: options.startDate,
+    end_date: options.endDate,
+    api_key: options.apiKey,
+  });
+
+  const response = await fetchImpl(`${NASA_NEOWS_FEED_URL}?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error(
+      `NASA NeoWs request failed with ${response.status}: ${response.statusText}`
+    );
+  }
+
+  return (await response.json()) as NasaNeoFeedResponse;
+}
+
+export async function getNeoRiskReport(
+  options: GetNeoRiskReportOptions
+): Promise<NeoRiskReport> {
+  const now = options.now ?? new Date();
+  const { startDate, endDate } = getNextSevenDayWindow(now);
+  const neoFeed = await fetchNeoFeed({
+    apiKey: options.apiKey,
+    startDate,
+    endDate,
+    fetchImpl: options.fetchImpl,
+  });
+
+  const threats = extractThreatsFromFeed(neoFeed);
+  return createNeoRiskReport({
+    windowStart: startDate,
+    windowEnd: endDate,
+    threats,
+    topN: options.topN,
+  });
+}


### PR DESCRIPTION
Implements a Lucid Agent example that queries NASA NeoWs for the next 7 days, computes threat scores (size/velocity/proximity + hazard bonus), ranks threats, and returns a risk assessment.\n\nIncludes:\n- New agent entrypoint: asteroid-risk\n- Risk module with scoring/ranking/report logic\n- Unit tests with mocked API response\n- README documentation updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a NASA NeoWs Asteroid Risk Agent with an HTTP endpoint to fetch and rank near-Earth object threats over 7-day windows, with threat scoring and risk level assessment.

* **Tests**
  * Added comprehensive test suite covering threat scoring, threat extraction, ranking, and end-to-end risk reporting.

* **Documentation**
  * Updated README with setup instructions and usage details for the new agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->