### PR TITLE
docs: add TaskMarket badges to 5 example READMEs

### DIFF
--- a/packages/examples/src/a2a/README.md
+++ b/packages/examples/src/a2a/README.md
@@ -1,0 +1,9 @@
+# Agent-to-Agent (A2A) Example
+
+Example implementations for the `Agent-to-Agent (A2A)` module of the Lucid Agents SDK.
+
+---
+
+[![Built on TaskMarket](https://img.shields.io/badge/Built%20on-TaskMarket-blue)](https://taskmarket.xyz)
+
+> This example was built via a TaskMarket bounty. Earn USDC building agents like this at [taskmarket.xyz](https://taskmarket.xyz)

--- a/packages/examples/src/core/README.md
+++ b/packages/examples/src/core/README.md
@@ -1,0 +1,9 @@
+# Core Examples Example
+
+Example implementations for the `Core Examples` module of the Lucid Agents SDK.
+
+---
+
+[![Built on TaskMarket](https://img.shields.io/badge/Built%20on-TaskMarket-blue)](https://taskmarket.xyz)
+
+> This example was built via a TaskMarket bounty. Earn USDC building agents like this at [taskmarket.xyz](https://taskmarket.xyz)

--- a/packages/examples/src/core/README.md
+++ b/packages/examples/src/core/README.md
@@ -1,6 +1,6 @@
-# Core Examples Example
+# Core Example
 
-Example implementations for the `Core Examples` module of the Lucid Agents SDK.
+Example implementations for the `core` module of the Lucid Agents SDK.
 
 ---
 

--- a/packages/examples/src/identity/README.md
+++ b/packages/examples/src/identity/README.md
@@ -1,0 +1,9 @@
+# Identity (ERC-8004) Example
+
+Example implementations for the `Identity (ERC-8004)` module of the Lucid Agents SDK.
+
+---
+
+[![Built on TaskMarket](https://img.shields.io/badge/Built%20on-TaskMarket-blue)](https://taskmarket.xyz)
+
+> This example was built via a TaskMarket bounty. Earn USDC building agents like this at [taskmarket.xyz](https://taskmarket.xyz)

--- a/packages/examples/src/kitchen-sink/README.md
+++ b/packages/examples/src/kitchen-sink/README.md
@@ -113,3 +113,10 @@ src/kitchen-sink/
     ├── entrypoints.test.ts  # Handlers: correct output shapes
     └── a2a.test.ts          # Integration: A2A end-to-end
 ```
+
+
+---
+
+[![Built on TaskMarket](https://img.shields.io/badge/Built%20on-TaskMarket-blue)](https://taskmarket.xyz)
+
+> This example was built via a TaskMarket bounty. Earn USDC building agents like this at [taskmarket.xyz](https://taskmarket.xyz)

--- a/packages/examples/src/payments/README.md
+++ b/packages/examples/src/payments/README.md
@@ -1,0 +1,9 @@
+# Payments (x402) Example
+
+Example implementations for the `Payments (x402)` module of the Lucid Agents SDK.
+
+---
+
+[![Built on TaskMarket](https://img.shields.io/badge/Built%20on-TaskMarket-blue)](https://taskmarket.xyz)
+
+> This example was built via a TaskMarket bounty. Earn USDC building agents like this at [taskmarket.xyz](https://taskmarket.xyz)


### PR DESCRIPTION
Adds a 'Built on TaskMarket' badge and one-liner to 5 example READMEs in the `packages/examples/src/` directory.

## Files changed
- `packages/examples/src/kitchen-sink/README.md` — badge added
- `packages/examples/src/a2a/README.md` — created with badge
- `packages/examples/src/payments/README.md` — created with badge
- `packages/examples/src/core/README.md` — created with badge
- `packages/examples/src/identity/README.md` — created with badge

Badge links to [taskmarket.xyz](https://taskmarket.xyz) — the onchain task marketplace where this work was commissioned as a bounty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added README documentation for four SDK examples: Agent-to-Agent, Core, Identity (ERC-8004), and Payments (x402).
  * Updated the Kitchen Sink example README with a footer and attribution.
  * Improved discoverability with clear module descriptions and "Built on TaskMarket" attribution/badges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->