### PR TITLE
Add paid TaskMarket data API examples

### DIFF
--- a/packages/examples/src/data-apis/README.md
+++ b/packages/examples/src/data-apis/README.md
@@ -8,7 +8,7 @@ This directory contains paid data API examples for five TaskMarket PRDs:
 - Sanctions & PEP Exposure Intelligence API, issue #185
 - Macro Event Impact Vector API for Agents, issue #186
 
-Each API is built with Lucid core, HTTP, payments, and Zod contracts. Monetized routes return `402` without an `X-402-Payment` or `payment-signature` header and return deterministic JSON with freshness and confidence metadata when paid.
+Each API is built with Lucid core, HTTP, payments, and Zod contracts. Monetized routes return `402` with the x402 v2 `PAYMENT-REQUIRED` response header until the caller provides a valid payment credential, and return deterministic JSON with freshness and confidence metadata when paid.
 
 ## Endpoints
 

--- a/packages/examples/src/data-apis/README.md
+++ b/packages/examples/src/data-apis/README.md
@@ -1,0 +1,59 @@
+# TaskMarket Data API Examples
+
+This directory contains paid data API examples for five TaskMarket PRDs:
+
+- Supplier Reliability Signal Marketplace API, issue #181
+- Geo Demand Pulse Index for Agent Buyers, issue #182
+- Data Freshness & Provenance Verification API, issue #184
+- Sanctions & PEP Exposure Intelligence API, issue #185
+- Macro Event Impact Vector API for Agents, issue #186
+
+Each API is built with Lucid core, HTTP, payments, and Zod contracts. Monetized routes return `402` without an `X-402-Payment` or `payment-signature` header and return deterministic JSON with freshness and confidence metadata when paid.
+
+## Endpoints
+
+Supplier:
+
+```bash
+GET /v1/suppliers/score?supplierId=supplier-acme&category=components&region=na
+GET /v1/suppliers/lead-time-forecast?supplierId=supplier-acme&horizonDays=30
+GET /v1/suppliers/disruption-alerts?supplierId=supplier-acme
+```
+
+Demand:
+
+```bash
+GET /v1/demand/index?geoType=city&geoCode=SFO&category=apparel
+GET /v1/demand/trend?geoCode=SFO&category=apparel&lookbackWindow=30d&seasonalityMode=weekly
+GET /v1/demand/anomalies?geoCode=SFO&category=apparel
+```
+
+Provenance:
+
+```bash
+GET /v1/provenance/lineage?datasetId=dataset-prices&sourceId=source-primary
+GET /v1/provenance/freshness?datasetId=dataset-prices&sourceId=source-primary&maxStalenessMs=300000
+POST /v1/provenance/verify-hash
+```
+
+Screening:
+
+```bash
+POST /v1/screening/check
+GET /v1/screening/exposure-chain?entityName=Acme%20Trading%20LLC
+GET /v1/screening/jurisdiction-risk?jurisdictions=US,CA
+```
+
+Macro:
+
+```bash
+GET /v1/macro/events?eventTypes=rates,energy&geography=global
+GET /v1/macro/impact-vectors?sectorSet=energy,retail&horizon=30d
+POST /v1/macro/scenario-score
+```
+
+## Test
+
+```bash
+bun test packages/examples/src/data-apis/__tests__/marketplace.test.ts
+```

--- a/packages/examples/src/data-apis/README.md
+++ b/packages/examples/src/data-apis/README.md
@@ -1,12 +1,17 @@
 # TaskMarket Data API Examples
 
-This directory contains paid data API examples for five TaskMarket PRDs:
+This directory contains paid data API examples for ten TaskMarket PRDs:
 
 - Supplier Reliability Signal Marketplace API, issue #181
 - Geo Demand Pulse Index for Agent Buyers, issue #182
 - Data Freshness & Provenance Verification API, issue #184
 - Sanctions & PEP Exposure Intelligence API, issue #185
 - Macro Event Impact Vector API for Agents, issue #186
+- Cross-Chain Liquidity Snapshot Service, issue #177
+- Real-Time Gas & Inclusion Probability Oracle, issue #178
+- Counterparty Risk Graph Intelligence API, issue #179
+- Regulatory Delta Feed for Agent Compliance, issue #180
+- ERC-8004 Identity Reputation Signal API, issue #183
 
 Each API is built with Lucid core, HTTP, payments, and Zod contracts. Monetized routes return `402` with the x402 v2 `PAYMENT-REQUIRED` response header until the caller provides a valid payment credential, and return deterministic JSON with freshness and confidence metadata when paid.
 
@@ -50,6 +55,46 @@ Macro:
 GET /v1/macro/events?eventTypes=rates,energy&geography=global
 GET /v1/macro/impact-vectors?sectorSet=energy,retail&horizon=30d
 POST /v1/macro/scenario-score
+```
+
+Liquidity:
+
+```bash
+GET /v1/liquidity/snapshot?chain=base&baseToken=ETH&quoteToken=USDC
+GET /v1/liquidity/slippage?chain=base&baseToken=ETH&quoteToken=USDC&notionalUsd=100000
+GET /v1/liquidity/routes?chain=base&baseToken=ETH&quoteToken=USDC&notionalUsd=100000
+```
+
+Gas:
+
+```bash
+GET /v1/gas/quote?chain=base&urgency=standard&targetBlocks=3
+GET /v1/gas/forecast?chain=base&horizonMinutes=30
+GET /v1/gas/congestion?chain=base
+```
+
+Risk:
+
+```bash
+POST /v1/risk/score
+GET /v1/risk/exposure-paths?address=0x1&network=base&threshold=50
+GET /v1/risk/entity-profile?address=0x1&network=base
+```
+
+Regulations:
+
+```bash
+GET /v1/regulations/delta?jurisdiction=US&industry=crypto&since=2026-01-01
+GET /v1/regulations/impact?jurisdiction=US&industry=crypto&controlFramework=SOC2
+POST /v1/regulations/map-controls
+```
+
+Identity:
+
+```bash
+GET /v1/identity/reputation?agentAddress=0x1&chain=base&timeframe=90d
+GET /v1/identity/history?agentAddress=0x1&chain=base&timeframe=90d
+GET /v1/identity/trust-breakdown?agentAddress=0x1&chain=base&evidenceDepth=3
 ```
 
 ## Test

--- a/packages/examples/src/data-apis/__tests__/marketplace.test.ts
+++ b/packages/examples/src/data-apis/__tests__/marketplace.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'bun:test';
 
 import { apiRoutes, apiSchemas, createDataApiApp } from '../marketplace';
 
-const paymentHeaders = { 'X-402-Payment': 'test-payment' };
+const paymentHeaders = { PAYMENT: 'test-payment' };
 
 async function request(
   app: { fetch: (request: Request) => Response | Promise<Response> },
@@ -42,11 +42,41 @@ describe('TaskMarket data API examples', () => {
     ]);
   });
 
-  it('enforces x402 payment on monetized supplier endpoints', async () => {
+  it('enforces x402 payment on all monetized API surfaces', async () => {
+    const cases = [
+      ['supplier', '/v1/suppliers/score?supplierId=s1'],
+      ['demand', '/v1/demand/index?geoType=city&geoCode=SFO'],
+      ['provenance', '/v1/provenance/lineage?datasetId=d1'],
+      ['screening', '/v1/screening/exposure-chain?entityName=Acme'],
+      ['macro', '/v1/macro/events?eventTypes=rates'],
+    ] as const;
+
+    for (const [name, path] of cases) {
+      const { app } = await createDataApiApp(name);
+      const res = await request(app, path);
+      expect(res.status).toBe(402);
+      expect(res.headers.get('PAYMENT-REQUIRED')).toBeTruthy();
+      expect(res.headers.get('x-402-payment-required')).toBeNull();
+    }
+  });
+
+  it('accepts a non-empty payment credential from any supported payment header', async () => {
     const { app } = await createDataApiApp('supplier');
-    const res = await request(app, '/v1/suppliers/score?supplierId=s1');
-    expect(res.status).toBe(402);
-    expect(res.headers.get('x-402-payment-required')).toBe('true');
+    const res = await request(app, '/v1/suppliers/score?supplierId=s1', {
+      headers: { 'X-PAYMENT': ' ', 'payment-signature': 'test-payment' },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('normalizes invalid positive numeric query values before schema validation', async () => {
+    const { app } = await createDataApiApp('supplier');
+    const res = await paidGet(
+      app,
+      '/v1/suppliers/lead-time-forecast?supplierId=s1&horizonDays=0'
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.horizon_days).toBe(1);
   });
 
   it('returns valid supplier intelligence contracts', async () => {
@@ -179,7 +209,18 @@ describe('TaskMarket data API examples', () => {
     );
   });
 
-  it('keeps cached-path responses under the 500ms budget in-process', async () => {
+  it('returns deterministic responses for identical paid requests', async () => {
+    const { app } = await createDataApiApp('macro');
+    const first = await (
+      await paidGet(app, '/v1/macro/events?eventTypes=rates&geography=global')
+    ).json();
+    const second = await (
+      await paidGet(app, '/v1/macro/events?eventTypes=rates&geography=global')
+    ).json();
+    expect(second).toEqual(first);
+  });
+
+  it('keeps raw in-process response generation under the 500ms budget', async () => {
     const { app } = await createDataApiApp('macro');
     const started = performance.now();
     for (let index = 0; index < 50; index += 1) {

--- a/packages/examples/src/data-apis/__tests__/marketplace.test.ts
+++ b/packages/examples/src/data-apis/__tests__/marketplace.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'bun:test';
+
+import { apiRoutes, apiSchemas, createDataApiApp } from '../marketplace';
+
+const paymentHeaders = { 'X-402-Payment': 'test-payment' };
+
+async function request(
+  app: { fetch: (request: Request) => Response | Promise<Response> },
+  path: string,
+  init?: RequestInit
+) {
+  return app.fetch(new Request(`http://localhost${path}`, init));
+}
+
+async function paidGet(
+  app: { fetch: (request: Request) => Response | Promise<Response> },
+  path: string
+) {
+  return request(app, path, { headers: paymentHeaders });
+}
+
+async function paidPost(
+  app: { fetch: (request: Request) => Response | Promise<Response> },
+  path: string,
+  body: unknown
+) {
+  return request(app, path, {
+    method: 'POST',
+    headers: { ...paymentHeaders, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('TaskMarket data API examples', () => {
+  it('registers five paid API surfaces', () => {
+    expect(Object.keys(apiRoutes).sort()).toEqual([
+      'demand',
+      'macro',
+      'provenance',
+      'screening',
+      'supplier',
+    ]);
+  });
+
+  it('enforces x402 payment on monetized supplier endpoints', async () => {
+    const { app } = await createDataApiApp('supplier');
+    const res = await request(app, '/v1/suppliers/score?supplierId=s1');
+    expect(res.status).toBe(402);
+    expect(res.headers.get('x-402-payment-required')).toBe('true');
+  });
+
+  it('returns valid supplier intelligence contracts', async () => {
+    const { app } = await createDataApiApp('supplier');
+    apiSchemas.supplierScore.parse(
+      await (
+        await paidGet(
+          app,
+          '/v1/suppliers/score?supplierId=s1&category=chips&region=na'
+        )
+      ).json()
+    );
+    apiSchemas.supplierForecast.parse(
+      await (
+        await paidGet(
+          app,
+          '/v1/suppliers/lead-time-forecast?supplierId=s1&horizonDays=45'
+        )
+      ).json()
+    );
+    apiSchemas.supplierAlerts.parse(
+      await (
+        await paidGet(app, '/v1/suppliers/disruption-alerts?supplierId=s1')
+      ).json()
+    );
+  });
+
+  it('returns valid demand pulse contracts', async () => {
+    const { app } = await createDataApiApp('demand');
+    apiSchemas.demandIndex.parse(
+      await (
+        await paidGet(
+          app,
+          '/v1/demand/index?geoType=city&geoCode=SFO&category=apparel'
+        )
+      ).json()
+    );
+    apiSchemas.demandTrend.parse(
+      await (
+        await paidGet(
+          app,
+          '/v1/demand/trend?geoCode=SFO&category=apparel&lookbackWindow=30d'
+        )
+      ).json()
+    );
+    apiSchemas.demandAnomalies.parse(
+      await (
+        await paidGet(app, '/v1/demand/anomalies?geoCode=SFO&category=apparel')
+      ).json()
+    );
+  });
+
+  it('returns valid provenance verification contracts', async () => {
+    const { app } = await createDataApiApp('provenance');
+    apiSchemas.provenanceLineage.parse(
+      await (
+        await paidGet(app, '/v1/provenance/lineage?datasetId=d1&sourceId=s1')
+      ).json()
+    );
+    apiSchemas.provenanceFreshness.parse(
+      await (
+        await paidGet(
+          app,
+          '/v1/provenance/freshness?datasetId=d1&sourceId=s1&maxStalenessMs=500000'
+        )
+      ).json()
+    );
+    apiSchemas.provenanceVerify.parse(
+      await (
+        await paidPost(app, '/v1/provenance/verify-hash', {
+          datasetId: 'd1',
+          expectedHash: 'sha256:abc',
+        })
+      ).json()
+    );
+  });
+
+  it('returns valid screening intelligence contracts', async () => {
+    const { app } = await createDataApiApp('screening');
+    apiSchemas.screeningCheck.parse(
+      await (
+        await paidPost(app, '/v1/screening/check', {
+          entityName: 'Acme Trading LLC',
+        })
+      ).json()
+    );
+    apiSchemas.screeningExposure.parse(
+      await (
+        await paidGet(
+          app,
+          '/v1/screening/exposure-chain?entityName=Acme%20Trading%20LLC'
+        )
+      ).json()
+    );
+    apiSchemas.screeningJurisdiction.parse(
+      await (
+        await paidGet(
+          app,
+          '/v1/screening/jurisdiction-risk?jurisdictions=US,CA'
+        )
+      ).json()
+    );
+  });
+
+  it('returns valid macro impact contracts', async () => {
+    const { app } = await createDataApiApp('macro');
+    apiSchemas.macroEvents.parse(
+      await (
+        await paidGet(
+          app,
+          '/v1/macro/events?eventTypes=rates,energy&geography=global'
+        )
+      ).json()
+    );
+    apiSchemas.macroImpact.parse(
+      await (
+        await paidGet(
+          app,
+          '/v1/macro/impact-vectors?sectorSet=energy,retail&horizon=30d'
+        )
+      ).json()
+    );
+    apiSchemas.macroScenario.parse(
+      await (
+        await paidPost(app, '/v1/macro/scenario-score', {
+          geography: 'global',
+          horizon: '30d',
+        })
+      ).json()
+    );
+  });
+
+  it('keeps cached-path responses under the 500ms budget in-process', async () => {
+    const { app } = await createDataApiApp('macro');
+    const started = performance.now();
+    for (let index = 0; index < 50; index += 1) {
+      const res = await paidGet(
+        app,
+        `/v1/macro/events?eventTypes=rates&geography=global-${index}`
+      );
+      expect(res.status).toBe(200);
+    }
+    const elapsed = performance.now() - started;
+    expect(elapsed / 50).toBeLessThan(500);
+  });
+});

--- a/packages/examples/src/data-apis/__tests__/marketplace.test.ts
+++ b/packages/examples/src/data-apis/__tests__/marketplace.test.ts
@@ -32,11 +32,16 @@ async function paidPost(
 }
 
 describe('TaskMarket data API examples', () => {
-  it('registers five paid API surfaces', () => {
+  it('registers ten paid API surfaces', () => {
     expect(Object.keys(apiRoutes).sort()).toEqual([
       'demand',
+      'gas',
+      'identity',
+      'liquidity',
       'macro',
       'provenance',
+      'regulations',
+      'risk',
       'screening',
       'supplier',
     ]);
@@ -49,6 +54,11 @@ describe('TaskMarket data API examples', () => {
       ['provenance', '/v1/provenance/lineage?datasetId=d1'],
       ['screening', '/v1/screening/exposure-chain?entityName=Acme'],
       ['macro', '/v1/macro/events?eventTypes=rates'],
+      ['liquidity', '/v1/liquidity/snapshot?chain=base'],
+      ['gas', '/v1/gas/quote?chain=base'],
+      ['risk', '/v1/risk/exposure-paths?address=0x1'],
+      ['regulations', '/v1/regulations/delta?jurisdiction=US'],
+      ['identity', '/v1/identity/reputation?agentAddress=0x1'],
     ] as const;
 
     for (const [name, path] of cases) {
@@ -205,6 +215,88 @@ describe('TaskMarket data API examples', () => {
           geography: 'global',
           horizon: '30d',
         })
+      ).json()
+    );
+  });
+
+  it('returns valid liquidity intelligence contracts', async () => {
+    const { app } = await createDataApiApp('liquidity');
+    apiSchemas.liquidity.parse(
+      await (await paidGet(app, '/v1/liquidity/snapshot?chain=base')).json()
+    );
+    apiSchemas.liquidity.parse(
+      await (
+        await paidGet(app, '/v1/liquidity/slippage?notionalUsd=100000')
+      ).json()
+    );
+    apiSchemas.liquidity.parse(
+      await (
+        await paidGet(app, '/v1/liquidity/routes?notionalUsd=100000')
+      ).json()
+    );
+  });
+
+  it('returns valid gas oracle contracts', async () => {
+    const { app } = await createDataApiApp('gas');
+    apiSchemas.gas.parse(await (await paidGet(app, '/v1/gas/quote')).json());
+    apiSchemas.gas.parse(
+      await (await paidGet(app, '/v1/gas/forecast?horizonMinutes=30')).json()
+    );
+    apiSchemas.gas.parse(
+      await (await paidGet(app, '/v1/gas/congestion?chain=base')).json()
+    );
+  });
+
+  it('returns valid counterparty risk contracts', async () => {
+    const { app } = await createDataApiApp('risk');
+    apiSchemas.risk.parse(
+      await (
+        await paidPost(app, '/v1/risk/score', {
+          address: '0x0000000000000000000000000000000000000001',
+        })
+      ).json()
+    );
+    apiSchemas.risk.parse(
+      await (await paidGet(app, '/v1/risk/exposure-paths?address=0x1')).json()
+    );
+    apiSchemas.risk.parse(
+      await (await paidGet(app, '/v1/risk/entity-profile?address=0x1')).json()
+    );
+  });
+
+  it('returns valid regulatory delta contracts', async () => {
+    const { app } = await createDataApiApp('regulations');
+    apiSchemas.regulations.parse(
+      await (await paidGet(app, '/v1/regulations/delta?jurisdiction=US')).json()
+    );
+    apiSchemas.regulations.parse(
+      await (
+        await paidGet(app, '/v1/regulations/impact?controlFramework=SOC2')
+      ).json()
+    );
+    apiSchemas.regulations.parse(
+      await (
+        await paidPost(app, '/v1/regulations/map-controls', {
+          jurisdiction: 'US',
+          controlFramework: 'SOC2',
+        })
+      ).json()
+    );
+  });
+
+  it('returns valid identity reputation contracts', async () => {
+    const { app } = await createDataApiApp('identity');
+    apiSchemas.identity.parse(
+      await (
+        await paidGet(app, '/v1/identity/reputation?agentAddress=0x1')
+      ).json()
+    );
+    apiSchemas.identity.parse(
+      await (await paidGet(app, '/v1/identity/history?agentAddress=0x1')).json()
+    );
+    apiSchemas.identity.parse(
+      await (
+        await paidGet(app, '/v1/identity/trust-breakdown?agentAddress=0x1')
       ).json()
     );
   });

--- a/packages/examples/src/data-apis/marketplace.ts
+++ b/packages/examples/src/data-apis/marketplace.ts
@@ -1,0 +1,557 @@
+import { createAgent } from '@lucid-agents/core';
+import { createAgentApp } from '@lucid-agents/hono';
+import { http } from '@lucid-agents/http';
+import { payments, paymentsFromEnv } from '@lucid-agents/payments';
+import type { Context } from 'hono';
+import { z } from 'zod';
+
+type ApiName = 'supplier' | 'demand' | 'provenance' | 'screening' | 'macro';
+
+type RouteDef = {
+  method: 'GET' | 'POST';
+  path: string;
+  handler: (request: Request, now: number) => Response | Promise<Response>;
+};
+
+const freshnessSchema = z.object({
+  generated_at: z.string(),
+  freshness_ms: z.number().int().nonnegative(),
+  confidence: z.number().min(0).max(1),
+});
+
+const supplierScoreSchema = z.object({
+  supplier_id: z.string(),
+  category: z.string(),
+  region: z.string(),
+  supplier_score: z.number().min(0).max(100),
+  completion_rate: z.number().min(0).max(1),
+  lead_time_p50_p95: z.object({ p50_days: z.number(), p95_days: z.number() }),
+  disruption_probability: z.number().min(0).max(1),
+  alert_reasons: z.array(z.string()),
+  freshness: freshnessSchema,
+});
+
+const supplierForecastSchema = z.object({
+  supplier_id: z.string(),
+  horizon_days: z.number().int().positive(),
+  lead_time_p50_p95: z.object({ p50_days: z.number(), p95_days: z.number() }),
+  confidence_band: z.object({ low_days: z.number(), high_days: z.number() }),
+  freshness: freshnessSchema,
+});
+
+const supplierAlertsSchema = z.object({
+  supplier_id: z.string(),
+  disruption_probability: z.number().min(0).max(1),
+  alert_reasons: z.array(z.string()),
+  freshness: freshnessSchema,
+});
+
+const demandIndexSchema = z.object({
+  geo_type: z.enum(['zip', 'city', 'region']),
+  geo_code: z.string(),
+  category: z.string(),
+  demand_index: z.number(),
+  confidence_interval: z.object({ low: z.number(), high: z.number() }),
+  comparable_geos: z.array(z.string()),
+  freshness: freshnessSchema,
+});
+
+const demandTrendSchema = z.object({
+  geo_code: z.string(),
+  category: z.string(),
+  velocity: z.number(),
+  lookback_window: z.string(),
+  seasonality_mode: z.string(),
+  freshness: freshnessSchema,
+});
+
+const demandAnomaliesSchema = z.object({
+  geo_code: z.string(),
+  category: z.string(),
+  anomaly_flags: z.array(z.object({ code: z.string(), severity: z.number() })),
+  freshness: freshnessSchema,
+});
+
+const provenanceLineageSchema = z.object({
+  dataset_id: z.string(),
+  lineage_graph: z.object({
+    nodes: z.array(z.object({ id: z.string(), type: z.string() })),
+    edges: z.array(z.object({ from: z.string(), to: z.string() })),
+  }),
+  attestation_refs: z.array(z.string()),
+  freshness: freshnessSchema,
+});
+
+const provenanceFreshnessSchema = z.object({
+  dataset_id: z.string(),
+  source_id: z.string(),
+  staleness_ms: z.number().int().nonnegative(),
+  sla_status: z.enum(['fresh', 'stale']),
+  freshness: freshnessSchema,
+});
+
+const provenanceVerifySchema = z.object({
+  dataset_id: z.string(),
+  expected_hash: z.string(),
+  verification_status: z.enum(['match', 'mismatch']),
+  attestation_refs: z.array(z.string()),
+  freshness: freshnessSchema,
+});
+
+const screeningCheckSchema = z.object({
+  entity_name: z.string(),
+  screening_status: z.enum(['clear', 'review', 'blocked']),
+  match_confidence: z.number().min(0).max(1),
+  jurisdiction_risk: z.number().min(0).max(1),
+  evidence_bundle: z.array(z.string()),
+  freshness: freshnessSchema,
+});
+
+const screeningExposureSchema = z.object({
+  entity_name: z.string(),
+  exposure_chain: z.array(
+    z.object({ entity: z.string(), relationship: z.string() })
+  ),
+  match_confidence: z.number().min(0).max(1),
+  freshness: freshnessSchema,
+});
+
+const screeningJurisdictionSchema = z.object({
+  jurisdictions: z.array(z.string()),
+  jurisdiction_risk: z.number().min(0).max(1),
+  rationale: z.array(z.string()),
+  freshness: freshnessSchema,
+});
+
+const macroEventsSchema = z.object({
+  event_types: z.array(z.string()),
+  geography: z.string(),
+  event_feed: z.array(
+    z.object({
+      id: z.string(),
+      event_type: z.string(),
+      urgency_score: z.number(),
+    })
+  ),
+  freshness: freshnessSchema,
+});
+
+const macroImpactSchema = z.object({
+  sector_set: z.array(z.string()),
+  impact_vector: z.record(z.string(), z.number()),
+  confidence_band: z.object({ low: z.number(), high: z.number() }),
+  freshness: freshnessSchema,
+});
+
+const macroScenarioSchema = z.object({
+  scenario_score: z.number(),
+  sensitivity_breakdown: z.record(z.string(), z.number()),
+  freshness: freshnessSchema,
+});
+
+export const apiSchemas = {
+  supplierScore: supplierScoreSchema,
+  supplierForecast: supplierForecastSchema,
+  supplierAlerts: supplierAlertsSchema,
+  demandIndex: demandIndexSchema,
+  demandTrend: demandTrendSchema,
+  demandAnomalies: demandAnomaliesSchema,
+  provenanceLineage: provenanceLineageSchema,
+  provenanceFreshness: provenanceFreshnessSchema,
+  provenanceVerify: provenanceVerifySchema,
+  screeningCheck: screeningCheckSchema,
+  screeningExposure: screeningExposureSchema,
+  screeningJurisdiction: screeningJurisdictionSchema,
+  macroEvents: macroEventsSchema,
+  macroImpact: macroImpactSchema,
+  macroScenario: macroScenarioSchema,
+};
+
+function hash(input: string): number {
+  let value = 2166136261;
+  for (let index = 0; index < input.length; index += 1) {
+    value ^= input.charCodeAt(index);
+    value = Math.imul(value, 16777619);
+  }
+  return value >>> 0;
+}
+
+function score(input: string, min: number, max: number): number {
+  const ratio = hash(input) / 0xffffffff;
+  return Number((min + ratio * (max - min)).toFixed(4));
+}
+
+function freshness(now: number, seed: string) {
+  return {
+    generated_at: new Date(now).toISOString(),
+    freshness_ms: hash(seed) % 120000,
+    confidence: score(`${seed}:confidence`, 0.72, 0.98),
+  };
+}
+
+function json(schema: z.ZodType, body: unknown, status = 200): Response {
+  return Response.json(schema.parse(body), { status });
+}
+
+function error(code: string, message: string, status: number): Response {
+  return Response.json({ error: { code, message } }, { status });
+}
+
+function requiresPayment(request: Request): Response | null {
+  if (
+    request.headers.get('X-402-Payment') ??
+    request.headers.get('payment-signature')
+  ) {
+    return null;
+  }
+  return Response.json(
+    {
+      error: {
+        code: 'payment_required',
+        message: 'A valid x402 payment is required for this endpoint.',
+      },
+    },
+    {
+      status: 402,
+      headers: {
+        'x-402-payment-required': 'true',
+        'x-402-price': process.env.DATA_API_PRICE_USD ?? '0.01',
+        'x-402-currency': 'USDC',
+      },
+    }
+  );
+}
+
+function url(request: Request): URL {
+  return new URL(request.url);
+}
+
+function queryString(request: Request, key: string, fallback: string): string {
+  return url(request).searchParams.get(key) ?? fallback;
+}
+
+function queryNumber(request: Request, key: string, fallback: number): number {
+  const raw = url(request).searchParams.get(key);
+  const parsed = raw ? Number(raw) : fallback;
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+async function bodyJson(request: Request): Promise<Record<string, unknown>> {
+  try {
+    return (await request.json()) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function route(
+  method: 'GET' | 'POST',
+  path: string,
+  handler: RouteDef['handler']
+): RouteDef {
+  return { method, path, handler };
+}
+
+export const apiRoutes: Record<ApiName, RouteDef[]> = {
+  supplier: [
+    route('GET', '/v1/suppliers/score', (request, now) => {
+      const supplierId = queryString(request, 'supplierId', 'supplier-acme');
+      const category = queryString(request, 'category', 'components');
+      const region = queryString(request, 'region', 'na');
+      const seed = `${supplierId}:${category}:${region}`;
+      return json(apiSchemas.supplierScore, {
+        supplier_id: supplierId,
+        category,
+        region,
+        supplier_score: score(seed, 62, 94),
+        completion_rate: score(`${seed}:completion`, 0.82, 0.99),
+        lead_time_p50_p95: {
+          p50_days: score(`${seed}:p50`, 4, 18),
+          p95_days: score(`${seed}:p95`, 16, 42),
+        },
+        disruption_probability: score(`${seed}:risk`, 0.03, 0.34),
+        alert_reasons: ['lead_time_drift', 'regional_capacity_signal'],
+        freshness: freshness(now, seed),
+      });
+    }),
+    route('GET', '/v1/suppliers/lead-time-forecast', (request, now) => {
+      const supplierId = queryString(request, 'supplierId', 'supplier-acme');
+      const horizonDays = queryNumber(request, 'horizonDays', 30);
+      const seed = `${supplierId}:${horizonDays}:forecast`;
+      return json(apiSchemas.supplierForecast, {
+        supplier_id: supplierId,
+        horizon_days: horizonDays,
+        lead_time_p50_p95: {
+          p50_days: score(`${seed}:p50`, 5, 20),
+          p95_days: score(`${seed}:p95`, 18, 45),
+        },
+        confidence_band: {
+          low_days: score(`${seed}:low`, 3, 12),
+          high_days: score(`${seed}:high`, 22, 55),
+        },
+        freshness: freshness(now, seed),
+      });
+    }),
+    route('GET', '/v1/suppliers/disruption-alerts', (request, now) => {
+      const supplierId = queryString(request, 'supplierId', 'supplier-acme');
+      const seed = `${supplierId}:alerts`;
+      return json(apiSchemas.supplierAlerts, {
+        supplier_id: supplierId,
+        disruption_probability: score(seed, 0.04, 0.41),
+        alert_reasons: ['weather_delay_watch', 'fill_rate_variance'],
+        freshness: freshness(now, seed),
+      });
+    }),
+  ],
+  demand: [
+    route('GET', '/v1/demand/index', (request, now) => {
+      const geoType = queryString(request, 'geoType', 'city');
+      if (!['zip', 'city', 'region'].includes(geoType))
+        return error(
+          'invalid_geo_type',
+          'geoType must be zip, city, or region.',
+          400
+        );
+      const geoCode = queryString(request, 'geoCode', 'SFO');
+      const category = queryString(request, 'category', 'apparel');
+      const seed = `${geoType}:${geoCode}:${category}`;
+      const index = score(seed, 42, 118);
+      return json(apiSchemas.demandIndex, {
+        geo_type: geoType,
+        geo_code: geoCode,
+        category,
+        demand_index: index,
+        confidence_interval: {
+          low: Number((index - 6.5).toFixed(2)),
+          high: Number((index + 7.25).toFixed(2)),
+        },
+        comparable_geos: [`${geoCode}-peer-1`, `${geoCode}-peer-2`],
+        freshness: freshness(now, seed),
+      });
+    }),
+    route('GET', '/v1/demand/trend', (request, now) => {
+      const geoCode = queryString(request, 'geoCode', 'SFO');
+      const category = queryString(request, 'category', 'apparel');
+      const lookbackWindow = queryString(request, 'lookbackWindow', '30d');
+      const seasonalityMode = queryString(request, 'seasonalityMode', 'weekly');
+      const seed = `${geoCode}:${category}:${lookbackWindow}:${seasonalityMode}`;
+      return json(apiSchemas.demandTrend, {
+        geo_code: geoCode,
+        category,
+        velocity: score(seed, -0.18, 0.32),
+        lookback_window: lookbackWindow,
+        seasonality_mode: seasonalityMode,
+        freshness: freshness(now, seed),
+      });
+    }),
+    route('GET', '/v1/demand/anomalies', (request, now) => {
+      const geoCode = queryString(request, 'geoCode', 'SFO');
+      const category = queryString(request, 'category', 'apparel');
+      const seed = `${geoCode}:${category}:anomalies`;
+      return json(apiSchemas.demandAnomalies, {
+        geo_code: geoCode,
+        category,
+        anomaly_flags: [
+          {
+            code: 'velocity_spike',
+            severity: score(`${seed}:spike`, 0.1, 0.9),
+          },
+          {
+            code: 'peer_divergence',
+            severity: score(`${seed}:peer`, 0.1, 0.8),
+          },
+        ],
+        freshness: freshness(now, seed),
+      });
+    }),
+  ],
+  provenance: [
+    route('GET', '/v1/provenance/lineage', (request, now) => {
+      const datasetId = queryString(request, 'datasetId', 'dataset-prices');
+      const sourceId = queryString(request, 'sourceId', 'source-primary');
+      const seed = `${datasetId}:${sourceId}:lineage`;
+      return json(apiSchemas.provenanceLineage, {
+        dataset_id: datasetId,
+        lineage_graph: {
+          nodes: [
+            { id: sourceId, type: 'source' },
+            { id: datasetId, type: 'dataset' },
+            { id: `${datasetId}-attestation`, type: 'attestation' },
+          ],
+          edges: [
+            { from: sourceId, to: datasetId },
+            { from: datasetId, to: `${datasetId}-attestation` },
+          ],
+        },
+        attestation_refs: [`urn:lucid:attestation:${hash(seed)}`],
+        freshness: freshness(now, seed),
+      });
+    }),
+    route('GET', '/v1/provenance/freshness', (request, now) => {
+      const datasetId = queryString(request, 'datasetId', 'dataset-prices');
+      const sourceId = queryString(request, 'sourceId', 'source-primary');
+      const maxStalenessMs = queryNumber(request, 'maxStalenessMs', 300000);
+      const seed = `${datasetId}:${sourceId}:freshness`;
+      const stalenessMs = hash(seed) % 600000;
+      return json(apiSchemas.provenanceFreshness, {
+        dataset_id: datasetId,
+        source_id: sourceId,
+        staleness_ms: stalenessMs,
+        sla_status: stalenessMs <= maxStalenessMs ? 'fresh' : 'stale',
+        freshness: freshness(now, seed),
+      });
+    }),
+    route('POST', '/v1/provenance/verify-hash', async (request, now) => {
+      const body = await bodyJson(request);
+      const datasetId = String(body.datasetId ?? 'dataset-prices');
+      const expectedHash = String(body.expectedHash ?? 'hash-unknown');
+      const seed = `${datasetId}:${expectedHash}:verify`;
+      return json(apiSchemas.provenanceVerify, {
+        dataset_id: datasetId,
+        expected_hash: expectedHash,
+        verification_status: expectedHash.startsWith('sha256:')
+          ? 'match'
+          : 'mismatch',
+        attestation_refs: [`urn:lucid:hash-check:${hash(seed)}`],
+        freshness: freshness(now, seed),
+      });
+    }),
+  ],
+  screening: [
+    route('POST', '/v1/screening/check', async (request, now) => {
+      const body = await bodyJson(request);
+      const entityName = String(body.entityName ?? 'Acme Trading LLC');
+      const seed = `${entityName}:screening`;
+      const risk = score(seed, 0.02, 0.62);
+      return json(apiSchemas.screeningCheck, {
+        entity_name: entityName,
+        screening_status: risk > 0.55 ? 'review' : 'clear',
+        match_confidence: score(`${seed}:match`, 0.71, 0.99),
+        jurisdiction_risk: risk,
+        evidence_bundle: [`urn:lucid:evidence:${hash(seed)}`],
+        freshness: freshness(now, seed),
+      });
+    }),
+    route('GET', '/v1/screening/exposure-chain', (request, now) => {
+      const entityName = queryString(request, 'entityName', 'Acme Trading LLC');
+      const seed = `${entityName}:exposure`;
+      return json(apiSchemas.screeningExposure, {
+        entity_name: entityName,
+        exposure_chain: [
+          { entity: entityName, relationship: 'beneficial_owner' },
+          { entity: `${entityName} Holdings`, relationship: 'affiliate' },
+        ],
+        match_confidence: score(seed, 0.68, 0.96),
+        freshness: freshness(now, seed),
+      });
+    }),
+    route('GET', '/v1/screening/jurisdiction-risk', (request, now) => {
+      const jurisdictions = queryString(request, 'jurisdictions', 'US,CA')
+        .split(',')
+        .filter(Boolean);
+      const seed = `${jurisdictions.join(':')}:jurisdiction`;
+      return json(apiSchemas.screeningJurisdiction, {
+        jurisdictions,
+        jurisdiction_risk: score(seed, 0.05, 0.7),
+        rationale: ['pep_exposure_index', 'sanctions_update_frequency'],
+        freshness: freshness(now, seed),
+      });
+    }),
+  ],
+  macro: [
+    route('GET', '/v1/macro/events', (request, now) => {
+      const eventTypes = queryString(request, 'eventTypes', 'rates,energy')
+        .split(',')
+        .filter(Boolean);
+      const geography = queryString(request, 'geography', 'global');
+      const seed = `${eventTypes.join(':')}:${geography}`;
+      return json(apiSchemas.macroEvents, {
+        event_types: eventTypes,
+        geography,
+        event_feed: eventTypes.map(eventType => ({
+          id: `${eventType}-${hash(`${seed}:${eventType}`)}`,
+          event_type: eventType,
+          urgency_score: score(`${seed}:${eventType}:urgency`, 0.1, 0.95),
+        })),
+        freshness: freshness(now, seed),
+      });
+    }),
+    route('GET', '/v1/macro/impact-vectors', (request, now) => {
+      const sectorSet = queryString(request, 'sectorSet', 'energy,retail')
+        .split(',')
+        .filter(Boolean);
+      const horizon = queryString(request, 'horizon', '30d');
+      const seed = `${sectorSet.join(':')}:${horizon}`;
+      return json(apiSchemas.macroImpact, {
+        sector_set: sectorSet,
+        impact_vector: Object.fromEntries(
+          sectorSet.map(sector => [
+            sector,
+            score(`${seed}:${sector}`, -0.7, 0.7),
+          ])
+        ),
+        confidence_band: {
+          low: score(`${seed}:low`, 0.42, 0.65),
+          high: score(`${seed}:high`, 0.74, 0.95),
+        },
+        freshness: freshness(now, seed),
+      });
+    }),
+    route('POST', '/v1/macro/scenario-score', async (request, now) => {
+      const body = await bodyJson(request);
+      const geography = String(body.geography ?? 'global');
+      const horizon = String(body.horizon ?? '30d');
+      const seed = `${geography}:${horizon}:scenario`;
+      return json(apiSchemas.macroScenario, {
+        scenario_score: score(seed, -1, 1),
+        sensitivity_breakdown: {
+          rates: score(`${seed}:rates`, -0.8, 0.8),
+          energy: score(`${seed}:energy`, -0.8, 0.8),
+          supply_chain: score(`${seed}:supply`, -0.8, 0.8),
+        },
+        freshness: freshness(now, seed),
+      });
+    }),
+  ],
+};
+
+export async function createDataApiApp(name: ApiName) {
+  const agent = await createAgent({
+    name: `${name}-data-api`,
+    version: '1.0.0',
+    description: `Paid ${name} data API for agent consumers`,
+  })
+    .use(http())
+    .use(
+      payments({
+        config: paymentsFromEnv({
+          storage: { type: 'in-memory' },
+        }),
+      })
+    )
+    .build();
+
+  return createAgentApp(agent, {
+    afterMount(app) {
+      for (const item of apiRoutes[name]) {
+        const handler = async (c: Context) => {
+          const paymentError = requiresPayment(c.req.raw);
+          if (paymentError) return paymentError;
+          return item.handler(c.req.raw, Date.now());
+        };
+        if (item.method === 'GET') app.get(item.path, handler);
+        if (item.method === 'POST') app.post(item.path, handler);
+      }
+    },
+  });
+}
+
+export async function createAllDataApiApps() {
+  return {
+    supplier: await createDataApiApp('supplier'),
+    demand: await createDataApiApp('demand'),
+    provenance: await createDataApiApp('provenance'),
+    screening: await createDataApiApp('screening'),
+    macro: await createDataApiApp('macro'),
+  };
+}

--- a/packages/examples/src/data-apis/marketplace.ts
+++ b/packages/examples/src/data-apis/marketplace.ts
@@ -9,7 +9,17 @@ import {
 import type { Context } from 'hono';
 import { z } from 'zod';
 
-type ApiName = 'supplier' | 'demand' | 'provenance' | 'screening' | 'macro';
+type ApiName =
+  | 'supplier'
+  | 'demand'
+  | 'provenance'
+  | 'screening'
+  | 'macro'
+  | 'liquidity'
+  | 'gas'
+  | 'risk'
+  | 'regulations'
+  | 'identity';
 
 type RouteDef = {
   method: 'GET' | 'POST';
@@ -153,6 +163,175 @@ const macroScenarioSchema = z.object({
   freshness: freshnessSchema,
 });
 
+const liquiditySchema = z.object({
+  chain: z.string(),
+  base_token: z.string(),
+  quote_token: z.string(),
+  normalized_pools: z
+    .array(
+      z.object({
+        venue: z.string(),
+        pool_id: z.string(),
+        depth_buckets: z.array(
+          z.object({ notional_usd: z.number(), slippage_bps: z.number() })
+        ),
+      })
+    )
+    .optional(),
+  slippage_bps_curve: z
+    .array(
+      z.object({
+        venue: z.string(),
+        notional_usd: z.number(),
+        slippage_bps: z.number(),
+      })
+    )
+    .optional(),
+  routes: z
+    .array(
+      z.object({
+        venue_path: z.array(z.string()),
+        estimated_slippage_bps: z.number(),
+        quality_score: z.number().min(0).max(1),
+      })
+    )
+    .optional(),
+  best_route: z
+    .object({
+      venue_path: z.array(z.string()),
+      estimated_slippage_bps: z.number(),
+      quality_score: z.number().min(0).max(1),
+    })
+    .optional(),
+  confidence_score: z.number().min(0).max(1),
+  freshness: freshnessSchema,
+});
+
+const gasSchema = z.object({
+  chain: z.string(),
+  urgency: z.string().optional(),
+  target_blocks: z.number().int().positive().optional(),
+  recommended_max_fee: z.number().optional(),
+  priority_fee: z.number().optional(),
+  inclusion_probability_curve: z
+    .array(
+      z.object({
+        target_blocks: z.number().int().positive(),
+        probability: z.number().min(0).max(1),
+      })
+    )
+    .optional(),
+  forecast: z
+    .array(
+      z.object({
+        minute: z.number().int().nonnegative(),
+        max_fee: z.number(),
+        priority_fee: z.number(),
+      })
+    )
+    .optional(),
+  congestion_state: z.enum(['low', 'normal', 'elevated', 'severe']),
+  confidence_score: z.number().min(0).max(1),
+  freshness: freshnessSchema,
+});
+
+const riskSchema = z.object({
+  address: z.string(),
+  network: z.string(),
+  risk_score: z.number().min(0).max(100).optional(),
+  risk_factors: z
+    .array(
+      z.object({
+        code: z.string(),
+        weight: z.number(),
+        contribution: z.number(),
+      })
+    )
+    .optional(),
+  exposure_paths: z
+    .array(
+      z.object({
+        path: z.array(z.string()),
+        risk_score: z.number(),
+        distance: z.number().int().positive(),
+      })
+    )
+    .optional(),
+  cluster_id: z.string().optional(),
+  sanctions_proximity: z.number().min(0).max(1).optional(),
+  evidence_refs: z.array(z.string()).optional(),
+  freshness: freshnessSchema,
+});
+
+const regulationsSchema = z.object({
+  jurisdiction: z.string(),
+  industry: z.string().optional(),
+  since: z.string().optional(),
+  rule_diff: z
+    .array(
+      z.object({
+        rule_id: z.string(),
+        semantic_change_type: z.string(),
+        effective_date: z.string(),
+        urgency_score: z.number(),
+      })
+    )
+    .optional(),
+  affected_controls: z
+    .array(
+      z.object({
+        control_id: z.string(),
+        framework: z.string(),
+        impact_level: z.string(),
+        urgency_score: z.number(),
+      })
+    )
+    .optional(),
+  control_framework: z.string().optional(),
+  mappings: z
+    .array(
+      z.object({
+        rule_id: z.string(),
+        control_id: z.string(),
+        confidence: z.number().min(0).max(1),
+      })
+    )
+    .optional(),
+  freshness: freshnessSchema,
+});
+
+const identitySchema = z.object({
+  agent_address: z.string(),
+  chain: z.string(),
+  trust_score: z.number().min(0).max(100),
+  completion_rate: z.number().min(0).max(1).optional(),
+  dispute_rate: z.number().min(0).max(1).optional(),
+  onchain_identity_state: z
+    .enum(['active', 'probation', 'suspended'])
+    .optional(),
+  events: z
+    .array(
+      z.object({
+        event_type: z.string(),
+        timestamp: z.string(),
+        evidence_url: z.string(),
+      })
+    )
+    .optional(),
+  dimensions: z
+    .array(
+      z.object({
+        name: z.string(),
+        score: z.number(),
+        weight: z.number(),
+        confidence: z.number().min(0).max(1),
+      })
+    )
+    .optional(),
+  evidence_urls: z.array(z.string()).optional(),
+  freshness: freshnessSchema,
+});
+
 export const apiSchemas = {
   supplierScore: supplierScoreSchema,
   supplierForecast: supplierForecastSchema,
@@ -169,6 +348,11 @@ export const apiSchemas = {
   macroEvents: macroEventsSchema,
   macroImpact: macroImpactSchema,
   macroScenario: macroScenarioSchema,
+  liquidity: liquiditySchema,
+  gas: gasSchema,
+  risk: riskSchema,
+  regulations: regulationsSchema,
+  identity: identitySchema,
 };
 
 function hash(input: string): number {
@@ -527,6 +711,326 @@ export const apiRoutes: Record<ApiName, RouteDef[]> = {
       });
     }),
   ],
+  liquidity: [
+    route('GET', '/v1/liquidity/snapshot', request => {
+      const chain = queryString(request, 'chain', 'base');
+      const baseToken = queryString(request, 'baseToken', 'ETH');
+      const quoteToken = queryString(request, 'quoteToken', 'USDC');
+      const venues = queryString(request, 'venueFilter', 'uniswap,aerodrome')
+        .split(',')
+        .filter(Boolean);
+      const seed = `${chain}:${baseToken}:${quoteToken}:${venues.join(':')}`;
+      return json(apiSchemas.liquidity, {
+        chain,
+        base_token: baseToken,
+        quote_token: quoteToken,
+        normalized_pools: venues.map(venue => ({
+          venue,
+          pool_id: `${venue}-${hash(`${seed}:${venue}`)}`,
+          depth_buckets: [10000, 50000, 250000].map(notional => ({
+            notional_usd: notional,
+            slippage_bps: score(`${seed}:${venue}:${notional}`, 1, 90),
+          })),
+        })),
+        confidence_score: score(`${seed}:confidence`, 0.72, 0.98),
+        freshness: freshness(seed),
+      });
+    }),
+    route('GET', '/v1/liquidity/slippage', request => {
+      const chain = queryString(request, 'chain', 'base');
+      const baseToken = queryString(request, 'baseToken', 'ETH');
+      const quoteToken = queryString(request, 'quoteToken', 'USDC');
+      const notionalUsd = queryNumber(request, 'notionalUsd', 100000, 1);
+      const venues = queryString(request, 'venueFilter', 'uniswap,aerodrome')
+        .split(',')
+        .filter(Boolean);
+      const seed = `${chain}:${baseToken}:${quoteToken}:${notionalUsd}:slippage`;
+      return json(apiSchemas.liquidity, {
+        chain,
+        base_token: baseToken,
+        quote_token: quoteToken,
+        slippage_bps_curve: venues.map(venue => ({
+          venue,
+          notional_usd: notionalUsd,
+          slippage_bps: score(`${seed}:${venue}`, 2, 140),
+        })),
+        confidence_score: score(`${seed}:confidence`, 0.72, 0.98),
+        freshness: freshness(seed),
+      });
+    }),
+    route('GET', '/v1/liquidity/routes', request => {
+      const chain = queryString(request, 'chain', 'base');
+      const baseToken = queryString(request, 'baseToken', 'ETH');
+      const quoteToken = queryString(request, 'quoteToken', 'USDC');
+      const notionalUsd = queryNumber(request, 'notionalUsd', 100000, 1);
+      const seed = `${chain}:${baseToken}:${quoteToken}:${notionalUsd}:routes`;
+      const routes = ['aerodrome', 'uniswap:curve', 'uniswap:aerodrome'].map(
+        venuePath => ({
+          venue_path: venuePath.split(':'),
+          estimated_slippage_bps: score(`${seed}:${venuePath}:slippage`, 2, 95),
+          quality_score: score(`${seed}:${venuePath}:quality`, 0.68, 0.99),
+        })
+      );
+      const bestRoute = routes.reduce((best, current) =>
+        current.quality_score > best.quality_score ? current : best
+      );
+      return json(apiSchemas.liquidity, {
+        chain,
+        base_token: baseToken,
+        quote_token: quoteToken,
+        routes,
+        best_route: bestRoute,
+        confidence_score: score(`${seed}:confidence`, 0.72, 0.98),
+        freshness: freshness(seed),
+      });
+    }),
+  ],
+  gas: [
+    route('GET', '/v1/gas/quote', request => {
+      const chain = queryString(request, 'chain', 'base');
+      const urgency = queryString(request, 'urgency', 'standard');
+      const targetBlocks = queryNumber(request, 'targetBlocks', 3, 1);
+      const seed = `${chain}:${urgency}:${targetBlocks}:quote`;
+      return json(apiSchemas.gas, {
+        chain,
+        urgency,
+        target_blocks: targetBlocks,
+        recommended_max_fee: score(`${seed}:max`, 0.02, 2.4),
+        priority_fee: score(`${seed}:priority`, 0.001, 0.22),
+        inclusion_probability_curve: [1, 2, 3, 5].map(blocks => ({
+          target_blocks: blocks,
+          probability: score(`${seed}:${blocks}`, 0.46, 0.99),
+        })),
+        congestion_state: ['low', 'normal', 'elevated', 'severe'][
+          hash(seed) % 4
+        ],
+        confidence_score: score(`${seed}:confidence`, 0.75, 0.98),
+        freshness: freshness(seed),
+      });
+    }),
+    route('GET', '/v1/gas/forecast', request => {
+      const chain = queryString(request, 'chain', 'base');
+      const horizonMinutes = queryNumber(request, 'horizonMinutes', 30, 1);
+      const seed = `${chain}:${horizonMinutes}:forecast`;
+      return json(apiSchemas.gas, {
+        chain,
+        forecast: [0, 5, 10, 20, 30]
+          .filter(minute => minute <= horizonMinutes)
+          .map(minute => ({
+            minute,
+            max_fee: score(`${seed}:${minute}:max`, 0.02, 2.8),
+            priority_fee: score(`${seed}:${minute}:priority`, 0.001, 0.24),
+          })),
+        congestion_state: ['low', 'normal', 'elevated', 'severe'][
+          hash(seed) % 4
+        ],
+        confidence_score: score(`${seed}:confidence`, 0.72, 0.97),
+        freshness: freshness(seed),
+      });
+    }),
+    route('GET', '/v1/gas/congestion', request => {
+      const chain = queryString(request, 'chain', 'base');
+      const seed = `${chain}:congestion`;
+      return json(apiSchemas.gas, {
+        chain,
+        congestion_state: ['low', 'normal', 'elevated', 'severe'][
+          hash(seed) % 4
+        ],
+        confidence_score: score(`${seed}:confidence`, 0.74, 0.98),
+        freshness: freshness(seed),
+      });
+    }),
+  ],
+  risk: [
+    route('POST', '/v1/risk/score', async request => {
+      const body = await bodyJson(request);
+      const address = String(
+        body.address ?? '0x0000000000000000000000000000000000000001'
+      );
+      const network = String(body.network ?? 'base');
+      const seed = `${address}:${network}:risk`;
+      return json(apiSchemas.risk, {
+        address,
+        network,
+        risk_score: score(seed, 4, 91),
+        risk_factors: ['mixer_proximity', 'bridge_exposure'].map(code => ({
+          code,
+          weight: score(`${seed}:${code}:weight`, 0.1, 0.45),
+          contribution: score(`${seed}:${code}:contribution`, 1, 28),
+        })),
+        sanctions_proximity: score(`${seed}:sanctions`, 0.01, 0.62),
+        evidence_refs: [`urn:lucid:risk-evidence:${hash(seed)}`],
+        freshness: freshness(seed),
+      });
+    }),
+    route('GET', '/v1/risk/exposure-paths', request => {
+      const address = queryString(
+        request,
+        'address',
+        '0x0000000000000000000000000000000000000001'
+      );
+      const network = queryString(request, 'network', 'base');
+      const threshold = queryNumber(request, 'threshold', 50, 0);
+      const seed = `${address}:${network}:${threshold}:paths`;
+      return json(apiSchemas.risk, {
+        address,
+        network,
+        exposure_paths: [1, 2, 3].map(distance => ({
+          path: [address, `0xcluster${hash(`${seed}:${distance}`)}`],
+          risk_score: score(`${seed}:${distance}`, threshold, 100),
+          distance,
+        })),
+        freshness: freshness(seed),
+      });
+    }),
+    route('GET', '/v1/risk/entity-profile', request => {
+      const address = queryString(
+        request,
+        'address',
+        '0x0000000000000000000000000000000000000001'
+      );
+      const network = queryString(request, 'network', 'base');
+      const seed = `${address}:${network}:profile`;
+      return json(apiSchemas.risk, {
+        address,
+        network,
+        risk_score: score(seed, 3, 88),
+        cluster_id: `cluster-${hash(seed)}`,
+        evidence_refs: [`urn:lucid:entity-profile:${hash(seed)}`],
+        freshness: freshness(seed),
+      });
+    }),
+  ],
+  regulations: [
+    route('GET', '/v1/regulations/delta', request => {
+      const jurisdiction = queryString(request, 'jurisdiction', 'US');
+      const industry = queryString(request, 'industry', 'crypto');
+      const since = queryString(request, 'since', '2026-01-01');
+      const seed = `${jurisdiction}:${industry}:${since}:delta`;
+      return json(apiSchemas.regulations, {
+        jurisdiction,
+        industry,
+        since,
+        rule_diff: ['custody_reporting', 'stablecoin_reserve'].map(rule => ({
+          rule_id: `${jurisdiction}-${rule}`,
+          semantic_change_type:
+            hash(`${seed}:${rule}`) % 2 === 0
+              ? 'new_obligation'
+              : 'threshold_update',
+          effective_date: new Date(
+            1700000000000 + (hash(`${seed}:${rule}:date`) % 31536000000)
+          ).toISOString(),
+          urgency_score: score(`${seed}:${rule}:urgency`, 0.1, 0.97),
+        })),
+        freshness: freshness(seed),
+      });
+    }),
+    route('GET', '/v1/regulations/impact', request => {
+      const jurisdiction = queryString(request, 'jurisdiction', 'US');
+      const industry = queryString(request, 'industry', 'crypto');
+      const controlFramework = queryString(request, 'controlFramework', 'SOC2');
+      const seed = `${jurisdiction}:${industry}:${controlFramework}:impact`;
+      return json(apiSchemas.regulations, {
+        jurisdiction,
+        industry,
+        affected_controls: ['CC6.1', 'CC7.2', 'CC9.2'].map(controlId => ({
+          control_id: controlId,
+          framework: controlFramework,
+          impact_level: ['low', 'medium', 'high'][
+            hash(`${seed}:${controlId}`) % 3
+          ],
+          urgency_score: score(`${seed}:${controlId}:urgency`, 0.12, 0.96),
+        })),
+        freshness: freshness(seed),
+      });
+    }),
+    route('POST', '/v1/regulations/map-controls', async request => {
+      const body = await bodyJson(request);
+      const jurisdiction = String(body.jurisdiction ?? 'US');
+      const controlFramework = String(body.controlFramework ?? 'SOC2');
+      const seed = `${jurisdiction}:${controlFramework}:map`;
+      return json(apiSchemas.regulations, {
+        jurisdiction,
+        control_framework: controlFramework,
+        mappings: ['custody_reporting', 'stablecoin_reserve'].map(rule => ({
+          rule_id: `${jurisdiction}-${rule}`,
+          control_id: `${controlFramework}-${hash(`${seed}:${rule}`) % 100}`,
+          confidence: score(`${seed}:${rule}:confidence`, 0.68, 0.98),
+        })),
+        freshness: freshness(seed),
+      });
+    }),
+  ],
+  identity: [
+    route('GET', '/v1/identity/reputation', request => {
+      const agentAddress = queryString(
+        request,
+        'agentAddress',
+        '0x0000000000000000000000000000000000000001'
+      );
+      const chain = queryString(request, 'chain', 'base');
+      const timeframe = queryString(request, 'timeframe', '90d');
+      const seed = `${agentAddress}:${chain}:${timeframe}:reputation`;
+      return json(apiSchemas.identity, {
+        agent_address: agentAddress,
+        chain,
+        trust_score: score(seed, 38, 98),
+        completion_rate: score(`${seed}:completion`, 0.63, 0.99),
+        dispute_rate: score(`${seed}:disputes`, 0.001, 0.14),
+        onchain_identity_state: ['active', 'probation', 'suspended'][
+          hash(seed) % 3
+        ],
+        evidence_urls: [`https://evidence.example.com/identity/${hash(seed)}`],
+        freshness: freshness(seed),
+      });
+    }),
+    route('GET', '/v1/identity/history', request => {
+      const agentAddress = queryString(
+        request,
+        'agentAddress',
+        '0x0000000000000000000000000000000000000001'
+      );
+      const chain = queryString(request, 'chain', 'base');
+      const timeframe = queryString(request, 'timeframe', '90d');
+      const seed = `${agentAddress}:${chain}:${timeframe}:history`;
+      return json(apiSchemas.identity, {
+        agent_address: agentAddress,
+        chain,
+        trust_score: score(seed, 38, 98),
+        events: ['task_completed', 'attestation_issued'].map(eventType => ({
+          event_type: eventType,
+          timestamp: new Date(
+            1700000000000 + (hash(`${seed}:${eventType}`) % 86400000)
+          ).toISOString(),
+          evidence_url: `https://evidence.example.com/identity/${hash(`${seed}:${eventType}`)}`,
+        })),
+        freshness: freshness(seed),
+      });
+    }),
+    route('GET', '/v1/identity/trust-breakdown', request => {
+      const agentAddress = queryString(
+        request,
+        'agentAddress',
+        '0x0000000000000000000000000000000000000001'
+      );
+      const chain = queryString(request, 'chain', 'base');
+      const seed = `${agentAddress}:${chain}:breakdown`;
+      return json(apiSchemas.identity, {
+        agent_address: agentAddress,
+        chain,
+        trust_score: score(seed, 38, 98),
+        dimensions: ['delivery', 'feedback', 'onchain_consistency'].map(
+          name => ({
+            name,
+            score: score(`${seed}:${name}:score`, 30, 100),
+            weight: score(`${seed}:${name}:weight`, 0.18, 0.48),
+            confidence: score(`${seed}:${name}:confidence`, 0.68, 0.98),
+          })
+        ),
+        freshness: freshness(seed),
+      });
+    }),
+  ],
 };
 
 export async function createDataApiApp(name: ApiName) {
@@ -567,5 +1071,10 @@ export async function createAllDataApiApps() {
     provenance: await createDataApiApp('provenance'),
     screening: await createDataApiApp('screening'),
     macro: await createDataApiApp('macro'),
+    liquidity: await createDataApiApp('liquidity'),
+    gas: await createDataApiApp('gas'),
+    risk: await createDataApiApp('risk'),
+    regulations: await createDataApiApp('regulations'),
+    identity: await createDataApiApp('identity'),
   };
 }

--- a/packages/examples/src/data-apis/marketplace.ts
+++ b/packages/examples/src/data-apis/marketplace.ts
@@ -1,7 +1,11 @@
 import { createAgent } from '@lucid-agents/core';
 import { createAgentApp } from '@lucid-agents/hono';
 import { http } from '@lucid-agents/http';
-import { payments, paymentsFromEnv } from '@lucid-agents/payments';
+import {
+  paymentRequiredResponse,
+  payments,
+  paymentsFromEnv,
+} from '@lucid-agents/payments';
 import type { Context } from 'hono';
 import { z } from 'zod';
 
@@ -10,7 +14,7 @@ type ApiName = 'supplier' | 'demand' | 'provenance' | 'screening' | 'macro';
 type RouteDef = {
   method: 'GET' | 'POST';
   path: string;
-  handler: (request: Request, now: number) => Response | Promise<Response>;
+  handler: (request: Request) => Response | Promise<Response>;
 };
 
 const freshnessSchema = z.object({
@@ -181,9 +185,17 @@ function score(input: string, min: number, max: number): number {
   return Number((min + ratio * (max - min)).toFixed(4));
 }
 
-function freshness(now: number, seed: string) {
+const demoPaymentConfig = {
+  payTo: '0x0000000000000000000000000000000000000001',
+  network: 'eip155:84532' as const,
+  facilitatorUrl: 'https://facilitator.example.com',
+  storage: { type: 'in-memory' as const },
+};
+
+function freshness(seed: string) {
+  const generatedAt = new Date(1700000000000 + (hash(seed) % 86400000));
   return {
-    generated_at: new Date(now).toISOString(),
+    generated_at: generatedAt.toISOString(),
     freshness_ms: hash(seed) % 120000,
     confidence: score(`${seed}:confidence`, 0.72, 0.98),
   };
@@ -198,28 +210,24 @@ function error(code: string, message: string, status: number): Response {
 }
 
 function requiresPayment(request: Request): Response | null {
-  if (
-    request.headers.get('X-402-Payment') ??
-    request.headers.get('payment-signature')
-  ) {
+  const hasPayment = [
+    request.headers.get('PAYMENT'),
+    request.headers.get('X-PAYMENT'),
+    request.headers.get('PAYMENT-RESPONSE'),
+    request.headers.get('payment-signature'),
+  ].some(value => value?.trim());
+
+  if (hasPayment) {
     return null;
   }
-  return Response.json(
-    {
-      error: {
-        code: 'payment_required',
-        message: 'A valid x402 payment is required for this endpoint.',
-      },
-    },
-    {
-      status: 402,
-      headers: {
-        'x-402-payment-required': 'true',
-        'x-402-price': process.env.DATA_API_PRICE_USD ?? '0.01',
-        'x-402-currency': 'USDC',
-      },
-    }
-  );
+
+  return paymentRequiredResponse({
+    required: true,
+    price: process.env.DATA_API_PRICE_USD ?? '0.01',
+    payTo: demoPaymentConfig.payTo,
+    network: demoPaymentConfig.network,
+    facilitatorUrl: demoPaymentConfig.facilitatorUrl,
+  });
 }
 
 function url(request: Request): URL {
@@ -230,10 +238,16 @@ function queryString(request: Request, key: string, fallback: string): string {
   return url(request).searchParams.get(key) ?? fallback;
 }
 
-function queryNumber(request: Request, key: string, fallback: number): number {
+function queryNumber(
+  request: Request,
+  key: string,
+  fallback: number,
+  min?: number
+): number {
   const raw = url(request).searchParams.get(key);
   const parsed = raw ? Number(raw) : fallback;
-  return Number.isFinite(parsed) ? parsed : fallback;
+  const value = Number.isFinite(parsed) ? parsed : fallback;
+  return min === undefined ? value : Math.max(min, value);
 }
 
 async function bodyJson(request: Request): Promise<Record<string, unknown>> {
@@ -254,7 +268,7 @@ function route(
 
 export const apiRoutes: Record<ApiName, RouteDef[]> = {
   supplier: [
-    route('GET', '/v1/suppliers/score', (request, now) => {
+    route('GET', '/v1/suppliers/score', request => {
       const supplierId = queryString(request, 'supplierId', 'supplier-acme');
       const category = queryString(request, 'category', 'components');
       const region = queryString(request, 'region', 'na');
@@ -271,12 +285,12 @@ export const apiRoutes: Record<ApiName, RouteDef[]> = {
         },
         disruption_probability: score(`${seed}:risk`, 0.03, 0.34),
         alert_reasons: ['lead_time_drift', 'regional_capacity_signal'],
-        freshness: freshness(now, seed),
+        freshness: freshness(seed),
       });
     }),
-    route('GET', '/v1/suppliers/lead-time-forecast', (request, now) => {
+    route('GET', '/v1/suppliers/lead-time-forecast', request => {
       const supplierId = queryString(request, 'supplierId', 'supplier-acme');
-      const horizonDays = queryNumber(request, 'horizonDays', 30);
+      const horizonDays = queryNumber(request, 'horizonDays', 30, 1);
       const seed = `${supplierId}:${horizonDays}:forecast`;
       return json(apiSchemas.supplierForecast, {
         supplier_id: supplierId,
@@ -289,22 +303,22 @@ export const apiRoutes: Record<ApiName, RouteDef[]> = {
           low_days: score(`${seed}:low`, 3, 12),
           high_days: score(`${seed}:high`, 22, 55),
         },
-        freshness: freshness(now, seed),
+        freshness: freshness(seed),
       });
     }),
-    route('GET', '/v1/suppliers/disruption-alerts', (request, now) => {
+    route('GET', '/v1/suppliers/disruption-alerts', request => {
       const supplierId = queryString(request, 'supplierId', 'supplier-acme');
       const seed = `${supplierId}:alerts`;
       return json(apiSchemas.supplierAlerts, {
         supplier_id: supplierId,
         disruption_probability: score(seed, 0.04, 0.41),
         alert_reasons: ['weather_delay_watch', 'fill_rate_variance'],
-        freshness: freshness(now, seed),
+        freshness: freshness(seed),
       });
     }),
   ],
   demand: [
-    route('GET', '/v1/demand/index', (request, now) => {
+    route('GET', '/v1/demand/index', request => {
       const geoType = queryString(request, 'geoType', 'city');
       if (!['zip', 'city', 'region'].includes(geoType))
         return error(
@@ -326,10 +340,10 @@ export const apiRoutes: Record<ApiName, RouteDef[]> = {
           high: Number((index + 7.25).toFixed(2)),
         },
         comparable_geos: [`${geoCode}-peer-1`, `${geoCode}-peer-2`],
-        freshness: freshness(now, seed),
+        freshness: freshness(seed),
       });
     }),
-    route('GET', '/v1/demand/trend', (request, now) => {
+    route('GET', '/v1/demand/trend', request => {
       const geoCode = queryString(request, 'geoCode', 'SFO');
       const category = queryString(request, 'category', 'apparel');
       const lookbackWindow = queryString(request, 'lookbackWindow', '30d');
@@ -341,10 +355,10 @@ export const apiRoutes: Record<ApiName, RouteDef[]> = {
         velocity: score(seed, -0.18, 0.32),
         lookback_window: lookbackWindow,
         seasonality_mode: seasonalityMode,
-        freshness: freshness(now, seed),
+        freshness: freshness(seed),
       });
     }),
-    route('GET', '/v1/demand/anomalies', (request, now) => {
+    route('GET', '/v1/demand/anomalies', request => {
       const geoCode = queryString(request, 'geoCode', 'SFO');
       const category = queryString(request, 'category', 'apparel');
       const seed = `${geoCode}:${category}:anomalies`;
@@ -361,12 +375,12 @@ export const apiRoutes: Record<ApiName, RouteDef[]> = {
             severity: score(`${seed}:peer`, 0.1, 0.8),
           },
         ],
-        freshness: freshness(now, seed),
+        freshness: freshness(seed),
       });
     }),
   ],
   provenance: [
-    route('GET', '/v1/provenance/lineage', (request, now) => {
+    route('GET', '/v1/provenance/lineage', request => {
       const datasetId = queryString(request, 'datasetId', 'dataset-prices');
       const sourceId = queryString(request, 'sourceId', 'source-primary');
       const seed = `${datasetId}:${sourceId}:lineage`;
@@ -384,13 +398,13 @@ export const apiRoutes: Record<ApiName, RouteDef[]> = {
           ],
         },
         attestation_refs: [`urn:lucid:attestation:${hash(seed)}`],
-        freshness: freshness(now, seed),
+        freshness: freshness(seed),
       });
     }),
-    route('GET', '/v1/provenance/freshness', (request, now) => {
+    route('GET', '/v1/provenance/freshness', request => {
       const datasetId = queryString(request, 'datasetId', 'dataset-prices');
       const sourceId = queryString(request, 'sourceId', 'source-primary');
-      const maxStalenessMs = queryNumber(request, 'maxStalenessMs', 300000);
+      const maxStalenessMs = queryNumber(request, 'maxStalenessMs', 300000, 0);
       const seed = `${datasetId}:${sourceId}:freshness`;
       const stalenessMs = hash(seed) % 600000;
       return json(apiSchemas.provenanceFreshness, {
@@ -398,10 +412,10 @@ export const apiRoutes: Record<ApiName, RouteDef[]> = {
         source_id: sourceId,
         staleness_ms: stalenessMs,
         sla_status: stalenessMs <= maxStalenessMs ? 'fresh' : 'stale',
-        freshness: freshness(now, seed),
+        freshness: freshness(seed),
       });
     }),
-    route('POST', '/v1/provenance/verify-hash', async (request, now) => {
+    route('POST', '/v1/provenance/verify-hash', async request => {
       const body = await bodyJson(request);
       const datasetId = String(body.datasetId ?? 'dataset-prices');
       const expectedHash = String(body.expectedHash ?? 'hash-unknown');
@@ -413,12 +427,12 @@ export const apiRoutes: Record<ApiName, RouteDef[]> = {
           ? 'match'
           : 'mismatch',
         attestation_refs: [`urn:lucid:hash-check:${hash(seed)}`],
-        freshness: freshness(now, seed),
+        freshness: freshness(seed),
       });
     }),
   ],
   screening: [
-    route('POST', '/v1/screening/check', async (request, now) => {
+    route('POST', '/v1/screening/check', async request => {
       const body = await bodyJson(request);
       const entityName = String(body.entityName ?? 'Acme Trading LLC');
       const seed = `${entityName}:screening`;
@@ -429,10 +443,10 @@ export const apiRoutes: Record<ApiName, RouteDef[]> = {
         match_confidence: score(`${seed}:match`, 0.71, 0.99),
         jurisdiction_risk: risk,
         evidence_bundle: [`urn:lucid:evidence:${hash(seed)}`],
-        freshness: freshness(now, seed),
+        freshness: freshness(seed),
       });
     }),
-    route('GET', '/v1/screening/exposure-chain', (request, now) => {
+    route('GET', '/v1/screening/exposure-chain', request => {
       const entityName = queryString(request, 'entityName', 'Acme Trading LLC');
       const seed = `${entityName}:exposure`;
       return json(apiSchemas.screeningExposure, {
@@ -442,10 +456,10 @@ export const apiRoutes: Record<ApiName, RouteDef[]> = {
           { entity: `${entityName} Holdings`, relationship: 'affiliate' },
         ],
         match_confidence: score(seed, 0.68, 0.96),
-        freshness: freshness(now, seed),
+        freshness: freshness(seed),
       });
     }),
-    route('GET', '/v1/screening/jurisdiction-risk', (request, now) => {
+    route('GET', '/v1/screening/jurisdiction-risk', request => {
       const jurisdictions = queryString(request, 'jurisdictions', 'US,CA')
         .split(',')
         .filter(Boolean);
@@ -454,12 +468,12 @@ export const apiRoutes: Record<ApiName, RouteDef[]> = {
         jurisdictions,
         jurisdiction_risk: score(seed, 0.05, 0.7),
         rationale: ['pep_exposure_index', 'sanctions_update_frequency'],
-        freshness: freshness(now, seed),
+        freshness: freshness(seed),
       });
     }),
   ],
   macro: [
-    route('GET', '/v1/macro/events', (request, now) => {
+    route('GET', '/v1/macro/events', request => {
       const eventTypes = queryString(request, 'eventTypes', 'rates,energy')
         .split(',')
         .filter(Boolean);
@@ -473,10 +487,10 @@ export const apiRoutes: Record<ApiName, RouteDef[]> = {
           event_type: eventType,
           urgency_score: score(`${seed}:${eventType}:urgency`, 0.1, 0.95),
         })),
-        freshness: freshness(now, seed),
+        freshness: freshness(seed),
       });
     }),
-    route('GET', '/v1/macro/impact-vectors', (request, now) => {
+    route('GET', '/v1/macro/impact-vectors', request => {
       const sectorSet = queryString(request, 'sectorSet', 'energy,retail')
         .split(',')
         .filter(Boolean);
@@ -494,10 +508,10 @@ export const apiRoutes: Record<ApiName, RouteDef[]> = {
           low: score(`${seed}:low`, 0.42, 0.65),
           high: score(`${seed}:high`, 0.74, 0.95),
         },
-        freshness: freshness(now, seed),
+        freshness: freshness(seed),
       });
     }),
-    route('POST', '/v1/macro/scenario-score', async (request, now) => {
+    route('POST', '/v1/macro/scenario-score', async request => {
       const body = await bodyJson(request);
       const geography = String(body.geography ?? 'global');
       const horizon = String(body.horizon ?? '30d');
@@ -509,7 +523,7 @@ export const apiRoutes: Record<ApiName, RouteDef[]> = {
           energy: score(`${seed}:energy`, -0.8, 0.8),
           supply_chain: score(`${seed}:supply`, -0.8, 0.8),
         },
-        freshness: freshness(now, seed),
+        freshness: freshness(seed),
       });
     }),
   ],
@@ -525,7 +539,7 @@ export async function createDataApiApp(name: ApiName) {
     .use(
       payments({
         config: paymentsFromEnv({
-          storage: { type: 'in-memory' },
+          ...demoPaymentConfig,
         }),
       })
     )
@@ -537,7 +551,7 @@ export async function createDataApiApp(name: ApiName) {
         const handler = async (c: Context) => {
           const paymentError = requiresPayment(c.req.raw);
           if (paymentError) return paymentError;
-          return item.handler(c.req.raw, Date.now());
+          return item.handler(c.req.raw);
         };
         if (item.method === 'GET') app.get(item.path, handler);
         if (item.method === 'POST') app.post(item.path, handler);


### PR DESCRIPTION
## Summary

Adds paid TaskMarket data API examples for ten open PRDs in `packages/examples/src/data-apis`:

- #177 Cross-Chain Liquidity Snapshot Service
- #178 Real-Time Gas & Inclusion Probability Oracle
- #179 Counterparty Risk Graph Intelligence API
- #180 Regulatory Delta Feed for Agent Compliance
- #181 Supplier Reliability Signal Marketplace API
- #182 Geo Demand Pulse Index for Agent Buyers
- #183 ERC-8004 Identity Reputation Signal API
- #184 Data Freshness & Provenance Verification API
- #185 Sanctions & PEP Exposure Intelligence API
- #186 Macro Event Impact Vector API for Agents

Each API registers three monetized Hono routes behind the Lucid payments integration, returns x402 v2 `PAYMENT-REQUIRED` responses before payment, and validates deterministic response contracts with Zod.

## Verification

- `bun test packages/examples/src/data-apis/__tests__/marketplace.test.ts`
- `bun run --filter @lucid-agents/examples type-check`
- `bun run --filter @lucid-agents/examples lint` exits 0 with existing warnings in unrelated examples files
