### PR TITLE
docs: replace dead facilitator.x402.org with live x402.org/facilitator

### DIFF
--- a/lucid-docs/content/docs/examples/index.mdx
+++ b/lucid-docs/content/docs/examples/index.mdx
@@ -69,7 +69,7 @@ Most examples require environment variables. Create a `.env` file based on the e
 
 ```bash
 # Common variables
-FACILITATOR_URL=https://facilitator.x402.org
+FACILITATOR_URL=https://x402.org/facilitator
 PAYMENTS_RECEIVABLE_ADDRESS=0x...
 NETWORK=ethereum
 AGENT_WALLET_PRIVATE_KEY=0x...

--- a/lucid-docs/content/docs/examples/scheduler.mdx
+++ b/lucid-docs/content/docs/examples/scheduler.mdx
@@ -229,7 +229,7 @@ worker.stop();
 # Set environment variables
 export AGENT_WALLET_PRIVATE_KEY=0x...
 export PAYMENTS_RECEIVABLE_ADDRESS=0x...
-export FACILITATOR_URL=https://facilitator.x402.org
+export FACILITATOR_URL=https://x402.org/facilitator
 export NETWORK=ethereum
 
 # Run

--- a/lucid-docs/content/docs/examples/stripe-destination-mode.mdx
+++ b/lucid-docs/content/docs/examples/stripe-destination-mode.mdx
@@ -21,7 +21,7 @@ Use Stripe destination mode when:
 ## Environment
 
 ```bash
-FACILITATOR_URL=https://facilitator.x402.org
+FACILITATOR_URL=https://x402.org/facilitator
 NETWORK=base
 PAYMENTS_DESTINATION=stripe
 STRIPE_SECRET_KEY=sk_test_...

--- a/lucid-docs/content/docs/packages/payments.mdx
+++ b/lucid-docs/content/docs/packages/payments.mdx
@@ -34,7 +34,7 @@ const agent = await createAgent({
 
 ```bash
 # Required in all payment modes
-FACILITATOR_URL=https://facilitator.x402.org
+FACILITATOR_URL=https://x402.org/facilitator
 NETWORK=base
 
 # Static destination mode (default)
@@ -108,7 +108,7 @@ Important behavior:
 
 ```bash
 # Stripe destination mode setup
-FACILITATOR_URL=https://facilitator.x402.org
+FACILITATOR_URL=https://x402.org/facilitator
 NETWORK=base
 PAYMENTS_DESTINATION=stripe
 STRIPE_SECRET_KEY=sk_live_...
@@ -418,10 +418,10 @@ In Stripe destination mode, the card omits static `payee` and marks dynamic paye
     {
       "method": "x402",
       "network": "base",
-      "endpoint": "https://facilitator.x402.org",
+      "endpoint": "https://x402.org/facilitator",
       "extensions": {
         "x402": {
-          "facilitatorUrl": "https://facilitator.x402.org",
+          "facilitatorUrl": "https://x402.org/facilitator",
           "payeeMode": "dynamic"
         }
       }


### PR DESCRIPTION
`https://facilitator.x402.org` has no DNS record (NXDOMAIN), but it's the `FACILITATOR_URL` value shown in the examples and payments docs — anyone copying those env blocks gets a config that fails at the first payment request. The live endpoint the x402 project documents is `https://x402.org/facilitator` (verified serving `GET /supported`; upstream fixed the same dead host in x402-foundation/x402#2787).

7 occurrences replaced across 4 docs files. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018p8jtKC5g7uUMrjGCWksqu