### PR TITLE
Fix Changesets version PR creation

### DIFF
--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -41,22 +41,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Verify and configure npm auth
+      - name: Configure npm auth
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          if [ -z "$NPM_TOKEN" ]; then
-            echo "::error::NPM_TOKEN secret is required"
-            exit 1
-          fi
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-          cat ~/.npmrc
-
-      - name: Preflight npm publish access
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: bun run scripts/changeset-publish.ts --preflight-only
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
       - name: Create Version PR or Publish
         uses: changesets/action@v1
@@ -68,3 +56,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What changed

- stop validating npm credentials before `changesets/action`
- keep npm auth configured for the publish path
- pass `NODE_AUTH_TOKEN` into the Changesets action

## Root cause

The release bot runs npm publish preflight before Changesets decides whether it needs to open a version PR or publish. The current `NPM_TOKEN` returns `401 Unauthorized`, so the job exits before `changesets/action` and no `Version Packages` PR is created.

This keeps version-PR creation independent from npm availability. The existing `release:publish` script still performs npm credential and collaborator preflight immediately before publishing.

## Impact

After this PR merges to `master`, the push-triggered release bot can create the pending `Version Packages` PR. Publishing that version PR still requires replacing the invalid `NPM_TOKEN` repository secret.

## Validation

- Changesets status resolves a release plan for 17 packages
- `actionlint .github/workflows/release-bot.yml`
- `bun test scripts/__tests__/changeset-publish-utils.test.ts` (6 passed)
- repository pre-commit checks: lint, type-check, and formatting passed
