### PR TITLE
Fix release bot package build before versioning

### DIFF
--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Build packages
+        run: bun run build:packages
+
       - name: Configure git user
         run: |
           git config user.name "github-actions[bot]"

--- a/scripts/__tests__/release-workflows.test.ts
+++ b/scripts/__tests__/release-workflows.test.ts
@@ -90,6 +90,19 @@ describe('release workflow policy', () => {
   test('release bot runs only after successful master CI', () => {
     const workflow = readWorkflow('release-bot.yml');
     const source = workflowSource('release-bot.yml');
+    const releaseBot = workflow.jobs?.['release-bot'] as
+      | { steps?: WorkflowStep[] }
+      | undefined;
+    const steps = releaseBot?.steps ?? [];
+    const installIndex = steps.findIndex(
+      step => step.run === 'bun install --frozen-lockfile'
+    );
+    const buildIndex = steps.findIndex(
+      step => step.run === 'bun run build:packages'
+    );
+    const changesetsIndex = steps.findIndex(
+      step => step.uses === 'changesets/action@v1'
+    );
 
     expect(workflow.on).toEqual({
       workflow_run: {
@@ -102,6 +115,9 @@ describe('release workflow policy', () => {
       "github.event.workflow_run.conclusion == 'success'"
     );
     expect(source).toContain('publish: bun run release:publish:verified');
+    expect(installIndex).toBeGreaterThan(-1);
+    expect(buildIndex).toBeGreaterThan(installIndex);
+    expect(changesetsIndex).toBeGreaterThan(buildIndex);
   });
 
   test('manual dry runs version, build, and inspect package artifacts', () => {


### PR DESCRIPTION
## Summary

- Restore the topological workspace build before the Changesets action so package declarations exist when Husky checks the generated version commit.
- Add a regression test enforcing install → build → Changesets ordering.

## Root cause

The hardened release workflow removed its former build step, causing `TS2307` module-resolution failures and preventing the Version Packages PR from being created.

## Validation

- `bun test scripts/__tests__/release-workflows.test.ts scripts/__tests__/release-policy.test.ts`
- `bun run build:packages`
- Full pre-commit lint, workspace type-check, and package formatting checks